### PR TITLE
Do not check if date returned by modulemd_module_get_eol is valid, it is always valid when not NULL.

### DIFF
--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -2267,7 +2267,7 @@ _modulemd_upgrade_v1_to_v2 (ModulemdModule *self)
 
   /* Upgrade the EOL field to a "rawhide" servicelevel*/
   eol = modulemd_module_get_eol (self);
-  if (g_date_valid (eol))
+  if (eol)
     {
       sl = modulemd_servicelevel_new ();
       modulemd_servicelevel_set_eol (sl, eol);


### PR DESCRIPTION
Fixes "Warning: g_date_valid: assertion 'd != NULL' failed" during `module_v1.upgrade()` which is spamming ODCS test logs.