### PR TITLE
(SEMVER-MINOR) Add peek(), dup() and copy() functions to all libmodulemd objects

### DIFF
--- a/modulemd/modulemd-component-module.c
+++ b/modulemd/modulemd-component-module.c
@@ -124,6 +124,22 @@ modulemd_component_module_peek_ref (ModulemdComponentModule *self)
 
 
 /**
+ * modulemd_component_module_dup_ref:
+ *
+ * Retrieves a copy of the repository ref.
+ *
+ * Returns: A copy of the string containing the repository ref.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_component_module_dup_ref (ModulemdComponentModule *self)
+{
+  return g_strdup (modulemd_component_module_peek_ref (self));
+}
+
+
+/**
  * modulemd_component_module_set_repository
  * @repository: (nullable): A string: The VCS repository with the modulemd file, and other
  * module data.
@@ -182,6 +198,55 @@ modulemd_component_module_peek_repository (ModulemdComponentModule *self)
 }
 
 
+/**
+ * modulemd_component_module_dup_repository:
+ *
+ * Retrieves a copy of the repository location.
+ *
+ * Returns: A copy of the string containing the repository location.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_component_module_dup_repository (ModulemdComponentModule *self)
+{
+  return g_strdup (modulemd_component_module_peek_repository (self));
+}
+
+
+static ModulemdComponent *
+modulemd_component_module_copy (ModulemdComponent *self)
+{
+  ModulemdComponentModule *old_component = NULL;
+  ModulemdComponentModule *new_component = NULL;
+
+  g_return_val_if_fail (self, NULL);
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT_MODULE (self), NULL);
+
+  old_component = MODULEMD_COMPONENT_MODULE (self);
+
+  new_component = modulemd_component_module_new ();
+
+  modulemd_component_set_buildorder (
+    MODULEMD_COMPONENT (new_component),
+    modulemd_component_peek_buildorder (self));
+
+  modulemd_component_set_name (MODULEMD_COMPONENT (new_component),
+                               modulemd_component_peek_name (self));
+
+  modulemd_component_set_rationale (MODULEMD_COMPONENT (new_component),
+                                    modulemd_component_peek_rationale (self));
+
+  modulemd_component_module_set_ref (
+    new_component, modulemd_component_module_peek_ref (old_component));
+
+  modulemd_component_module_set_repository (
+    new_component, modulemd_component_module_peek_repository (old_component));
+
+  return MODULEMD_COMPONENT (new_component);
+}
+
+
 static void
 modulemd_component_module_set_property (GObject *object,
                                         guint prop_id,
@@ -232,10 +297,13 @@ static void
 modulemd_component_module_class_init (ModulemdComponentModuleClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ModulemdComponentClass *parent_class = MODULEMD_COMPONENT_CLASS (klass);
 
   object_class->finalize = modulemd_component_module_finalize;
   object_class->get_property = modulemd_component_module_get_property;
   object_class->set_property = modulemd_component_module_set_property;
+
+  parent_class->copy = modulemd_component_module_copy;
 
   properties[PROP_REF] =
     g_param_spec_string ("ref",

--- a/modulemd/modulemd-component-module.c
+++ b/modulemd/modulemd-component-module.c
@@ -86,20 +86,42 @@ modulemd_component_module_set_ref (ModulemdComponentModule *self,
     }
 }
 
+
 /**
  * modulemd_component_module_get_ref:
  *
  * Retrieves the repository ref.
  *
  * Returns: A string containing the repository ref.
+ *
+ * Deprecated: 1.1
+ * Use peek_ref() instead.
  */
+G_DEPRECATED_FOR (modulemd_component_module_peek_ref)
 const gchar *
 modulemd_component_module_get_ref (ModulemdComponentModule *self)
+{
+  return modulemd_component_module_peek_ref (self);
+}
+
+
+/**
+ * modulemd_component_module_peek_ref:
+ *
+ * Retrieves the repository ref.
+ *
+ * Returns: A string containing the repository ref.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_component_module_peek_ref (ModulemdComponentModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_COMPONENT_MODULE (self), NULL);
 
   return self->ref;
 }
+
 
 /**
  * modulemd_component_module_set_repository
@@ -121,13 +143,18 @@ modulemd_component_module_set_repository (ModulemdComponentModule *self,
     }
 }
 
+
 /**
  * modulemd_component_module_get_repository:
  *
  * Retrieves the repository location.
  *
  * Returns: A string containing the repository location.
+ *
+ * Deprecated: 1.1
+ * Use peek_repository() instead.
  */
+G_DEPRECATED_FOR (modulemd_component_module_peek_repository)
 const gchar *
 modulemd_component_module_get_repository (ModulemdComponentModule *self)
 {
@@ -135,6 +162,25 @@ modulemd_component_module_get_repository (ModulemdComponentModule *self)
 
   return self->repo;
 }
+
+
+/**
+ * modulemd_component_module_peek_repository:
+ *
+ * Retrieves the repository location.
+ *
+ * Returns: A string containing the repository location.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_component_module_peek_repository (ModulemdComponentModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT_MODULE (self), NULL);
+
+  return self->repo;
+}
+
 
 static void
 modulemd_component_module_set_property (GObject *object,
@@ -170,12 +216,12 @@ modulemd_component_module_get_property (GObject *object,
   switch (prop_id)
     {
     case PROP_REF:
-      g_value_set_string (value, modulemd_component_module_get_ref (self));
+      g_value_set_string (value, modulemd_component_module_peek_ref (self));
       break;
 
     case PROP_REPO:
       g_value_set_string (value,
-                          modulemd_component_module_get_repository (self));
+                          modulemd_component_module_peek_repository (self));
       break;
 
     default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec); break;

--- a/modulemd/modulemd-component-module.h
+++ b/modulemd/modulemd-component-module.h
@@ -47,11 +47,16 @@ modulemd_component_module_set_ref (ModulemdComponentModule *self,
                                    const gchar *ref);
 const gchar *
 modulemd_component_module_get_ref (ModulemdComponentModule *self);
+const gchar *
+modulemd_component_module_peek_ref (ModulemdComponentModule *self);
 
 void
 modulemd_component_module_set_repository (ModulemdComponentModule *self,
                                           const gchar *repository);
 const gchar *
 modulemd_component_module_get_repository (ModulemdComponentModule *self);
+
+const gchar *
+modulemd_component_module_peek_repository (ModulemdComponentModule *self);
 
 #endif /* MODULEMD_COMPONENT_MODULE_H */

--- a/modulemd/modulemd-component-module.h
+++ b/modulemd/modulemd-component-module.h
@@ -49,6 +49,8 @@ const gchar *
 modulemd_component_module_get_ref (ModulemdComponentModule *self);
 const gchar *
 modulemd_component_module_peek_ref (ModulemdComponentModule *self);
+gchar *
+modulemd_component_module_dup_ref (ModulemdComponentModule *self);
 
 void
 modulemd_component_module_set_repository (ModulemdComponentModule *self,
@@ -58,5 +60,7 @@ modulemd_component_module_get_repository (ModulemdComponentModule *self);
 
 const gchar *
 modulemd_component_module_peek_repository (ModulemdComponentModule *self);
+gchar *
+modulemd_component_module_dup_repository (ModulemdComponentModule *self);
 
 #endif /* MODULEMD_COMPONENT_MODULE_H */

--- a/modulemd/modulemd-component-rpm.c
+++ b/modulemd/modulemd-component-rpm.c
@@ -133,6 +133,27 @@ modulemd_component_rpm_peek_arches (ModulemdComponentRpm *self)
 
 
 /**
+ * modulemd_component_rpm_dup_arches:
+ *
+ * Retrieves a copy of the set of arches for this component.
+ *
+ * Returns: (transfer full): A #ModulemdSimpleSet containing the set of
+ * supported architectures for this component.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_component_rpm_dup_arches (ModulemdComponentRpm *self)
+{
+  ModulemdSimpleSet *arches = NULL;
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
+
+  modulemd_simpleset_copy (self->arches, &arches);
+  return arches;
+}
+
+
+/**
  * modulemd_component_rpm_set_cache
  * @cache: (nullable): A string: The URL of the lookaside cache where this package's
  * sources are stored.
@@ -185,6 +206,24 @@ modulemd_component_rpm_peek_cache (ModulemdComponentRpm *self)
   g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
 
   return self->cache;
+}
+
+
+/**
+ * modulemd_component_rpm_dup_cache:
+ *
+ * Retrieves a copy of the lookaside cache URL.
+ *
+ * Returns: A copy of the string containing the URL to the lookaside cache.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_component_rpm_dup_cache (ModulemdComponentRpm *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
+
+  return g_strdup (self->cache);
 }
 
 
@@ -246,6 +285,28 @@ modulemd_component_rpm_peek_multilib (ModulemdComponentRpm *self)
 
 
 /**
+ * modulemd_component_rpm_dup_multilib:
+ *
+ * Retrieves a copy of the set of multilib for this component.
+ *
+ * Returns: (transfer full): A #ModulemdSimpleSet containing the set of
+ * supported multilib architectures for this component.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_component_rpm_dup_multilib (ModulemdComponentRpm *self)
+{
+  ModulemdSimpleSet *multilib = NULL;
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
+
+  modulemd_simpleset_copy (self->multilib, &multilib);
+
+  return multilib;
+}
+
+
+/**
  * modulemd_component_rpm_set_ref
  * @ref: (nullable): A string: The particular repository commit hash, branch or tag name
  * used in this module.
@@ -297,6 +358,24 @@ modulemd_component_rpm_peek_ref (ModulemdComponentRpm *self)
   g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
 
   return self->ref;
+}
+
+
+/**
+ * modulemd_component_rpm_dup_ref:
+ *
+ * Retrieves a copy of the repository ref.
+ *
+ * Returns: A copy of the string containing the repository ref.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_component_rpm_dup_ref (ModulemdComponentRpm *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
+
+  return g_strdup (self->ref);
 }
 
 
@@ -354,6 +433,66 @@ modulemd_component_rpm_peek_repository (ModulemdComponentRpm *self)
   g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
 
   return self->repo;
+}
+
+
+/**
+ * modulemd_component_rpm_dup_repository:
+ *
+ * Retrieves a copy of the repository location.
+ *
+ * Returns: A copy of the string containing the repository location.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_component_rpm_dup_repository (ModulemdComponentRpm *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
+
+  return g_strdup (self->repo);
+}
+
+
+static ModulemdComponent *
+modulemd_component_rpm_copy (ModulemdComponent *self)
+{
+  ModulemdComponentRpm *old_component = NULL;
+  ModulemdComponentRpm *new_component = NULL;
+
+  g_return_val_if_fail (self, NULL);
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
+
+  old_component = MODULEMD_COMPONENT_RPM (self);
+
+  new_component = modulemd_component_rpm_new ();
+
+  modulemd_component_set_buildorder (
+    MODULEMD_COMPONENT (new_component),
+    modulemd_component_peek_buildorder (self));
+
+  modulemd_component_set_name (MODULEMD_COMPONENT (new_component),
+                               modulemd_component_peek_name (self));
+
+  modulemd_component_set_rationale (MODULEMD_COMPONENT (new_component),
+                                    modulemd_component_peek_rationale (self));
+
+  modulemd_component_rpm_set_arches (
+    new_component, modulemd_component_rpm_peek_arches (old_component));
+
+  modulemd_component_rpm_set_cache (
+    new_component, modulemd_component_rpm_peek_cache (old_component));
+
+  modulemd_component_rpm_set_multilib (
+    new_component, modulemd_component_rpm_peek_multilib (old_component));
+
+  modulemd_component_rpm_set_ref (
+    new_component, modulemd_component_rpm_peek_ref (old_component));
+
+  modulemd_component_rpm_set_repository (
+    new_component, modulemd_component_rpm_peek_repository (old_component));
+
+  return MODULEMD_COMPONENT (new_component);
 }
 
 
@@ -430,10 +569,13 @@ static void
 modulemd_component_rpm_class_init (ModulemdComponentRpmClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ModulemdComponentClass *parent_class = MODULEMD_COMPONENT_CLASS (klass);
 
   object_class->finalize = modulemd_component_rpm_finalize;
   object_class->get_property = modulemd_component_rpm_get_property;
   object_class->set_property = modulemd_component_rpm_set_property;
+
+  parent_class->copy = modulemd_component_rpm_copy;
 
   properties[PROP_ARCHES] =
     g_param_spec_object ("arches",

--- a/modulemd/modulemd-component-rpm.c
+++ b/modulemd/modulemd-component-rpm.c
@@ -93,6 +93,7 @@ modulemd_component_rpm_set_arches (ModulemdComponentRpm *self,
   g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_ARCHES]);
 }
 
+
 /**
  * modulemd_component_rpm_get_arches:
  *
@@ -100,14 +101,36 @@ modulemd_component_rpm_set_arches (ModulemdComponentRpm *self,
  *
  * Returns: (transfer none): A #ModulemdSimpleSet containing the set of
  * supported architectures for this component.
+ *
+ * Deprecated: 1.1
+ * Use peek_arches() instead.
  */
+G_DEPRECATED_FOR (modulemd_component_rpm_peek_arches)
 ModulemdSimpleSet *
 modulemd_component_rpm_get_arches (ModulemdComponentRpm *self)
+{
+  return modulemd_component_rpm_peek_arches (self);
+}
+
+
+/**
+ * modulemd_component_rpm_peek_arches:
+ *
+ * Retrieves the set of arches for this component.
+ *
+ * Returns: (transfer none): A #ModulemdSimpleSet containing the set of
+ * supported architectures for this component.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_component_rpm_peek_arches (ModulemdComponentRpm *self)
 {
   g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
 
   return self->arches;
 }
+
 
 /**
  * modulemd_component_rpm_set_cache
@@ -129,20 +152,41 @@ modulemd_component_rpm_set_cache (ModulemdComponentRpm *self,
     }
 }
 
+
 /**
  * modulemd_component_rpm_get_cache:
  *
  * Retrieves the lookaside cache URL.
  *
  * Returns: A string containing the URL to the lookaside cache.
+ *
+ * Deprecated: 1.1
+ * Use peek_cache() instead.
  */
 const gchar *
 modulemd_component_rpm_get_cache (ModulemdComponentRpm *self)
+{
+  return modulemd_component_rpm_peek_cache (self);
+}
+
+
+/**
+ * modulemd_component_rpm_peek_cache:
+ *
+ * Retrieves the lookaside cache URL.
+ *
+ * Returns: A string containing the URL to the lookaside cache.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_component_rpm_peek_cache (ModulemdComponentRpm *self)
 {
   g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
 
   return self->cache;
 }
+
 
 /**
  * modulemd_component_rpm_set_multilib:
@@ -162,6 +206,7 @@ modulemd_component_rpm_set_multilib (ModulemdComponentRpm *self,
   g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_ARCHES]);
 }
 
+
 /**
  * modulemd_component_rpm_get_multilib:
  *
@@ -169,14 +214,36 @@ modulemd_component_rpm_set_multilib (ModulemdComponentRpm *self,
  *
  * Returns: (transfer none): A #ModulemdSimpleSet containing the set of
  * supported multilib architectures for this component.
+ *
+ * Deprecated: 1.1
+ * Use peek_multilib() instead.
  */
+G_DEPRECATED_FOR (modulemd_component_rpm_peek_multilib)
 ModulemdSimpleSet *
 modulemd_component_rpm_get_multilib (ModulemdComponentRpm *self)
+{
+  return modulemd_component_rpm_peek_multilib (self);
+}
+
+
+/**
+ * modulemd_component_rpm_peek_multilib:
+ *
+ * Retrieves the set of multilib for this component.
+ *
+ * Returns: (transfer none): A #ModulemdSimpleSet containing the set of
+ * supported multilib architectures for this component.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_component_rpm_peek_multilib (ModulemdComponentRpm *self)
 {
   g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
 
   return self->multilib;
 }
+
 
 /**
  * modulemd_component_rpm_set_ref
@@ -203,14 +270,35 @@ modulemd_component_rpm_set_ref (ModulemdComponentRpm *self, const gchar *ref)
  * Retrieves the repository ref.
  *
  * Returns: A string containing the repository ref.
+ *
+ * Deprecated: 1.1
+ * Use peek_ref() instead.
  */
+G_DEPRECATED_FOR (modulemd_component_rpm_peek_ref)
 const gchar *
 modulemd_component_rpm_get_ref (ModulemdComponentRpm *self)
+{
+  return modulemd_component_rpm_peek_ref (self);
+}
+
+
+/**
+ * modulemd_component_rpm_peek_ref:
+ *
+ * Retrieves the repository ref.
+ *
+ * Returns: A string containing the repository ref.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_component_rpm_peek_ref (ModulemdComponentRpm *self)
 {
   g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
 
   return self->ref;
 }
+
 
 /**
  * modulemd_component_rpm_set_repository
@@ -232,20 +320,42 @@ modulemd_component_rpm_set_repository (ModulemdComponentRpm *self,
     }
 }
 
+
 /**
  * modulemd_component_rpm_get_repository:
  *
  * Retrieves the repository location.
  *
  * Returns: A string containing the repository location.
+ *
+ * Deprecated: 1.1
+ * Use peek_repository() instead.
  */
+G_DEPRECATED_FOR (modulemd_component_rpm_peek_repository)
 const gchar *
 modulemd_component_rpm_get_repository (ModulemdComponentRpm *self)
+{
+  return modulemd_component_rpm_peek_repository (self);
+}
+
+
+/**
+ * modulemd_component_rpm_peek_repository:
+ *
+ * Retrieves the repository location.
+ *
+ * Returns: A string containing the repository location.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_component_rpm_peek_repository (ModulemdComponentRpm *self)
 {
   g_return_val_if_fail (MODULEMD_IS_COMPONENT_RPM (self), NULL);
 
   return self->repo;
 }
+
 
 static void
 modulemd_component_rpm_set_property (GObject *object,
@@ -292,23 +402,24 @@ modulemd_component_rpm_get_property (GObject *object,
   switch (prop_id)
     {
     case PROP_ARCHES:
-      g_value_set_object (value, modulemd_component_rpm_get_arches (self));
+      g_value_set_object (value, modulemd_component_rpm_peek_arches (self));
       break;
 
     case PROP_CACHE:
-      g_value_set_string (value, modulemd_component_rpm_get_cache (self));
+      g_value_set_string (value, modulemd_component_rpm_peek_cache (self));
       break;
 
     case PROP_MULTILIB:
-      g_value_set_object (value, modulemd_component_rpm_get_multilib (self));
+      g_value_set_object (value, modulemd_component_rpm_peek_multilib (self));
       break;
 
     case PROP_REF:
-      g_value_set_string (value, modulemd_component_rpm_get_ref (self));
+      g_value_set_string (value, modulemd_component_rpm_peek_ref (self));
       break;
 
     case PROP_REPO:
-      g_value_set_string (value, modulemd_component_rpm_get_repository (self));
+      g_value_set_string (value,
+                          modulemd_component_rpm_peek_repository (self));
       break;
 
     default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec); break;

--- a/modulemd/modulemd-component-rpm.h
+++ b/modulemd/modulemd-component-rpm.h
@@ -47,28 +47,38 @@ modulemd_component_rpm_set_arches (ModulemdComponentRpm *self,
                                    ModulemdSimpleSet *arches);
 ModulemdSimpleSet *
 modulemd_component_rpm_get_arches (ModulemdComponentRpm *self);
+ModulemdSimpleSet *
+modulemd_component_rpm_peek_arches (ModulemdComponentRpm *self);
 
 void
 modulemd_component_rpm_set_cache (ModulemdComponentRpm *self,
                                   const gchar *cache);
 const gchar *
 modulemd_component_rpm_get_cache (ModulemdComponentRpm *self);
+const gchar *
+modulemd_component_rpm_peek_cache (ModulemdComponentRpm *self);
 
 void
 modulemd_component_rpm_set_multilib (ModulemdComponentRpm *self,
                                      ModulemdSimpleSet *multilib);
 ModulemdSimpleSet *
 modulemd_component_rpm_get_multilib (ModulemdComponentRpm *self);
+ModulemdSimpleSet *
+modulemd_component_rpm_peek_multilib (ModulemdComponentRpm *self);
 
 void
 modulemd_component_rpm_set_ref (ModulemdComponentRpm *self, const gchar *ref);
 const gchar *
 modulemd_component_rpm_get_ref (ModulemdComponentRpm *self);
+const gchar *
+modulemd_component_rpm_peek_ref (ModulemdComponentRpm *self);
 
 void
 modulemd_component_rpm_set_repository (ModulemdComponentRpm *self,
                                        const gchar *repository);
 const gchar *
 modulemd_component_rpm_get_repository (ModulemdComponentRpm *self);
+const gchar *
+modulemd_component_rpm_peek_repository (ModulemdComponentRpm *self);
 
 #endif /* MODULEMD_COMPONENT_RPM_H */

--- a/modulemd/modulemd-component-rpm.h
+++ b/modulemd/modulemd-component-rpm.h
@@ -49,6 +49,8 @@ ModulemdSimpleSet *
 modulemd_component_rpm_get_arches (ModulemdComponentRpm *self);
 ModulemdSimpleSet *
 modulemd_component_rpm_peek_arches (ModulemdComponentRpm *self);
+ModulemdSimpleSet *
+modulemd_component_rpm_dup_arches (ModulemdComponentRpm *self);
 
 void
 modulemd_component_rpm_set_cache (ModulemdComponentRpm *self,
@@ -57,6 +59,8 @@ const gchar *
 modulemd_component_rpm_get_cache (ModulemdComponentRpm *self);
 const gchar *
 modulemd_component_rpm_peek_cache (ModulemdComponentRpm *self);
+gchar *
+modulemd_component_rpm_dup_cache (ModulemdComponentRpm *self);
 
 void
 modulemd_component_rpm_set_multilib (ModulemdComponentRpm *self,
@@ -65,6 +69,8 @@ ModulemdSimpleSet *
 modulemd_component_rpm_get_multilib (ModulemdComponentRpm *self);
 ModulemdSimpleSet *
 modulemd_component_rpm_peek_multilib (ModulemdComponentRpm *self);
+ModulemdSimpleSet *
+modulemd_component_rpm_dup_multilib (ModulemdComponentRpm *self);
 
 void
 modulemd_component_rpm_set_ref (ModulemdComponentRpm *self, const gchar *ref);
@@ -72,6 +78,8 @@ const gchar *
 modulemd_component_rpm_get_ref (ModulemdComponentRpm *self);
 const gchar *
 modulemd_component_rpm_peek_ref (ModulemdComponentRpm *self);
+gchar *
+modulemd_component_rpm_dup_ref (ModulemdComponentRpm *self);
 
 void
 modulemd_component_rpm_set_repository (ModulemdComponentRpm *self,
@@ -80,5 +88,7 @@ const gchar *
 modulemd_component_rpm_get_repository (ModulemdComponentRpm *self);
 const gchar *
 modulemd_component_rpm_peek_repository (ModulemdComponentRpm *self);
+gchar *
+modulemd_component_rpm_dup_repository (ModulemdComponentRpm *self);
 
 #endif /* MODULEMD_COMPONENT_RPM_H */

--- a/modulemd/modulemd-component.c
+++ b/modulemd/modulemd-component.c
@@ -64,7 +64,7 @@ modulemd_component_default_set_buildorder (ModulemdComponent *self,
 }
 
 static guint64
-modulemd_component_default_get_buildorder (ModulemdComponent *self)
+modulemd_component_default_peek_buildorder (ModulemdComponent *self)
 {
   g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), 0);
   ModulemdComponentPrivate *priv =
@@ -85,7 +85,7 @@ modulemd_component_default_set_name (ModulemdComponent *self,
 }
 
 static const gchar *
-modulemd_component_default_get_name (ModulemdComponent *self)
+modulemd_component_default_peek_name (ModulemdComponent *self)
 {
   g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), 0);
   ModulemdComponentPrivate *priv =
@@ -106,7 +106,7 @@ modulemd_component_default_set_rationale (ModulemdComponent *self,
 }
 
 static const gchar *
-modulemd_component_default_get_rationale (ModulemdComponent *self)
+modulemd_component_default_peek_rationale (ModulemdComponent *self)
 {
   g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), 0);
   ModulemdComponentPrivate *priv =
@@ -138,19 +138,38 @@ modulemd_component_set_buildorder (ModulemdComponent *self, guint64 buildorder)
  * modulemd_component_get_buildorder:
  *
  * Returns the 'buildorder' property
+ *
+ * Deprecated: 1.1
+ * Use peek_buildorder() instead.
  */
+G_DEPRECATED_FOR (modulemd_component_peek_buildorder)
 guint64
 modulemd_component_get_buildorder (ModulemdComponent *self)
+{
+  return modulemd_component_peek_buildorder (self);
+}
+
+
+/**
+ * modulemd_component_peek_buildorder:
+ *
+ * Returns the 'buildorder' property
+ *
+ * Since: 1.1
+ */
+guint64
+modulemd_component_peek_buildorder (ModulemdComponent *self)
 {
   ModulemdComponentClass *klass;
 
   g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), 0);
 
   klass = MODULEMD_COMPONENT_GET_CLASS (self);
-  g_return_val_if_fail (klass->get_buildorder, 0);
+  g_return_val_if_fail (klass->peek_buildorder, 0);
 
-  return klass->get_buildorder (self);
+  return klass->peek_buildorder (self);
 }
+
 
 /**
  * modulemd_component_set_name:
@@ -171,24 +190,44 @@ modulemd_component_set_name (ModulemdComponent *self, const gchar *name)
   klass->set_name (self, name);
 }
 
+
 /**
  * modulemd_component_get_name:
  *
  * Returns the 'name' property;
+ *
+ * Deprecated: 1.1
+ * Use peek_name() instead.
  */
+G_DEPRECATED_FOR (modulemd_component_peek_name)
 const gchar *
 modulemd_component_get_name (ModulemdComponent *self)
+{
+  return modulemd_component_peek_name (self);
+}
+
+
+/**
+ * modulemd_component_peek_name:
+ *
+ * Returns the 'name' property;
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_component_peek_name (ModulemdComponent *self)
 {
   ModulemdComponentClass *klass;
 
   g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), NULL);
 
   klass = MODULEMD_COMPONENT_GET_CLASS (self);
-  g_return_val_if_fail (klass->get_name, NULL);
+  g_return_val_if_fail (klass->peek_name, NULL);
 
 
-  return klass->get_name (self);
+  return klass->peek_name (self);
 }
+
 
 /**
  * modulemd_component_set_rationale:
@@ -210,24 +249,44 @@ modulemd_component_set_rationale (ModulemdComponent *self,
   klass->set_rationale (self, rationale);
 }
 
+
 /**
  * modulemd_component_get_rationale:
  *
  * Returns the 'rationale' property;
+ *
+ * Deprecated: 1.1
+ * Use peek_rationale() instead.
  */
+G_DEPRECATED_FOR (modulemd_component_peek_rationale)
 const gchar *
 modulemd_component_get_rationale (ModulemdComponent *self)
+{
+  return modulemd_component_peek_rationale (self);
+}
+
+
+/**
+ * modulemd_component_peek_rationale:
+ *
+ * Returns the 'rationale' property;
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_component_peek_rationale (ModulemdComponent *self)
 {
   ModulemdComponentClass *klass;
 
   g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), NULL);
 
   klass = MODULEMD_COMPONENT_GET_CLASS (self);
-  g_return_val_if_fail (klass->get_rationale, NULL);
+  g_return_val_if_fail (klass->peek_rationale, NULL);
 
 
-  return klass->get_rationale (self);
+  return klass->peek_rationale (self);
 }
+
 
 static void
 modulemd_component_set_property (GObject *gobject,
@@ -268,15 +327,15 @@ modulemd_component_get_property (GObject *gobject,
   switch (property_id)
     {
     case COMPONENT_PROP_BUILDORDER:
-      g_value_set_uint64 (value, modulemd_component_get_buildorder (self));
+      g_value_set_uint64 (value, modulemd_component_peek_buildorder (self));
       break;
 
     case COMPONENT_PROP_NAME:
-      g_value_set_string (value, modulemd_component_get_name (self));
+      g_value_set_string (value, modulemd_component_peek_name (self));
       break;
 
     case COMPONENT_PROP_RATIONALE:
-      g_value_set_string (value, modulemd_component_get_rationale (self));
+      g_value_set_string (value, modulemd_component_peek_rationale (self));
       break;
 
     default:
@@ -307,13 +366,13 @@ modulemd_component_class_init (ModulemdComponentClass *klass)
   object_class->finalize = modulemd_component_finalize;
 
   klass->set_buildorder = modulemd_component_default_set_buildorder;
-  klass->get_buildorder = modulemd_component_default_get_buildorder;
+  klass->peek_buildorder = modulemd_component_default_peek_buildorder;
 
   klass->set_name = modulemd_component_default_set_name;
-  klass->get_name = modulemd_component_default_get_name;
+  klass->peek_name = modulemd_component_default_peek_name;
 
   klass->set_rationale = modulemd_component_default_set_rationale;
-  klass->get_rationale = modulemd_component_default_get_rationale;
+  klass->peek_rationale = modulemd_component_default_peek_rationale;
 
   component_properties[COMPONENT_PROP_BUILDORDER] =
     g_param_spec_uint64 ("buildorder",

--- a/modulemd/modulemd-component.c
+++ b/modulemd/modulemd-component.c
@@ -94,6 +94,16 @@ modulemd_component_default_peek_name (ModulemdComponent *self)
   return priv->name;
 }
 
+static gchar *
+modulemd_component_default_dup_name (ModulemdComponent *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), 0);
+  ModulemdComponentPrivate *priv =
+    modulemd_component_get_instance_private (self);
+
+  return g_strdup (priv->name);
+}
+
 static void
 modulemd_component_default_set_rationale (ModulemdComponent *self,
                                           const gchar *rationale)
@@ -113,6 +123,16 @@ modulemd_component_default_peek_rationale (ModulemdComponent *self)
     modulemd_component_get_instance_private (self);
 
   return priv->rationale;
+}
+
+static gchar *
+modulemd_component_default_dup_rationale (ModulemdComponent *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), 0);
+  ModulemdComponentPrivate *priv =
+    modulemd_component_get_instance_private (self);
+
+  return g_strdup (priv->rationale);
 }
 
 /**
@@ -228,6 +248,27 @@ modulemd_component_peek_name (ModulemdComponent *self)
   return klass->peek_name (self);
 }
 
+/**
+ * modulemd_component_dup_name:
+ *
+ * Returns a copy of the 'name' property;
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_component_dup_name (ModulemdComponent *self)
+{
+  ModulemdComponentClass *klass;
+
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), NULL);
+
+  klass = MODULEMD_COMPONENT_GET_CLASS (self);
+  g_return_val_if_fail (klass->dup_name, NULL);
+
+
+  return klass->dup_name (self);
+}
+
 
 /**
  * modulemd_component_set_rationale:
@@ -285,6 +326,51 @@ modulemd_component_peek_rationale (ModulemdComponent *self)
 
 
   return klass->peek_rationale (self);
+}
+
+/**
+ * modulemd_component_dup_rationale:
+ *
+ * Returns a copy of the 'rationale' property;
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_component_dup_rationale (ModulemdComponent *self)
+{
+  ModulemdComponentClass *klass;
+
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), NULL);
+
+  klass = MODULEMD_COMPONENT_GET_CLASS (self);
+  g_return_val_if_fail (klass->peek_rationale, NULL);
+
+
+  return klass->dup_rationale (self);
+}
+
+
+/**
+ * modulemd_component_copy:
+ *
+ * Returns a complete copy of this Component.
+ *
+ * Returns: (transfer full): A copy of this Component.
+ *
+ * Since: 1.1
+ */
+ModulemdComponent *
+modulemd_component_copy (ModulemdComponent *self)
+{
+  ModulemdComponentClass *klass;
+
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), NULL);
+
+  klass = MODULEMD_COMPONENT_GET_CLASS (self);
+  g_return_val_if_fail (klass->copy, NULL);
+
+
+  return klass->copy (self);
 }
 
 
@@ -370,9 +456,14 @@ modulemd_component_class_init (ModulemdComponentClass *klass)
 
   klass->set_name = modulemd_component_default_set_name;
   klass->peek_name = modulemd_component_default_peek_name;
+  klass->dup_name = modulemd_component_default_dup_name;
 
   klass->set_rationale = modulemd_component_default_set_rationale;
   klass->peek_rationale = modulemd_component_default_peek_rationale;
+  klass->dup_rationale = modulemd_component_default_dup_rationale;
+
+  /* copy() is pure-virtual */
+  klass->copy = NULL;
 
   component_properties[COMPONENT_PROP_BUILDORDER] =
     g_param_spec_uint64 ("buildorder",

--- a/modulemd/modulemd-component.h
+++ b/modulemd/modulemd-component.h
@@ -43,13 +43,18 @@ struct _ModulemdComponentClass
 
   void (*set_name) (ModulemdComponent *self, const gchar *name);
   const gchar *(*peek_name) (ModulemdComponent *self);
+  gchar *(*dup_name) (ModulemdComponent *self);
 
   void (*set_rationale) (ModulemdComponent *self, const gchar *rationale);
   const gchar *(*peek_rationale) (ModulemdComponent *self);
+  gchar *(*dup_rationale) (ModulemdComponent *self);
 
-  /* Padding to allow adding up to 12 new virtual functions without
-     * breaking ABI. */
-  gpointer padding[12];
+  /* Pure Virtual Public Members */
+  ModulemdComponent *(*copy) (ModulemdComponent *self);
+
+  /* Padding to allow adding up to 11 new virtual functions without
+   * breaking ABI. */
+  gpointer padding[9];
 };
 
 ModulemdComponent *
@@ -70,6 +75,8 @@ const gchar *
 modulemd_component_get_name (ModulemdComponent *self);
 const gchar *
 modulemd_component_peek_name (ModulemdComponent *self);
+gchar *
+modulemd_component_dup_name (ModulemdComponent *self);
 
 void
 modulemd_component_set_rationale (ModulemdComponent *self,
@@ -78,6 +85,11 @@ const gchar *
 modulemd_component_get_rationale (ModulemdComponent *self);
 const gchar *
 modulemd_component_peek_rationale (ModulemdComponent *self);
+gchar *
+modulemd_component_dup_rationale (ModulemdComponent *self);
+
+ModulemdComponent *
+modulemd_component_copy (ModulemdComponent *self);
 
 G_END_DECLS
 

--- a/modulemd/modulemd-component.h
+++ b/modulemd/modulemd-component.h
@@ -39,13 +39,13 @@ struct _ModulemdComponentClass
 
   /* Virtual Public Members */
   void (*set_buildorder) (ModulemdComponent *self, guint64 buildorder);
-  guint64 (*get_buildorder) (ModulemdComponent *self);
+  guint64 (*peek_buildorder) (ModulemdComponent *self);
 
   void (*set_name) (ModulemdComponent *self, const gchar *name);
-  const gchar *(*get_name) (ModulemdComponent *self);
+  const gchar *(*peek_name) (ModulemdComponent *self);
 
   void (*set_rationale) (ModulemdComponent *self, const gchar *rationale);
-  const gchar *(*get_rationale) (ModulemdComponent *self);
+  const gchar *(*peek_rationale) (ModulemdComponent *self);
 
   /* Padding to allow adding up to 12 new virtual functions without
      * breaking ABI. */
@@ -61,16 +61,23 @@ modulemd_component_set_buildorder (ModulemdComponent *self,
 guint64
 modulemd_component_get_buildorder (ModulemdComponent *self);
 
+guint64
+modulemd_component_peek_buildorder (ModulemdComponent *self);
+
 void
 modulemd_component_set_name (ModulemdComponent *self, const gchar *name);
 const gchar *
 modulemd_component_get_name (ModulemdComponent *self);
+const gchar *
+modulemd_component_peek_name (ModulemdComponent *self);
 
 void
 modulemd_component_set_rationale (ModulemdComponent *self,
                                   const gchar *rationale);
 const gchar *
 modulemd_component_get_rationale (ModulemdComponent *self);
+const gchar *
+modulemd_component_peek_rationale (ModulemdComponent *self);
 
 G_END_DECLS
 

--- a/modulemd/modulemd-dependencies.c
+++ b/modulemd/modulemd-dependencies.c
@@ -176,6 +176,7 @@ modulemd_dependencies_set_buildrequires (ModulemdDependencies *self,
                             deps_properties[DEPS_PROP_BUILDREQUIRES]);
 }
 
+
 /**
  * modulemd_dependencies_get_buildrequires:
  *
@@ -184,9 +185,31 @@ modulemd_dependencies_set_buildrequires (ModulemdDependencies *self,
  * Returns: (element-type utf8 ModulemdSimpleSet) (transfer none): A hash
  * table containing the "buildrequires" property. Returns NULL if there are no
  * buildrequires set.
+ *
+ * Deprecated: 1.1
+ * Use peek_buildrequires() instead.
  */
+G_DEPRECATED_FOR (modulemd_dependencies_peek_buildrequires)
 GHashTable *
 modulemd_dependencies_get_buildrequires (ModulemdDependencies *self)
+{
+  return modulemd_dependencies_peek_buildrequires (self);
+}
+
+
+/**
+ * modulemd_dependencies_peek_buildrequires:
+ *
+ * Retrieves the "buildrequires" for these dependencies.
+ *
+ * Returns: (element-type utf8 ModulemdSimpleSet) (transfer none): A hash
+ * table containing the "buildrequires" property. Returns NULL if there are no
+ * buildrequires set.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_dependencies_peek_buildrequires (ModulemdDependencies *self)
 {
   g_return_val_if_fail (MODULEMD_IS_DEPENDENCIES (self), NULL);
 
@@ -290,9 +313,29 @@ modulemd_dependencies_set_requires (ModulemdDependencies *self,
  *
  * Returns: (element-type utf8 ModulemdSimpleSet) (transfer none): A hash
  * table containing the "requires" property.
+ *
+ * Deprecated: 1.1
  */
+G_DEPRECATED_FOR (modulemd_dependencies_peek_requires)
 GHashTable *
 modulemd_dependencies_get_requires (ModulemdDependencies *self)
+{
+  return modulemd_dependencies_peek_requires (self);
+}
+
+
+/**
+ * modulemd_dependencies_peek_requires:
+ *
+ * Retrieves the "requires" for these dependencies.
+ *
+ * Returns: (element-type utf8 ModulemdSimpleSet) (transfer none): A hash
+ * table containing the "requires" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_dependencies_peek_requires (ModulemdDependencies *self)
 {
   g_return_val_if_fail (MODULEMD_IS_DEPENDENCIES (self), NULL);
 
@@ -363,11 +406,11 @@ modulemd_dependencies_get_property (GObject *object,
     {
     case DEPS_PROP_BUILDREQUIRES:
       g_value_set_boxed (value,
-                         modulemd_dependencies_get_buildrequires (self));
+                         modulemd_dependencies_peek_buildrequires (self));
       break;
 
     case DEPS_PROP_REQUIRES:
-      g_value_set_boxed (value, modulemd_dependencies_get_requires (self));
+      g_value_set_boxed (value, modulemd_dependencies_peek_requires (self));
       break;
 
     default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec); break;

--- a/modulemd/modulemd-dependencies.c
+++ b/modulemd/modulemd-dependencies.c
@@ -217,6 +217,51 @@ modulemd_dependencies_peek_buildrequires (ModulemdDependencies *self)
 }
 
 
+static GHashTable *
+modulemd_dependencies_dup_requires_common (GHashTable *requires)
+{
+  GHashTable *new_requires = NULL;
+  ModulemdSimpleSet *set = NULL;
+  GHashTableIter iter;
+  gpointer key, value;
+
+  g_return_val_if_fail (requires, NULL);
+
+  new_requires =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+
+  g_hash_table_iter_init (&iter, requires);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      set = NULL;
+      modulemd_simpleset_copy (MODULEMD_SIMPLESET (value), &set);
+      g_hash_table_replace (
+        new_requires, g_strdup ((gchar *)key), (gpointer)set);
+    }
+
+  return new_requires;
+}
+
+
+/**
+ * modulemd_dependencies_dup_buildrequires:
+ *
+ * Retrieves a copy of the "buildrequires" for these dependencies.
+ *
+ * Returns: (element-type utf8 ModulemdSimpleSet) (transfer container): A hash
+ * table containing the "buildrequires" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_dependencies_dup_buildrequires (ModulemdDependencies *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_DEPENDENCIES (self), NULL);
+
+  return modulemd_dependencies_dup_requires_common (self->buildrequires);
+}
+
+
 /**
  * modulemd_dependencies_add_requires:
  * @module: The module name
@@ -340,6 +385,25 @@ modulemd_dependencies_peek_requires (ModulemdDependencies *self)
   g_return_val_if_fail (MODULEMD_IS_DEPENDENCIES (self), NULL);
 
   return self->requires;
+}
+
+
+/**
+ * modulemd_dependencies_dup_requires:
+ *
+ * Retrieves a copy of the "requires" for these dependencies.
+ *
+ * Returns: (element-type utf8 ModulemdSimpleSet) (transfer container): A hash
+ * table containing the "requires" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_dependencies_dup_requires (ModulemdDependencies *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_DEPENDENCIES (self), NULL);
+
+  return modulemd_dependencies_dup_requires_common (self->requires);
 }
 
 

--- a/modulemd/modulemd-dependencies.h
+++ b/modulemd/modulemd-dependencies.h
@@ -56,6 +56,8 @@ modulemd_dependencies_get_buildrequires (ModulemdDependencies *self);
 
 GHashTable *
 modulemd_dependencies_peek_buildrequires (ModulemdDependencies *self);
+GHashTable *
+modulemd_dependencies_dup_buildrequires (ModulemdDependencies *self);
 
 void
 modulemd_dependencies_add_requires (ModulemdDependencies *self,
@@ -76,6 +78,9 @@ modulemd_dependencies_get_requires (ModulemdDependencies *self);
 
 GHashTable *
 modulemd_dependencies_peek_requires (ModulemdDependencies *self);
+
+GHashTable *
+modulemd_dependencies_dup_requires (ModulemdDependencies *self);
 
 void
 modulemd_dependencies_copy (ModulemdDependencies *self,

--- a/modulemd/modulemd-dependencies.h
+++ b/modulemd/modulemd-dependencies.h
@@ -54,6 +54,9 @@ modulemd_dependencies_set_buildrequires (ModulemdDependencies *self,
 GHashTable *
 modulemd_dependencies_get_buildrequires (ModulemdDependencies *self);
 
+GHashTable *
+modulemd_dependencies_peek_buildrequires (ModulemdDependencies *self);
+
 void
 modulemd_dependencies_add_requires (ModulemdDependencies *self,
                                     const gchar *module,
@@ -70,6 +73,9 @@ modulemd_dependencies_set_requires (ModulemdDependencies *self,
 
 GHashTable *
 modulemd_dependencies_get_requires (ModulemdDependencies *self);
+
+GHashTable *
+modulemd_dependencies_peek_requires (ModulemdDependencies *self);
 
 void
 modulemd_dependencies_copy (ModulemdDependencies *self,

--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -135,9 +135,28 @@ modulemd_module_set_arch (ModulemdModule *self, const gchar *arch)
  * Retrieves the "arch" for modulemd.
  *
  * Returns: A string containing the "arch" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_arch() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_arch)
 const gchar *
 modulemd_module_get_arch (ModulemdModule *self)
+{
+  return modulemd_module_peek_arch (self);
+}
+
+/**
+ * modulemd_module_peek_arch:
+ *
+ * Retrieves the "arch" for modulemd.
+ *
+ * Returns: A string containing the "arch" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_module_peek_arch (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
@@ -160,7 +179,7 @@ modulemd_module_set_buildrequires (ModulemdModule *self,
   gpointer module_name, stream_name;
   guint64 version;
 
-  version = modulemd_module_get_mdversion (self);
+  version = modulemd_module_peek_mdversion (self);
 
   g_return_if_fail (MODULEMD_IS_MODULE (self));
   g_return_if_fail (self->buildrequires != buildrequires);
@@ -208,9 +227,29 @@ modulemd_module_set_buildrequires (ModulemdModule *self,
  *
  * Returns: (element-type utf8 utf8) (transfer none): A hash table
  * containing the "buildrequires" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_buildrequires() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_buildrequires)
 GHashTable *
 modulemd_module_get_buildrequires (ModulemdModule *self)
+{
+  return modulemd_module_peek_buildrequires (self);
+}
+
+/**
+ * modulemd_module_peek_buildrequires:
+ *
+ * Retrieves the "buildrequires" for modulemd.
+ *
+ * Returns: (element-type utf8 utf8) (transfer none): A hash table
+ * containing the "buildrequires" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_peek_buildrequires (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
   g_return_val_if_fail (modulemd_module_check_mdversion_range_full (
@@ -246,14 +285,35 @@ modulemd_module_set_community (ModulemdModule *self, const gchar *community)
  * Retrieves the "community" for modulemd.
  *
  * Returns: A string containing the "community" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_community() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_community)
 const gchar *
 modulemd_module_get_community (ModulemdModule *self)
+{
+  return modulemd_module_peek_community (self);
+}
+
+
+/**
+ * modulemd_module_peek_community:
+ *
+ * Retrieves the "community" for modulemd.
+ *
+ * Returns: A string containing the "community" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_module_peek_community (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->community;
 }
+
 
 /**
  * modulemd_module_set_content_licenses:
@@ -282,7 +342,12 @@ modulemd_module_set_content_licenses (ModulemdModule *self,
  *
  * Returns: (transfer none): a #SimpleSet containing the set of licenses in the
  * "content_licenses" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_content_licenses() instead.
+ *
  */
+G_DEPRECATED_FOR (modulemd_module_peek_content_licenses)
 ModulemdSimpleSet *
 modulemd_module_get_content_licenses (ModulemdModule *self)
 {
@@ -290,6 +355,26 @@ modulemd_module_get_content_licenses (ModulemdModule *self)
 
   return self->content_licenses;
 }
+
+
+/**
+ * modulemd_module_peek_content_licenses:
+ *
+ * Retrieves the "content_licenses" for modulemd
+ *
+ * Returns: (transfer none): a #SimpleSet containing the set of licenses in the
+ * "content_licenses" property.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_module_peek_content_licenses (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return self->content_licenses;
+}
+
 
 /**
  * modulemd_module_set_context:
@@ -317,9 +402,29 @@ modulemd_module_set_context (ModulemdModule *self, const gchar *context)
  * Retrieves the "context" for modulemd.
  *
  * Returns: A string containing the "context" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_context() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_context)
 const gchar *
 modulemd_module_get_context (ModulemdModule *self)
+{
+  return modulemd_module_peek_context (self);
+}
+
+
+/**
+ * modulemd_module_peek_context:
+ *
+ * Retrieves the "context" for modulemd.
+ *
+ * Returns: A string containing the "context" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_module_peek_context (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
@@ -341,7 +446,7 @@ modulemd_module_set_dependencies (ModulemdModule *self, GPtrArray *deps)
   ModulemdDependencies *copy = NULL;
   guint64 mdversion;
 
-  mdversion = modulemd_module_get_mdversion (self);
+  mdversion = modulemd_module_peek_mdversion (self);
 
   g_return_if_fail (MODULEMD_IS_MODULE (self));
 
@@ -394,7 +499,7 @@ modulemd_module_add_dependencies (ModulemdModule *self,
 
   guint64 mdversion;
 
-  mdversion = modulemd_module_get_mdversion (self);
+  mdversion = modulemd_module_peek_mdversion (self);
 
   g_return_if_fail (MODULEMD_IS_MODULE (self));
 
@@ -430,9 +535,28 @@ modulemd_module_add_dependencies (ModulemdModule *self,
  *
  * Returns: (element-type ModulemdDependencies) (transfer none): The list
  * of dependency objects for this module.
+ *
+ * Deprecated: 1.1
+ * Use peek_dependencies() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_dependencies)
 GPtrArray *
 modulemd_module_get_dependencies (ModulemdModule *self)
+{
+  return modulemd_module_peek_dependencies (self);
+}
+
+
+/**
+ * modulemd_module_peek_dependencies
+ *
+ * Returns: (element-type ModulemdDependencies) (transfer none): The list
+ * of dependency objects for this module.
+ *
+ * Since: 1.1
+ */
+GPtrArray *
+modulemd_module_peek_dependencies (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
   if (!modulemd_module_check_mdversion_range_full (
@@ -471,14 +595,35 @@ modulemd_module_set_description (ModulemdModule *self,
  * Retrieves the "description" for modulemd.
  *
  * Returns: A string containing the "description" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_description() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_description)
 const gchar *
 modulemd_module_get_description (ModulemdModule *self)
+{
+  return modulemd_module_peek_description (self);
+}
+
+
+/**
+ * modulemd_module_peek_description:
+ *
+ * Retrieves the "description" for modulemd.
+ *
+ * Returns: A string containing the "description" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_module_peek_description (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->description;
 }
+
 
 /**
  * modulemd_module_set_documentation:
@@ -506,14 +651,35 @@ modulemd_module_set_documentation (ModulemdModule *self,
  * Retrieves the "documentation" for modulemd.
  *
  * Returns: A string containing the "documentation" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_documentation() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_documentation)
 const gchar *
 modulemd_module_get_documentation (ModulemdModule *self)
+{
+  return modulemd_module_peek_documentation (self);
+}
+
+
+/**
+ * modulemd_module_peek_documentation:
+ *
+ * Retrieves the "documentation" for modulemd.
+ *
+ * Returns: A string containing the "documentation" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_module_peek_documentation (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->documentation;
 }
+
 
 /**
  * modulemd_module_set_eol:
@@ -528,7 +694,7 @@ void
 modulemd_module_set_eol (ModulemdModule *self, const GDate *date)
 {
   g_return_if_fail (MODULEMD_IS_MODULE (self));
-  g_return_if_fail (modulemd_module_get_mdversion (self) < 2);
+  g_return_if_fail (modulemd_module_peek_mdversion (self) < 2);
 
   if (!date)
     {
@@ -558,6 +724,7 @@ modulemd_module_set_eol (ModulemdModule *self, const GDate *date)
     }
 }
 
+
 /**
  * modulemd_module_get_eol:
  *
@@ -567,12 +734,35 @@ modulemd_module_set_eol (ModulemdModule *self, const GDate *date)
  * on modulemd files using the version 2 or later formats.
  *
  * Returns: A #GDate containing the "EOL" date
+ *
+ * Deprecated: 1.1
+ * Use peek_eol() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_eol)
 const GDate *
 modulemd_module_get_eol (ModulemdModule *self)
 {
+  return modulemd_module_peek_eol (self);
+}
+
+
+/**
+ * modulemd_module_peek_eol:
+ *
+ * Retrieves the "eol" property.
+ *
+ * Note: This property is obsolete. Use "servicelevels" instead. This will fail
+ * on modulemd files using the version 2 or later formats.
+ *
+ * Returns: A #GDate containing the "EOL" date
+ *
+ * Since: 1.1
+ */
+const GDate *
+modulemd_module_peek_eol (ModulemdModule *self)
+{
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
-  g_return_val_if_fail (modulemd_module_get_mdversion (self) < 2, NULL);
+  g_return_val_if_fail (modulemd_module_peek_mdversion (self) < 2, NULL);
 
   if (!g_date_valid (self->eol))
     {
@@ -709,9 +899,27 @@ modulemd_module_check_mdversion_range_full (ModulemdModule *self,
  * Retrieves the "mdversion" for modulemd.
  *
  * Returns: A 64-bit unsigned integer containing the "mdversion" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_mdversion() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_mdversion)
 const guint64
 modulemd_module_get_mdversion (ModulemdModule *self)
+{
+  return modulemd_module_peek_mdversion (self);
+}
+
+
+/**
+ * modulemd_module_peek_mdversion:
+ *
+ * Retrieves the "mdversion" for modulemd.
+ *
+ * Returns: A 64-bit unsigned integer containing the "mdversion" property.
+ */
+const guint64
+modulemd_module_peek_mdversion (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), 0);
 
@@ -812,14 +1020,36 @@ modulemd_module_set_module_components (ModulemdModule *self,
  *
  * Returns: (element-type utf8 ModulemdComponentModule) (transfer none): A hash table
  * containing the "module-components" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_module_components() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_module_components)
 GHashTable *
 modulemd_module_get_module_components (ModulemdModule *self)
+{
+  return modulemd_module_peek_module_components (self);
+}
+
+
+/**
+ * modulemd_module_peek_module_components:
+ *
+ * Retrieves the "module-components" for modulemd.
+ *
+ * Returns: (element-type utf8 ModulemdComponentModule) (transfer none): A hash table
+ * containing the "module-components" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_peek_module_components (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->module_components;
 }
+
 
 /**
  * modulemd_module_set_module_licenses:
@@ -848,14 +1078,36 @@ modulemd_module_set_module_licenses (ModulemdModule *self,
  *
  * Returns: (transfer none): a #ModulemdSimpleSet containing the set of
  * licenses in the "module_licenses" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_module_licenses() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_module_licenses)
 ModulemdSimpleSet *
 modulemd_module_get_module_licenses (ModulemdModule *self)
+{
+  return modulemd_module_peek_module_licenses (self);
+}
+
+
+/**
+ * modulemd_module_peek_module_licenses:
+ *
+ * Retrieves the "module_licenses" for modulemd
+ *
+ * Returns: (transfer none): a #ModulemdSimpleSet containing the set of
+ * licenses in the "module_licenses" property.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_module_peek_module_licenses (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->module_licenses;
 }
+
 
 /**
  * modulemd_module_set_name:
@@ -882,9 +1134,31 @@ modulemd_module_set_name (ModulemdModule *self, const gchar *name)
  * Retrieves the "name" for modulemd.
  *
  * Returns: A string containing the "name" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_name() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_name)
 const gchar *
 modulemd_module_get_name (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return modulemd_module_peek_name (self);
+}
+
+
+/**
+ * modulemd_module_peek_name:
+ *
+ * Retrieves the "name" for modulemd.
+ *
+ * Returns: A string containing the "name" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_module_peek_name (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
@@ -970,6 +1244,7 @@ modulemd_module_set_profiles (ModulemdModule *self, GHashTable *profiles)
   g_object_notify_by_pspec (G_OBJECT (self), md_properties[MD_PROP_PROFILES]);
 }
 
+
 /**
  * modulemd_module_get_profiles:
  *
@@ -977,14 +1252,34 @@ modulemd_module_set_profiles (ModulemdModule *self, GHashTable *profiles)
  *
  * Returns: (element-type utf8 ModulemdProfile) (transfer none): A hash
  * table containing the "profiles" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_profiles() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_profiles)
 GHashTable *
 modulemd_module_get_profiles (ModulemdModule *self)
+{
+  return modulemd_module_peek_profiles (self);
+}
+
+
+/**
+ * modulemd_module_peek_profiles:
+ *
+ * Retrieves the "profiles" for modulemd.
+ *
+ * Returns: (element-type utf8 ModulemdProfile) (transfer none): A hash
+ * table containing the "profiles" property.
+ */
+GHashTable *
+modulemd_module_peek_profiles (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->profiles;
 }
+
 
 /**
  * modulemd_module_set_requires:
@@ -1000,7 +1295,7 @@ modulemd_module_set_requires (ModulemdModule *self, GHashTable *requires)
   gpointer module_name, stream_name;
   guint64 version;
 
-  version = modulemd_module_get_mdversion (self);
+  version = modulemd_module_peek_mdversion (self);
 
   g_return_if_fail (MODULEMD_IS_MODULE (self));
   g_return_if_fail (self->requires != requires);
@@ -1039,6 +1334,7 @@ modulemd_module_set_requires (ModulemdModule *self, GHashTable *requires)
   g_object_notify_by_pspec (G_OBJECT (self), md_properties[MD_PROP_REQUIRES]);
 }
 
+
 /**
  * modulemd_module_get_requires:
  *
@@ -1047,9 +1343,31 @@ modulemd_module_set_requires (ModulemdModule *self, GHashTable *requires)
  * Returns: (element-type utf8 utf8) (transfer none): A hash table
  * containing the "requires" property. This function was deprecated and is not
  * valid for modulemd files of version 2 or later.
+ *
+ * Deprecated: 1.1
+ * Use peek_requires() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_requires)
 GHashTable *
 modulemd_module_get_requires (ModulemdModule *self)
+{
+  return modulemd_module_peek_requires (self);
+}
+
+
+/**
+ * modulemd_module_peek_requires:
+ *
+ * Retrieves the "requires" for modulemd.
+ *
+ * Returns: (element-type utf8 utf8) (transfer none): A hash table
+ * containing the "requires" property. This function was deprecated and is not
+ * valid for modulemd files of version 2 or later.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_peek_requires (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
   g_return_val_if_fail (modulemd_module_check_mdversion_range_full (
@@ -1058,6 +1376,7 @@ modulemd_module_get_requires (ModulemdModule *self)
 
   return self->requires;
 }
+
 
 /**
  * modulemd_module_set_rpm_api:
@@ -1077,6 +1396,7 @@ modulemd_module_set_rpm_api (ModulemdModule *self, ModulemdSimpleSet *apis)
   g_object_notify_by_pspec (G_OBJECT (self), md_properties[MD_PROP_RPM_API]);
 }
 
+
 /**
  * modulemd_module_get_rpm_api:
  *
@@ -1084,14 +1404,36 @@ modulemd_module_set_rpm_api (ModulemdModule *self, ModulemdSimpleSet *apis)
  *
  * Returns: (transfer none): a #SimpleSet containing the set of binary RPM
  * packages in the "rpm_api" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_rpm_api() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_rpm_api)
 ModulemdSimpleSet *
 modulemd_module_get_rpm_api (ModulemdModule *self)
+{
+  return modulemd_module_peek_rpm_api (self);
+}
+
+
+/**
+ * modulemd_module_peek_rpm_api:
+ *
+ * Retrieves the "rpm_api" for modulemd
+ *
+ * Returns: (transfer none): a #SimpleSet containing the set of binary RPM
+ * packages in the "rpm_api" property.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_module_peek_rpm_api (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->rpm_api;
 }
+
 
 /**
  * modulemd_module_set_rpm_artifacts:
@@ -1113,6 +1455,7 @@ modulemd_module_set_rpm_artifacts (ModulemdModule *self,
                             md_properties[MD_PROP_RPM_ARTIFACTS]);
 }
 
+
 /**
  * modulemd_module_get_rpm_artifacts:
  *
@@ -1120,9 +1463,32 @@ modulemd_module_set_rpm_artifacts (ModulemdModule *self,
  *
  * Returns: (transfer none): a #SimpleSet containing the set of binary RPMs
  * contained in this module.
+ *
+ * Deprecated: 1.1
+ * Use peek_rpm_artifacts() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_rpm_artifacts)
 ModulemdSimpleSet *
 modulemd_module_get_rpm_artifacts (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return modulemd_module_peek_rpm_artifacts (self);
+}
+
+
+/**
+ * modulemd_module_peek_rpm_artifacts:
+ *
+ * Retrieves the "rpm_artifacts" for modulemd
+ *
+ * Returns: (transfer none): a #SimpleSet containing the set of binary RPMs
+ * contained in this module.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_module_peek_rpm_artifacts (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
@@ -1169,9 +1535,30 @@ modulemd_module_set_rpm_buildopts (ModulemdModule *self, GHashTable *buildopts)
  *
  * Returns: (element-type utf8 utf8) (transfer none): A hash table
  * containing the "rpm-buildopts" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_rpm_buildopts() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_rpm_buildopts)
 GHashTable *
 modulemd_module_get_rpm_buildopts (ModulemdModule *self)
+{
+  return modulemd_module_peek_rpm_buildopts (self);
+}
+
+
+/**
+ * modulemd_module_peek_rpm_buildopts:
+ *
+ * Retrieves the "rpm-buildopts" for modulemd.
+ *
+ * Returns: (element-type utf8 utf8) (transfer none): A hash table
+ * containing the "rpm-buildopts" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_peek_rpm_buildopts (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
@@ -1264,6 +1651,7 @@ modulemd_module_set_rpm_components (ModulemdModule *self,
                             md_properties[MD_PROP_RPM_COMPONENTS]);
 }
 
+
 /**
  * modulemd_module_get_rpm_components:
  *
@@ -1271,14 +1659,38 @@ modulemd_module_set_rpm_components (ModulemdModule *self,
  *
  * Returns: (element-type utf8 ModulemdComponentRpm) (transfer none): A hash table
  * containing the "rpm-components" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_rpm_components() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_rpm_components)
 GHashTable *
 modulemd_module_get_rpm_components (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
+  return modulemd_module_peek_rpm_components (self);
+}
+
+
+/**
+ * modulemd_module_peek_rpm_components:
+ *
+ * Retrieves the "rpm-components" for modulemd.
+ *
+ * Returns: (element-type utf8 ModulemdComponentRpm) (transfer none): A hash table
+ * containing the "rpm-components" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_peek_rpm_components (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
   return self->rpm_components;
 }
+
 
 /**
  * modulemd_module_set_rpm_filter:
@@ -1300,6 +1712,7 @@ modulemd_module_set_rpm_filter (ModulemdModule *self,
                             md_properties[MD_PROP_RPM_FILTER]);
 }
 
+
 /**
  * modulemd_module_get_rpm_filter:
  *
@@ -1307,9 +1720,30 @@ modulemd_module_set_rpm_filter (ModulemdModule *self,
  *
  * Returns: (transfer none): a #SimpleSet containing the set of binary RPMs
  * filtered out of this module.
+ *
+ * Deprecated: 1.1
+ * Use peek_rpm_filter() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_rpm_filter)
 ModulemdSimpleSet *
 modulemd_module_get_rpm_filter (ModulemdModule *self)
+{
+  return modulemd_module_peek_rpm_filter (self);
+}
+
+
+/**
+ * modulemd_module_peek_rpm_filter:
+ *
+ * Retrieves the "rpm_filter" for modulemd
+ *
+ * Returns: (transfer none): a #SimpleSet containing the set of binary RPMs
+ * filtered out of this module.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_module_peek_rpm_filter (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
@@ -1434,9 +1868,30 @@ modulemd_module_add_servicelevel (ModulemdModule *self,
  *
  * Returns: (element-type utf8 ModulemdServiceLevel) (transfer none): A
  * hash table containing the service levels.
+ *
+ * Deprecated: 1.1
+ * Use peek_servicelevels() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_servicelevels)
 GHashTable *
 modulemd_module_get_servicelevels (ModulemdModule *self)
+{
+  return modulemd_module_peek_servicelevels (self);
+}
+
+
+/**
+ * modulemd_module_peek_servicelevels:
+ *
+ * Retrieves the service levels for the module
+ *
+ * Returns: (element-type utf8 ModulemdServiceLevel) (transfer none): A
+ * hash table containing the service levels.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_peek_servicelevels (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
@@ -1464,20 +1919,42 @@ modulemd_module_set_stream (ModulemdModule *self, const gchar *stream)
     }
 }
 
+
 /**
  * modulemd_module_get_stream:
  *
  * Retrieves the "stream" for modulemd.
  *
  * Returns: A string containing the "stream" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_stream() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_stream)
 const gchar *
 modulemd_module_get_stream (ModulemdModule *self)
+{
+  return modulemd_module_peek_stream (self);
+}
+
+
+/**
+ * modulemd_module_peek_stream:
+ *
+ * Retrieves the "stream" for modulemd.
+ *
+ * Returns: A string containing the "stream" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_module_peek_stream (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->stream;
 }
+
 
 /**
  * modulemd_module_set_summary:
@@ -1499,20 +1976,42 @@ modulemd_module_set_summary (ModulemdModule *self, const gchar *summary)
     }
 }
 
+
 /**
  * modulemd_module_get_summary:
  *
  * Retrieves the "summary" for modulemd.
  *
  * Returns: A string containing the "summary" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_summary() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_summary)
 const gchar *
 modulemd_module_get_summary (ModulemdModule *self)
+{
+  return modulemd_module_peek_summary (self);
+}
+
+
+/**
+ * modulemd_module_peek_summary:
+ *
+ * Retrieves the "summary" for modulemd.
+ *
+ * Returns: A string containing the "summary" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_module_peek_summary (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->summary;
 }
+
 
 /**
  * modulemd_module_set_tracker:
@@ -1534,20 +2033,42 @@ modulemd_module_set_tracker (ModulemdModule *self, const gchar *tracker)
     }
 }
 
+
 /**
  * modulemd_module_get_tracker:
  *
  * Retrieves the "tracker" for modulemd.
  *
  * Returns: A string containing the "tracker" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_tracker() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_tracker)
 const gchar *
 modulemd_module_get_tracker (ModulemdModule *self)
+{
+  return modulemd_module_peek_tracker (self);
+}
+
+
+/**
+ * modulemd_module_peek_tracker:
+ *
+ * Retrieves the "tracker" for modulemd.
+ *
+ * Returns: A string containing the "tracker" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_module_peek_tracker (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->tracker;
 }
+
 
 /**
  * modulemd_module_set_version
@@ -1567,20 +2088,44 @@ modulemd_module_set_version (ModulemdModule *self, const guint64 version)
     }
 }
 
+
 /**
  * modulemd_module_get_version:
  *
  * Retrieves the "version" for modulemd.
  *
  * Returns: A 64-bit unsigned integer containing the "version" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_version() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_version)
 const guint64
 modulemd_module_get_version (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), 0);
 
+  return modulemd_module_peek_version (self);
+}
+
+
+/**
+ * modulemd_module_peek_version:
+ *
+ * Retrieves the "version" for modulemd.
+ *
+ * Returns: A 64-bit unsigned integer containing the "version" property.
+ *
+ * Since: 1.1
+ */
+const guint64
+modulemd_module_peek_version (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), 0);
+
   return self->version;
 }
+
 
 /**
  * modulemd_module_set_xmd:
@@ -1612,6 +2157,7 @@ modulemd_module_set_xmd (ModulemdModule *self, GHashTable *xmd)
     }
 }
 
+
 /**
  * modulemd_module_get_xmd:
  *
@@ -1619,14 +2165,36 @@ modulemd_module_set_xmd (ModulemdModule *self, GHashTable *xmd)
  *
  * Returns: (element-type utf8 GVariant) (transfer none): A hash table
  * containing the "xmd" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_xmd() instead.
  */
+G_DEPRECATED_FOR (modulemd_module_peek_xmd)
 GHashTable *
 modulemd_module_get_xmd (ModulemdModule *self)
+{
+  return modulemd_module_peek_xmd (self);
+}
+
+
+/**
+ * modulemd_module_peek_xmd:
+ *
+ * Retrieves the "xmd" for modulemd.
+ *
+ * Returns: (element-type utf8 GVariant) (transfer none): A hash table
+ * containing the "xmd" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_peek_xmd (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->xmd;
 }
+
 
 static void
 modulemd_module_set_property (GObject *gobject,
@@ -1759,107 +2327,107 @@ modulemd_module_get_property (GObject *gobject,
   switch (property_id)
     {
     case MD_PROP_ARCH:
-      g_value_set_string (value, modulemd_module_get_arch (self));
+      g_value_set_string (value, modulemd_module_peek_arch (self));
       break;
 
     case MD_PROP_BUILDREQUIRES:
-      g_value_set_boxed (value, modulemd_module_get_buildrequires (self));
+      g_value_set_boxed (value, modulemd_module_peek_buildrequires (self));
       break;
 
     case MD_PROP_COMMUNITY:
-      g_value_set_string (value, modulemd_module_get_community (self));
+      g_value_set_string (value, modulemd_module_peek_community (self));
       break;
 
     case MD_PROP_CONTENT_LIC:
-      g_value_set_object (value, modulemd_module_get_content_licenses (self));
+      g_value_set_object (value, modulemd_module_peek_content_licenses (self));
       break;
 
     case MD_PROP_CONTEXT:
-      g_value_set_string (value, modulemd_module_get_context (self));
+      g_value_set_string (value, modulemd_module_peek_context (self));
       break;
 
     case MD_PROP_DEPS:
-      g_value_set_boxed (value, modulemd_module_get_description (self));
+      g_value_set_boxed (value, modulemd_module_peek_dependencies (self));
       break;
 
     case MD_PROP_DESC:
-      g_value_set_string (value, modulemd_module_get_description (self));
+      g_value_set_string (value, modulemd_module_peek_description (self));
       break;
 
     case MD_PROP_DOCS:
-      g_value_set_string (value, modulemd_module_get_documentation (self));
+      g_value_set_string (value, modulemd_module_peek_documentation (self));
       break;
 
     case MD_PROP_EOL:
-      g_value_set_boxed (value, modulemd_module_get_eol (self));
+      g_value_set_boxed (value, modulemd_module_peek_eol (self));
       break;
 
     case MD_PROP_MDVERSION:
-      g_value_set_uint64 (value, modulemd_module_get_mdversion (self));
+      g_value_set_uint64 (value, modulemd_module_peek_mdversion (self));
       break;
 
     case MD_PROP_MODULE_COMPONENTS:
-      g_value_set_boxed (value, modulemd_module_get_module_components (self));
+      g_value_set_boxed (value, modulemd_module_peek_module_components (self));
       break;
 
     case MD_PROP_MODULE_LIC:
-      g_value_set_object (value, modulemd_module_get_module_licenses (self));
+      g_value_set_object (value, modulemd_module_peek_module_licenses (self));
       break;
 
     case MD_PROP_NAME:
-      g_value_set_string (value, modulemd_module_get_name (self));
+      g_value_set_string (value, modulemd_module_peek_name (self));
       break;
 
     case MD_PROP_PROFILES:
-      g_value_set_boxed (value, modulemd_module_get_profiles (self));
+      g_value_set_boxed (value, modulemd_module_peek_profiles (self));
       break;
 
     case MD_PROP_REQUIRES:
-      g_value_set_boxed (value, modulemd_module_get_requires (self));
+      g_value_set_boxed (value, modulemd_module_peek_requires (self));
       break;
 
     case MD_PROP_RPM_API:
-      g_value_set_object (value, modulemd_module_get_rpm_api (self));
+      g_value_set_object (value, modulemd_module_peek_rpm_api (self));
       break;
 
     case MD_PROP_RPM_ARTIFACTS:
-      g_value_set_object (value, modulemd_module_get_rpm_artifacts (self));
+      g_value_set_object (value, modulemd_module_peek_rpm_artifacts (self));
       break;
 
     case MD_PROP_RPM_BUILDOPTS:
-      g_value_set_boxed (value, modulemd_module_get_rpm_buildopts (self));
+      g_value_set_boxed (value, modulemd_module_peek_rpm_buildopts (self));
       break;
 
     case MD_PROP_RPM_COMPONENTS:
-      g_value_set_boxed (value, modulemd_module_get_rpm_components (self));
+      g_value_set_boxed (value, modulemd_module_peek_rpm_components (self));
       break;
 
     case MD_PROP_RPM_FILTER:
-      g_value_set_object (value, modulemd_module_get_rpm_filter (self));
+      g_value_set_object (value, modulemd_module_peek_rpm_filter (self));
       break;
 
     case MD_PROP_SL:
-      g_value_set_boxed (value, modulemd_module_get_servicelevels (self));
+      g_value_set_boxed (value, modulemd_module_peek_servicelevels (self));
       break;
 
     case MD_PROP_STREAM:
-      g_value_set_string (value, modulemd_module_get_stream (self));
+      g_value_set_string (value, modulemd_module_peek_stream (self));
       break;
 
     case MD_PROP_SUMMARY:
-      g_value_set_string (value, modulemd_module_get_summary (self));
+      g_value_set_string (value, modulemd_module_peek_summary (self));
       break;
 
     case MD_PROP_TRACKER:
-      g_value_set_string (value, modulemd_module_get_tracker (self));
+      g_value_set_string (value, modulemd_module_peek_tracker (self));
       break;
 
     case MD_PROP_VERSION:
-      g_value_set_uint64 (value, modulemd_module_get_version (self));
+      g_value_set_uint64 (value, modulemd_module_peek_version (self));
       break;
 
     case MD_PROP_XMD:
-      g_value_set_boxed (value, modulemd_module_get_xmd (self));
+      g_value_set_boxed (value, modulemd_module_peek_xmd (self));
       break;
 
     default:
@@ -2474,7 +3042,7 @@ _modulemd_upgrade_v1_to_v2 (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), FALSE);
 
   /* Upgrade the EOL field to a "rawhide" servicelevel*/
-  eol = modulemd_module_get_eol (self);
+  eol = modulemd_module_peek_eol (self);
   if (eol && g_date_valid (eol))
     {
       sl = modulemd_servicelevel_new ();
@@ -2489,7 +3057,7 @@ _modulemd_upgrade_v1_to_v2 (ModulemdModule *self)
 
 
   /* First do BuildRequires */
-  buildrequires = modulemd_module_get_buildrequires (self);
+  buildrequires = modulemd_module_peek_buildrequires (self);
   g_hash_table_iter_init (&iter, buildrequires);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
@@ -2498,7 +3066,7 @@ _modulemd_upgrade_v1_to_v2 (ModulemdModule *self)
     }
 
   /* Now add runtime Requires */
-  requires = modulemd_module_get_requires (self);
+  requires = modulemd_module_peek_requires (self);
   g_hash_table_iter_init (&iter, requires);
   while (g_hash_table_iter_next (&iter, &key, &value))
     {
@@ -2549,7 +3117,7 @@ modulemd_module_upgrade_full (ModulemdModule *self, guint64 version)
 
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), FALSE);
 
-  mdversion = modulemd_module_get_mdversion (self);
+  mdversion = modulemd_module_peek_mdversion (self);
 
   while (mdversion < version)
     {

--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -163,6 +163,25 @@ modulemd_module_peek_arch (ModulemdModule *self)
   return self->arch;
 }
 
+
+/**
+ * modulemd_module_dup_arch:
+ *
+ * Retrieves a copy of the "arch" for modulemd.
+ *
+ * Returns: A copy of the string containing the "arch" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_module_dup_arch (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return g_strdup (self->arch);
+}
+
+
 /**
  * modulemd_module_set_buildrequires:
  * @buildrequires: (nullable) (element-type utf8 utf8): The requirements to build this
@@ -259,6 +278,29 @@ modulemd_module_peek_buildrequires (ModulemdModule *self)
   return self->buildrequires;
 }
 
+
+/**
+ * modulemd_module_dup_buildrequires:
+ *
+ * Retrieves the "buildrequires" for modulemd.
+ *
+ * Returns: (element-type utf8 utf8) (transfer container): A hash table
+ * containing the "buildrequires" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_dup_buildrequires (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+  g_return_val_if_fail (modulemd_module_check_mdversion_range_full (
+                          self, MD_VERSION_1, MD_VERSION_1),
+                        NULL);
+
+  return _modulemd_hash_table_deep_str_copy (self->buildrequires);
+}
+
+
 /**
  * modulemd_module_set_community:
  * @community: (nullable): the module community.
@@ -312,6 +354,24 @@ modulemd_module_peek_community (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->community;
+}
+
+
+/**
+ * modulemd_module_dup_community:
+ *
+ * Retrieves a copy of the "community" for modulemd.
+ *
+ * Returns: A copy of string containing the "community" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_module_dup_community (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return g_strdup (self->community);
 }
 
 
@@ -377,6 +437,28 @@ modulemd_module_peek_content_licenses (ModulemdModule *self)
 
 
 /**
+ * modulemd_module_dup_content_licenses:
+ *
+ * Retrieves the "content_licenses" for modulemd
+ *
+ * Returns: (transfer full): a #SimpleSet containing the set of licenses in the
+ * "content_licenses" property.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_module_dup_content_licenses (ModulemdModule *self)
+{
+  ModulemdSimpleSet *set = NULL;
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  modulemd_simpleset_copy (self->content_licenses, &set);
+
+  return set;
+}
+
+
+/**
  * modulemd_module_set_context:
  * @context: (nullable): the module artifact architecture.
  *
@@ -429,6 +511,24 @@ modulemd_module_peek_context (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->context;
+}
+
+
+/**
+ * modulemd_module_dup_context:
+ *
+ * Retrieves a copy of the "context" for modulemd.
+ *
+ * Returns: A copy of the string containing the "context" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_module_dup_context (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return g_strdup (self->context);
 }
 
 
@@ -570,6 +670,41 @@ modulemd_module_peek_dependencies (ModulemdModule *self)
 
 
 /**
+ * modulemd_module_dup_dependencies
+ *
+ * Returns: (element-type ModulemdDependencies) (transfer container): The list
+ * of dependency objects for this module.
+ *
+ * Since: 1.1
+ */
+GPtrArray *
+modulemd_module_dup_dependencies (ModulemdModule *self)
+{
+  GPtrArray *dependencies = NULL;
+  ModulemdDependencies *copy = NULL;
+
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+  if (!modulemd_module_check_mdversion_range_full (
+        self, MD_VERSION_2, MD_VERSION_MAX))
+    {
+      return NULL;
+    }
+
+  dependencies = g_ptr_array_new_with_free_func (g_object_unref);
+
+  for (gsize i = 0; i < self->dependencies->len; i++)
+    {
+      copy = NULL;
+      modulemd_dependencies_copy (g_ptr_array_index (self->dependencies, i),
+                                  &copy);
+      g_ptr_array_add (dependencies, copy);
+    }
+
+  return dependencies;
+}
+
+
+/**
  * modulemd_module_set_description:
  * @description: (nullable): the module description.
  *
@@ -626,6 +761,24 @@ modulemd_module_peek_description (ModulemdModule *self)
 
 
 /**
+ * modulemd_module_dup_description:
+ *
+ * Retrieves a copy of the "description" for modulemd.
+ *
+ * Returns: A copy of the string containing the "description" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_module_dup_description (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return g_strdup (self->description);
+}
+
+
+/**
  * modulemd_module_set_documentation:
  * @documentation: (nullable): the module documentation.
  *
@@ -678,6 +831,24 @@ modulemd_module_peek_documentation (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->documentation;
+}
+
+
+/**
+ * modulemd_module_dup_documentation:
+ *
+ * Retrieves a copy of the "documentation" for modulemd.
+ *
+ * Returns: A copy of the string containing the "documentation" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_module_dup_documentation (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return g_strdup (self->documentation);
 }
 
 
@@ -770,6 +941,35 @@ modulemd_module_peek_eol (ModulemdModule *self)
     }
 
   return self->eol;
+}
+
+
+/**
+ * modulemd_module_dup_eol:
+ *
+ * Retrieves a copy of the "eol" property.
+ *
+ * Note: This property is obsolete. Use "servicelevels" instead. This will fail
+ * on modulemd files using the version 2 or later formats.
+ *
+ * Returns: A #GDate containing a copy of the "EOL" date
+ *
+ * Since: 1.1
+ */
+GDate *
+modulemd_module_dup_eol (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+  g_return_val_if_fail (modulemd_module_peek_mdversion (self) < 2, NULL);
+
+  if (!g_date_valid (self->eol))
+    {
+      return NULL;
+    }
+
+  return g_date_new_dmy (g_date_get_day (self->eol),
+                         g_date_get_month (self->eol),
+                         g_date_get_year (self->eol));
 }
 
 
@@ -918,7 +1118,7 @@ modulemd_module_get_mdversion (ModulemdModule *self)
  *
  * Returns: A 64-bit unsigned integer containing the "mdversion" property.
  */
-const guint64
+guint64
 modulemd_module_peek_mdversion (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), 0);
@@ -1052,6 +1252,39 @@ modulemd_module_peek_module_components (ModulemdModule *self)
 
 
 /**
+ * modulemd_module_dup_module_components:
+ *
+ * Retrieves the "module-components" for modulemd.
+ *
+ * Returns: (element-type utf8 ModulemdComponentModule) (transfer container):
+ * A copy of the hash table containing the "module-components" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_dup_module_components (ModulemdModule *self)
+{
+  GHashTable *components = NULL;
+  GHashTableIter iter;
+  gpointer key, value;
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  components =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  g_hash_table_iter_init (&iter, self->module_components);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      g_hash_table_replace (
+        components,
+        g_strdup ((gchar *)key),
+        modulemd_component_copy (MODULEMD_COMPONENT (value)));
+    }
+
+  return components;
+}
+
+
+/**
  * modulemd_module_set_module_licenses:
  * @licenses: (nullable): A #ModuleSimpleSet: The licenses under which the components of
  * this module are released.
@@ -1110,6 +1343,28 @@ modulemd_module_peek_module_licenses (ModulemdModule *self)
 
 
 /**
+ * modulemd_module_dup_module_licenses:
+ *
+ * Retrieves a copy of the "module_licenses" for modulemd
+ *
+ * Returns: (transfer full): a #ModulemdSimpleSet containing the set of
+ * licenses in the "module_licenses" property.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_module_dup_module_licenses (ModulemdModule *self)
+{
+  ModulemdSimpleSet *licenses = NULL;
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  modulemd_simpleset_copy (self->module_licenses, &licenses);
+
+  return licenses;
+}
+
+
+/**
  * modulemd_module_set_name:
  * @name: (nullable): the module name.
  *
@@ -1163,6 +1418,24 @@ modulemd_module_peek_name (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->name;
+}
+
+
+/**
+ * modulemd_module_dup_name:
+ *
+ * Retrieves a copy of the "name" for modulemd.
+ *
+ * Returns: A copy of the string containing the "name" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_module_dup_name (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return g_strdup (self->name);
 }
 
 
@@ -1271,6 +1544,8 @@ modulemd_module_get_profiles (ModulemdModule *self)
  *
  * Returns: (element-type utf8 ModulemdProfile) (transfer none): A hash
  * table containing the "profiles" property.
+ *
+ * Since: 1.1
  */
 GHashTable *
 modulemd_module_peek_profiles (ModulemdModule *self)
@@ -1278,6 +1553,38 @@ modulemd_module_peek_profiles (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->profiles;
+}
+
+
+/**
+ * modulemd_module_dup_profiles:
+ *
+ * Retrieves a copy of the "profiles" for modulemd.
+ *
+ * Returns: (element-type utf8 ModulemdProfile) (transfer container): A hash
+ * table containing a copy of the "profiles" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_dup_profiles (ModulemdModule *self)
+{
+  GHashTable *profiles = NULL;
+  GHashTableIter iter;
+  gpointer key, value;
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  profiles =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  g_hash_table_iter_init (&iter, self->profiles);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      g_hash_table_replace (profiles,
+                            g_strdup ((gchar *)key),
+                            modulemd_profile_copy (MODULEMD_PROFILE (value)));
+    }
+
+  return profiles;
 }
 
 
@@ -1379,6 +1686,28 @@ modulemd_module_peek_requires (ModulemdModule *self)
 
 
 /**
+ * modulemd_module_dup_requires:
+ *
+ * Retrieves a copy of  the "requires" for modulemd.
+ *
+ * Returns: (element-type utf8 utf8) (transfer container): A hash table
+ * containing a copy of the "buildrequires" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_dup_requires (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+  g_return_val_if_fail (modulemd_module_check_mdversion_range_full (
+                          self, MD_VERSION_1, MD_VERSION_1),
+                        NULL);
+
+  return _modulemd_hash_table_deep_str_copy (self->requires);
+}
+
+
+/**
  * modulemd_module_set_rpm_api:
  * @apis: (nullable): A #ModuleSimpleSet: The set of binary RPM packages that form the
  * public API for this module.
@@ -1432,6 +1761,27 @@ modulemd_module_peek_rpm_api (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->rpm_api;
+}
+
+
+/**
+ * modulemd_module_dup_rpm_api:
+ *
+ * Retrieves a copy of the "rpm_api" for modulemd
+ *
+ * Returns: (transfer full): a #SimpleSet containing the set of binary RPM
+ * packages in the "rpm_api" property.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_module_dup_rpm_api (ModulemdModule *self)
+{
+  ModulemdSimpleSet *api = NULL;
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  modulemd_simpleset_copy (self->rpm_api, &api);
+  return api;
 }
 
 
@@ -1493,6 +1843,28 @@ modulemd_module_peek_rpm_artifacts (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->rpm_artifacts;
+}
+
+
+/**
+ * modulemd_module_dup_rpm_artifacts:
+ *
+ * Retrieves a copy of the "rpm_artifacts" for modulemd
+ *
+ * Returns: (transfer full): a #SimpleSet containing the set of binary RPMs
+ * contained in this module.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_module_dup_rpm_artifacts (ModulemdModule *self)
+{
+  ModulemdSimpleSet *artifacts = NULL;
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  modulemd_simpleset_copy (self->rpm_artifacts, &artifacts);
+
+  return artifacts;
 }
 
 
@@ -1563,6 +1935,26 @@ modulemd_module_peek_rpm_buildopts (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->rpm_buildopts;
+}
+
+
+/**
+ * modulemd_module_dup_rpm_buildopts:
+ *
+ * Retrieves a copy of the "rpm-buildopts" for modulemd.
+ *
+ * Returns: (element-type utf8 utf8) (transfer container): A hash table
+ * containing the "rpm-buildopts" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_dup_rpm_buildopts (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return _modulemd_hash_table_deep_str_copy (self->rpm_buildopts);
+  ;
 }
 
 
@@ -1693,6 +2085,39 @@ modulemd_module_peek_rpm_components (ModulemdModule *self)
 
 
 /**
+ * modulemd_module_dup_rpm_components:
+ *
+ * Retrieves the "rpm-components" for modulemd.
+ *
+ * Returns: (element-type utf8 ModulemdComponentRpm) (transfer container):
+ * A hash table containing the "rpm-components" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_dup_rpm_components (ModulemdModule *self)
+{
+  GHashTable *components = NULL;
+  GHashTableIter iter;
+  gpointer key, value;
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  components =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  g_hash_table_iter_init (&iter, self->rpm_components);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      g_hash_table_replace (
+        components,
+        g_strdup ((gchar *)key),
+        modulemd_component_copy (MODULEMD_COMPONENT (value)));
+    }
+
+  return components;
+}
+
+
+/**
  * modulemd_module_set_rpm_filter:
  * @filter: (nullable): A #ModuleSimpleSet: The set of binary RPM packages that are
  * explicitly filtered out of this module.
@@ -1748,6 +2173,28 @@ modulemd_module_peek_rpm_filter (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->rpm_filter;
+}
+
+
+/**
+ * modulemd_module_dup_rpm_filter:
+ *
+ * Retrieves a copy of the "rpm_filter" for modulemd
+ *
+ * Returns: (transfer full): a #SimpleSet containing the set of binary RPMs
+ * filtered out of this module.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_module_dup_rpm_filter (ModulemdModule *self)
+{
+  ModulemdSimpleSet *filters = NULL;
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  modulemd_simpleset_copy (self->rpm_filter, &filters);
+
+  return filters;
 }
 
 
@@ -1900,6 +2347,39 @@ modulemd_module_peek_servicelevels (ModulemdModule *self)
 
 
 /**
+ * modulemd_module_dup_servicelevels:
+ *
+ * Retrieves the service levels for the module
+ *
+ * Returns: (element-type utf8 ModulemdServiceLevel) (transfer container): A
+ * hash table containing the service levels.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_dup_servicelevels (ModulemdModule *self)
+{
+  GHashTable *servicelevels = NULL;
+  GHashTableIter iter;
+  gpointer key, value;
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  servicelevels =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  g_hash_table_iter_init (&iter, self->servicelevels);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      g_hash_table_replace (
+        servicelevels,
+        g_strdup ((gchar *)key),
+        modulemd_servicelevel_copy (MODULEMD_SERVICELEVEL (value)));
+    }
+
+  return servicelevels;
+}
+
+
+/**
  * modulemd_module_set_stream:
  * @stream: (nullable): the module stream.
  *
@@ -1953,6 +2433,24 @@ modulemd_module_peek_stream (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->stream;
+}
+
+
+/**
+ * modulemd_module_dup_stream:
+ *
+ * Retrieves a copy of the "stream" for modulemd.
+ *
+ * Returns: A copy of the string containing the "stream" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_module_dup_stream (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return g_strdup (self->stream);
 }
 
 
@@ -2014,6 +2512,24 @@ modulemd_module_peek_summary (ModulemdModule *self)
 
 
 /**
+ * modulemd_module_dup_summary:
+ *
+ * Retrieves a copy of the "summary" for modulemd.
+ *
+ * Returns: A copy of the string containing the "summary" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_module_dup_summary (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return g_strdup (self->summary);
+}
+
+
+/**
  * modulemd_module_set_tracker:
  * @tracker: (nullable): the module tracker.
  *
@@ -2071,6 +2587,24 @@ modulemd_module_peek_tracker (ModulemdModule *self)
 
 
 /**
+ * modulemd_module_dup_tracker:
+ *
+ * Retrieves a copy of the "tracker" for modulemd.
+ *
+ * Returns: A copy of the string containing the "tracker" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_module_dup_tracker (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return g_strdup (self->tracker);
+}
+
+
+/**
  * modulemd_module_set_version
  * @version: the module version
  *
@@ -2118,7 +2652,7 @@ modulemd_module_get_version (ModulemdModule *self)
  *
  * Since: 1.1
  */
-const guint64
+guint64
 modulemd_module_peek_version (ModulemdModule *self)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), 0);
@@ -2193,6 +2727,109 @@ modulemd_module_peek_xmd (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   return self->xmd;
+}
+
+
+/**
+ * modulemd_module_dup_xmd:
+ *
+ * Retrieves a copy of the "xmd" for modulemd.
+ *
+ * Returns: (element-type utf8 GVariant) (transfer container): A hash table
+ * containing the "xmd" property.
+ *
+ * Since: 1.1
+ */
+GHashTable *
+modulemd_module_dup_xmd (ModulemdModule *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+
+  return _modulemd_hash_table_deep_variant_copy (self->xmd);
+}
+
+
+/**
+ * modulemd_module_copy:
+ *
+ * Make a copy of the current module
+ *
+ * Returns: (transfer full): A deep copy of this #ModulemdModule
+ *
+ * Since: 1.1
+ */
+ModulemdModule *
+modulemd_module_copy (ModulemdModule *self)
+{
+  ModulemdModule *copy = NULL;
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+  g_return_val_if_fail (modulemd_module_peek_mdversion(self), NULL);
+
+  copy = modulemd_module_new ();
+
+  /* Set mdversion first */
+  modulemd_module_set_mdversion (copy, self->mdversion);
+
+  modulemd_module_set_arch (copy, self->arch);
+
+  modulemd_module_set_buildrequires (copy, self->buildrequires);
+
+  modulemd_module_set_community (copy, self->community);
+
+  modulemd_module_set_content_licenses (copy, self->content_licenses);
+
+  modulemd_module_set_context (copy, self->context);
+
+  modulemd_module_set_description (copy, self->description);
+
+  modulemd_module_set_documentation (copy, self->documentation);
+
+  modulemd_module_set_module_components (copy, self->module_components);
+
+  modulemd_module_set_module_licenses (copy, self->module_licenses);
+
+  modulemd_module_set_name (copy, self->name);
+
+  modulemd_module_set_profiles (copy, self->profiles);
+
+  modulemd_module_set_requires (copy, self->requires);
+
+  modulemd_module_set_rpm_api (copy, self->rpm_api);
+
+  modulemd_module_set_rpm_artifacts (copy, self->rpm_artifacts);
+
+  modulemd_module_set_rpm_components (copy, self->rpm_components);
+
+  modulemd_module_set_rpm_filter (copy, self->rpm_filter);
+
+  modulemd_module_set_servicelevels (copy, self->servicelevels);
+
+  modulemd_module_set_stream (copy, self->stream);
+
+  modulemd_module_set_summary (copy, self->summary);
+
+  modulemd_module_set_tracker (copy, self->tracker);
+
+  modulemd_module_set_version (copy, self->version);
+
+  modulemd_module_set_xmd (copy, self->xmd);
+
+
+  /* Version-specific content */
+  if (modulemd_module_peek_mdversion (copy) == 1)
+    {
+      if (modulemd_module_peek_eol (self))
+        {
+          modulemd_module_set_eol (copy, self->eol);
+        }
+    }
+  else if (modulemd_module_peek_mdversion (copy) >= 2)
+    {
+      modulemd_module_set_dependencies (copy, self->dependencies);
+    }
+
+
+  return copy;
 }
 
 

--- a/modulemd/modulemd-module.h
+++ b/modulemd/modulemd-module.h
@@ -89,6 +89,9 @@ modulemd_module_set_arch (ModulemdModule *self, const gchar *arch);
 const gchar *
 modulemd_module_get_arch (ModulemdModule *self);
 
+const gchar *
+modulemd_module_peek_arch (ModulemdModule *self);
+
 void
 modulemd_module_set_buildrequires (ModulemdModule *self,
                                    GHashTable *buildrequires);
@@ -96,11 +99,17 @@ modulemd_module_set_buildrequires (ModulemdModule *self,
 GHashTable *
 modulemd_module_get_buildrequires (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_peek_buildrequires (ModulemdModule *self);
+
 void
 modulemd_module_set_community (ModulemdModule *self, const gchar *community);
 
 const gchar *
 modulemd_module_get_community (ModulemdModule *self);
+
+const gchar *
+modulemd_module_peek_community (ModulemdModule *self);
 
 void
 modulemd_module_set_content_licenses (ModulemdModule *self,
@@ -109,24 +118,39 @@ modulemd_module_set_content_licenses (ModulemdModule *self,
 ModulemdSimpleSet *
 modulemd_module_get_content_licenses (ModulemdModule *self);
 
+ModulemdSimpleSet *
+modulemd_module_peek_content_licenses (ModulemdModule *self);
+
 void
 modulemd_module_set_context (ModulemdModule *self, const gchar *context);
 
 const gchar *
 modulemd_module_get_context (ModulemdModule *self);
 
+const gchar *
+modulemd_module_peek_context (ModulemdModule *self);
+
 void
 modulemd_module_set_description (ModulemdModule *self,
                                  const gchar *description);
+
+const gchar *
+modulemd_module_get_description (ModulemdModule *self);
+
+const gchar *
+modulemd_module_peek_description (ModulemdModule *self);
+
 void
 modulemd_module_set_dependencies (ModulemdModule *self, GPtrArray *deps);
+
 void
 modulemd_module_add_dependencies (ModulemdModule *self,
                                   ModulemdDependencies *dep);
 GPtrArray *
 modulemd_module_get_dependencies (ModulemdModule *self);
-const gchar *
-modulemd_module_get_description (ModulemdModule *self);
+
+GPtrArray *
+modulemd_module_peek_dependencies (ModulemdModule *self);
 
 void
 modulemd_module_set_documentation (ModulemdModule *self,
@@ -135,17 +159,26 @@ modulemd_module_set_documentation (ModulemdModule *self,
 const gchar *
 modulemd_module_get_documentation (ModulemdModule *self);
 
+const gchar *
+modulemd_module_peek_documentation (ModulemdModule *self);
+
 void
 modulemd_module_set_eol (ModulemdModule *self, const GDate *date);
 
 const GDate *
 modulemd_module_get_eol (ModulemdModule *self);
 
+const GDate *
+modulemd_module_peek_eol (ModulemdModule *self);
+
 void
 modulemd_module_set_mdversion (ModulemdModule *self, const guint64 mdversion);
 
 const guint64
 modulemd_module_get_mdversion (ModulemdModule *self);
+
+const guint64
+modulemd_module_peek_mdversion (ModulemdModule *self);
 
 void
 modulemd_module_add_module_component (ModulemdModule *self,
@@ -161,6 +194,9 @@ modulemd_module_set_module_components (ModulemdModule *self,
 GHashTable *
 modulemd_module_get_module_components (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_peek_module_components (ModulemdModule *self);
+
 void
 modulemd_module_set_module_licenses (ModulemdModule *self,
                                      ModulemdSimpleSet *licenses);
@@ -168,11 +204,17 @@ modulemd_module_set_module_licenses (ModulemdModule *self,
 ModulemdSimpleSet *
 modulemd_module_get_module_licenses (ModulemdModule *self);
 
+ModulemdSimpleSet *
+modulemd_module_peek_module_licenses (ModulemdModule *self);
+
 void
 modulemd_module_set_name (ModulemdModule *self, const gchar *name);
 
 const gchar *
 modulemd_module_get_name (ModulemdModule *self);
+
+const gchar *
+modulemd_module_peek_name (ModulemdModule *self);
 
 void
 modulemd_module_add_profile (ModulemdModule *self, ModulemdProfile *profile);
@@ -186,17 +228,26 @@ modulemd_module_set_profiles (ModulemdModule *self, GHashTable *profiles);
 GHashTable *
 modulemd_module_get_profiles (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_peek_profiles (ModulemdModule *self);
+
 void
 modulemd_module_set_requires (ModulemdModule *self, GHashTable *requires);
 
 GHashTable *
 modulemd_module_get_requires (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_peek_requires (ModulemdModule *self);
+
 void
 modulemd_module_set_rpm_api (ModulemdModule *self, ModulemdSimpleSet *apis);
 
 ModulemdSimpleSet *
 modulemd_module_get_rpm_api (ModulemdModule *self);
+
+ModulemdSimpleSet *
+modulemd_module_peek_rpm_api (ModulemdModule *self);
 
 void
 modulemd_module_set_rpm_artifacts (ModulemdModule *self,
@@ -205,12 +256,18 @@ modulemd_module_set_rpm_artifacts (ModulemdModule *self,
 ModulemdSimpleSet *
 modulemd_module_get_rpm_artifacts (ModulemdModule *self);
 
+ModulemdSimpleSet *
+modulemd_module_peek_rpm_artifacts (ModulemdModule *self);
+
 void
 modulemd_module_set_rpm_buildopts (ModulemdModule *self,
                                    GHashTable *buildopts);
 
 GHashTable *
 modulemd_module_get_rpm_buildopts (ModulemdModule *self);
+
+GHashTable *
+modulemd_module_peek_rpm_buildopts (ModulemdModule *self);
 
 void
 modulemd_module_add_rpm_component (ModulemdModule *self,
@@ -226,12 +283,18 @@ modulemd_module_set_rpm_components (ModulemdModule *self,
 GHashTable *
 modulemd_module_get_rpm_components (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_peek_rpm_components (ModulemdModule *self);
+
 void
 modulemd_module_set_rpm_filter (ModulemdModule *self,
                                 ModulemdSimpleSet *filter);
 
 ModulemdSimpleSet *
 modulemd_module_get_rpm_filter (ModulemdModule *self);
+
+ModulemdSimpleSet *
+modulemd_module_peek_rpm_filter (ModulemdModule *self);
 
 void
 modulemd_module_clear_servicelevels (ModulemdModule *self);
@@ -247,11 +310,17 @@ modulemd_module_add_servicelevel (ModulemdModule *self,
 GHashTable *
 modulemd_module_get_servicelevels (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_peek_servicelevels (ModulemdModule *self);
+
 void
 modulemd_module_set_stream (ModulemdModule *self, const gchar *stream);
 
 const gchar *
 modulemd_module_get_stream (ModulemdModule *self);
+
+const gchar *
+modulemd_module_peek_stream (ModulemdModule *self);
 
 void
 modulemd_module_set_summary (ModulemdModule *self, const gchar *summary);
@@ -259,11 +328,17 @@ modulemd_module_set_summary (ModulemdModule *self, const gchar *summary);
 const gchar *
 modulemd_module_get_summary (ModulemdModule *self);
 
+const gchar *
+modulemd_module_peek_summary (ModulemdModule *self);
+
 void
 modulemd_module_set_tracker (ModulemdModule *self, const gchar *tracker);
 
 const gchar *
 modulemd_module_get_tracker (ModulemdModule *self);
+
+const gchar *
+modulemd_module_peek_tracker (ModulemdModule *self);
 
 void
 modulemd_module_set_version (ModulemdModule *self, const guint64 version);
@@ -271,11 +346,17 @@ modulemd_module_set_version (ModulemdModule *self, const guint64 version);
 const guint64
 modulemd_module_get_version (ModulemdModule *self);
 
+const guint64
+modulemd_module_peek_version (ModulemdModule *self);
+
 void
 modulemd_module_set_xmd (ModulemdModule *self, GHashTable *xmd);
 
 GHashTable *
 modulemd_module_get_xmd (ModulemdModule *self);
+
+GHashTable *
+modulemd_module_peek_xmd (ModulemdModule *self);
 
 G_END_DECLS
 

--- a/modulemd/modulemd-module.h
+++ b/modulemd/modulemd-module.h
@@ -92,6 +92,9 @@ modulemd_module_get_arch (ModulemdModule *self);
 const gchar *
 modulemd_module_peek_arch (ModulemdModule *self);
 
+gchar *
+modulemd_module_dup_arch (ModulemdModule *self);
+
 void
 modulemd_module_set_buildrequires (ModulemdModule *self,
                                    GHashTable *buildrequires);
@@ -102,6 +105,9 @@ modulemd_module_get_buildrequires (ModulemdModule *self);
 GHashTable *
 modulemd_module_peek_buildrequires (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_dup_buildrequires (ModulemdModule *self);
+
 void
 modulemd_module_set_community (ModulemdModule *self, const gchar *community);
 
@@ -110,6 +116,9 @@ modulemd_module_get_community (ModulemdModule *self);
 
 const gchar *
 modulemd_module_peek_community (ModulemdModule *self);
+
+gchar *
+modulemd_module_dup_community (ModulemdModule *self);
 
 void
 modulemd_module_set_content_licenses (ModulemdModule *self,
@@ -121,6 +130,9 @@ modulemd_module_get_content_licenses (ModulemdModule *self);
 ModulemdSimpleSet *
 modulemd_module_peek_content_licenses (ModulemdModule *self);
 
+ModulemdSimpleSet *
+modulemd_module_dup_content_licenses (ModulemdModule *self);
+
 void
 modulemd_module_set_context (ModulemdModule *self, const gchar *context);
 
@@ -130,15 +142,8 @@ modulemd_module_get_context (ModulemdModule *self);
 const gchar *
 modulemd_module_peek_context (ModulemdModule *self);
 
-void
-modulemd_module_set_description (ModulemdModule *self,
-                                 const gchar *description);
-
-const gchar *
-modulemd_module_get_description (ModulemdModule *self);
-
-const gchar *
-modulemd_module_peek_description (ModulemdModule *self);
+gchar *
+modulemd_module_dup_context (ModulemdModule *self);
 
 void
 modulemd_module_set_dependencies (ModulemdModule *self, GPtrArray *deps);
@@ -152,6 +157,22 @@ modulemd_module_get_dependencies (ModulemdModule *self);
 GPtrArray *
 modulemd_module_peek_dependencies (ModulemdModule *self);
 
+GPtrArray *
+modulemd_module_dup_dependencies (ModulemdModule *self);
+
+void
+modulemd_module_set_description (ModulemdModule *self,
+                                 const gchar *description);
+
+const gchar *
+modulemd_module_get_description (ModulemdModule *self);
+
+const gchar *
+modulemd_module_peek_description (ModulemdModule *self);
+
+gchar *
+modulemd_module_dup_description (ModulemdModule *self);
+
 void
 modulemd_module_set_documentation (ModulemdModule *self,
                                    const gchar *documentation);
@@ -162,6 +183,9 @@ modulemd_module_get_documentation (ModulemdModule *self);
 const gchar *
 modulemd_module_peek_documentation (ModulemdModule *self);
 
+gchar *
+modulemd_module_dup_documentation (ModulemdModule *self);
+
 void
 modulemd_module_set_eol (ModulemdModule *self, const GDate *date);
 
@@ -171,13 +195,16 @@ modulemd_module_get_eol (ModulemdModule *self);
 const GDate *
 modulemd_module_peek_eol (ModulemdModule *self);
 
+GDate *
+modulemd_module_dup_eol (ModulemdModule *self);
+
 void
 modulemd_module_set_mdversion (ModulemdModule *self, const guint64 mdversion);
 
 const guint64
 modulemd_module_get_mdversion (ModulemdModule *self);
 
-const guint64
+guint64
 modulemd_module_peek_mdversion (ModulemdModule *self);
 
 void
@@ -197,6 +224,9 @@ modulemd_module_get_module_components (ModulemdModule *self);
 GHashTable *
 modulemd_module_peek_module_components (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_dup_module_components (ModulemdModule *self);
+
 void
 modulemd_module_set_module_licenses (ModulemdModule *self,
                                      ModulemdSimpleSet *licenses);
@@ -207,6 +237,9 @@ modulemd_module_get_module_licenses (ModulemdModule *self);
 ModulemdSimpleSet *
 modulemd_module_peek_module_licenses (ModulemdModule *self);
 
+ModulemdSimpleSet *
+modulemd_module_dup_module_licenses (ModulemdModule *self);
+
 void
 modulemd_module_set_name (ModulemdModule *self, const gchar *name);
 
@@ -215,6 +248,9 @@ modulemd_module_get_name (ModulemdModule *self);
 
 const gchar *
 modulemd_module_peek_name (ModulemdModule *self);
+
+gchar *
+modulemd_module_dup_name (ModulemdModule *self);
 
 void
 modulemd_module_add_profile (ModulemdModule *self, ModulemdProfile *profile);
@@ -231,6 +267,9 @@ modulemd_module_get_profiles (ModulemdModule *self);
 GHashTable *
 modulemd_module_peek_profiles (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_dup_profiles (ModulemdModule *self);
+
 void
 modulemd_module_set_requires (ModulemdModule *self, GHashTable *requires);
 
@@ -240,6 +279,9 @@ modulemd_module_get_requires (ModulemdModule *self);
 GHashTable *
 modulemd_module_peek_requires (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_dup_requires (ModulemdModule *self);
+
 void
 modulemd_module_set_rpm_api (ModulemdModule *self, ModulemdSimpleSet *apis);
 
@@ -248,6 +290,9 @@ modulemd_module_get_rpm_api (ModulemdModule *self);
 
 ModulemdSimpleSet *
 modulemd_module_peek_rpm_api (ModulemdModule *self);
+
+ModulemdSimpleSet *
+modulemd_module_dup_rpm_api (ModulemdModule *self);
 
 void
 modulemd_module_set_rpm_artifacts (ModulemdModule *self,
@@ -259,6 +304,9 @@ modulemd_module_get_rpm_artifacts (ModulemdModule *self);
 ModulemdSimpleSet *
 modulemd_module_peek_rpm_artifacts (ModulemdModule *self);
 
+ModulemdSimpleSet *
+modulemd_module_dup_rpm_artifacts (ModulemdModule *self);
+
 void
 modulemd_module_set_rpm_buildopts (ModulemdModule *self,
                                    GHashTable *buildopts);
@@ -268,6 +316,9 @@ modulemd_module_get_rpm_buildopts (ModulemdModule *self);
 
 GHashTable *
 modulemd_module_peek_rpm_buildopts (ModulemdModule *self);
+
+GHashTable *
+modulemd_module_dup_rpm_buildopts (ModulemdModule *self);
 
 void
 modulemd_module_add_rpm_component (ModulemdModule *self,
@@ -286,6 +337,9 @@ modulemd_module_get_rpm_components (ModulemdModule *self);
 GHashTable *
 modulemd_module_peek_rpm_components (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_dup_rpm_components (ModulemdModule *self);
+
 void
 modulemd_module_set_rpm_filter (ModulemdModule *self,
                                 ModulemdSimpleSet *filter);
@@ -295,6 +349,9 @@ modulemd_module_get_rpm_filter (ModulemdModule *self);
 
 ModulemdSimpleSet *
 modulemd_module_peek_rpm_filter (ModulemdModule *self);
+
+ModulemdSimpleSet *
+modulemd_module_dup_rpm_filter (ModulemdModule *self);
 
 void
 modulemd_module_clear_servicelevels (ModulemdModule *self);
@@ -313,6 +370,9 @@ modulemd_module_get_servicelevels (ModulemdModule *self);
 GHashTable *
 modulemd_module_peek_servicelevels (ModulemdModule *self);
 
+GHashTable *
+modulemd_module_dup_servicelevels (ModulemdModule *self);
+
 void
 modulemd_module_set_stream (ModulemdModule *self, const gchar *stream);
 
@@ -321,6 +381,9 @@ modulemd_module_get_stream (ModulemdModule *self);
 
 const gchar *
 modulemd_module_peek_stream (ModulemdModule *self);
+
+gchar *
+modulemd_module_dup_stream (ModulemdModule *self);
 
 void
 modulemd_module_set_summary (ModulemdModule *self, const gchar *summary);
@@ -331,6 +394,9 @@ modulemd_module_get_summary (ModulemdModule *self);
 const gchar *
 modulemd_module_peek_summary (ModulemdModule *self);
 
+gchar *
+modulemd_module_dup_summary (ModulemdModule *self);
+
 void
 modulemd_module_set_tracker (ModulemdModule *self, const gchar *tracker);
 
@@ -340,13 +406,16 @@ modulemd_module_get_tracker (ModulemdModule *self);
 const gchar *
 modulemd_module_peek_tracker (ModulemdModule *self);
 
+gchar *
+modulemd_module_dup_tracker (ModulemdModule *self);
+
 void
 modulemd_module_set_version (ModulemdModule *self, const guint64 version);
 
 const guint64
 modulemd_module_get_version (ModulemdModule *self);
 
-const guint64
+guint64
 modulemd_module_peek_version (ModulemdModule *self);
 
 void
@@ -357,6 +426,12 @@ modulemd_module_get_xmd (ModulemdModule *self);
 
 GHashTable *
 modulemd_module_peek_xmd (ModulemdModule *self);
+
+GHashTable *
+modulemd_module_dup_xmd (ModulemdModule *self);
+
+ModulemdModule *
+modulemd_module_copy (ModulemdModule *self);
 
 G_END_DECLS
 

--- a/modulemd/modulemd-profile.c
+++ b/modulemd/modulemd-profile.c
@@ -73,20 +73,42 @@ modulemd_profile_set_description (ModulemdProfile *self,
     }
 }
 
+
 /**
  * modulemd_profile_get_description:
  *
  * Retrieves the profile description.
  *
  * Returns: A string containing the "description" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_description() instead.
  */
+G_DEPRECATED_FOR (modulemd_profile_peek_description)
 const gchar *
 modulemd_profile_get_description (ModulemdProfile *self)
+{
+  return modulemd_profile_peek_description (self);
+}
+
+
+/**
+ * modulemd_profile_peek_description:
+ *
+ * Retrieves the profile description.
+ *
+ * Returns: A string containing the "description" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_profile_peek_description (ModulemdProfile *self)
 {
   g_return_val_if_fail (MODULEMD_IS_PROFILE (self), NULL);
 
   return self->description;
 }
+
 
 /**
  * modulemd_profile_set_name:
@@ -108,20 +130,42 @@ modulemd_profile_set_name (ModulemdProfile *self, const gchar *name)
     }
 }
 
+
 /**
  * modulemd_profile_get_name:
  *
  * Retrieves the profile name.
  *
  * Returns: A string containing the "name" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_name() instead.
  */
+G_DEPRECATED_FOR (modulemd_profile_peek_name)
 const gchar *
 modulemd_profile_get_name (ModulemdProfile *self)
+{
+  return modulemd_profile_peek_name (self);
+}
+
+
+/**
+ * modulemd_profile_peek_name:
+ *
+ * Retrieves the profile name.
+ *
+ * Returns: A string containing the "name" property.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_profile_peek_name (ModulemdProfile *self)
 {
   g_return_val_if_fail (MODULEMD_IS_PROFILE (self), NULL);
 
   return self->name;
 }
+
 
 /**
  * modulemd_profile_set_rpms:
@@ -142,6 +186,7 @@ modulemd_profile_set_rpms (ModulemdProfile *self, ModulemdSimpleSet *rpms)
                             profile_properties[PROFILE_PROP_RPMS]);
 }
 
+
 /**
  * modulemd_profile_get_rpms:
  *
@@ -149,14 +194,36 @@ modulemd_profile_set_rpms (ModulemdProfile *self, ModulemdSimpleSet *rpms)
  *
  * Returns: (transfer none): a #SimpleSet containing the set of RPMs in the
  * "rpms" property.
+ *
+ * Deprecated: 1.1
+ * Use peek_rpms() instead.
  */
+G_DEPRECATED_FOR (modulemd_profile_peek_rpms)
 ModulemdSimpleSet *
 modulemd_profile_get_rpms (ModulemdProfile *self)
+{
+  return modulemd_profile_peek_rpms (self);
+}
+
+
+/**
+ * modulemd_profile_peek_rpms:
+ *
+ * Retrieves the "rpms" for this profile
+ *
+ * Returns: (transfer none): a #SimpleSet containing the set of RPMs in the
+ * "rpms" property.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_profile_peek_rpms (ModulemdProfile *self)
 {
   g_return_val_if_fail (MODULEMD_IS_PROFILE (self), NULL);
 
   return self->rpms;
 }
+
 
 void
 modulemd_profile_add_rpm (ModulemdProfile *self, const gchar *rpm)
@@ -219,15 +286,15 @@ modulemd_profile_get_property (GObject *gobject,
   switch (property_id)
     {
     case PROFILE_PROP_DESC:
-      g_value_set_string (value, modulemd_profile_get_description (self));
+      g_value_set_string (value, modulemd_profile_peek_description (self));
       break;
 
     case PROFILE_PROP_NAME:
-      g_value_set_string (value, modulemd_profile_get_name (self));
+      g_value_set_string (value, modulemd_profile_peek_name (self));
       break;
 
     case PROFILE_PROP_RPMS:
-      g_value_set_object (value, modulemd_profile_get_rpms (self));
+      g_value_set_object (value, modulemd_profile_peek_rpms (self));
       break;
 
     default:

--- a/modulemd/modulemd-profile.c
+++ b/modulemd/modulemd-profile.c
@@ -111,6 +111,24 @@ modulemd_profile_peek_description (ModulemdProfile *self)
 
 
 /**
+ * modulemd_profile_dup_description:
+ *
+ * Retrieves a copy of the profile description.
+ *
+ * Returns: A copy of the string containing the "description" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_profile_dup_description (ModulemdProfile *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_PROFILE (self), NULL);
+
+  return g_strdup (self->description);
+}
+
+
+/**
  * modulemd_profile_set_name:
  * @name: (nullable): the profile name.
  *
@@ -164,6 +182,24 @@ modulemd_profile_peek_name (ModulemdProfile *self)
   g_return_val_if_fail (MODULEMD_IS_PROFILE (self), NULL);
 
   return self->name;
+}
+
+
+/**
+ * modulemd_profile_dup_name:
+ *
+ * Retrieves a copy of the profile name.
+ *
+ * Returns: A copy of string containing the "name" property.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_profile_dup_name (ModulemdProfile *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_PROFILE (self), NULL);
+
+  return g_strdup (self->name);
 }
 
 
@@ -225,6 +261,28 @@ modulemd_profile_peek_rpms (ModulemdProfile *self)
 }
 
 
+/**
+ * modulemd_profile_dup_rpms:
+ *
+ * Retrieves a copy of the "rpms" for this profile
+ *
+ * Returns: (transfer full): a #SimpleSet containing the set of RPMs in the
+ * "rpms" property.
+ *
+ * Since: 1.1
+ */
+ModulemdSimpleSet *
+modulemd_profile_dup_rpms (ModulemdProfile *self)
+{
+  ModulemdSimpleSet *rpms = NULL;
+  g_return_val_if_fail (MODULEMD_IS_PROFILE (self), NULL);
+
+  modulemd_simpleset_copy (self->rpms, &rpms);
+
+  return rpms;
+}
+
+
 void
 modulemd_profile_add_rpm (ModulemdProfile *self, const gchar *rpm)
 {
@@ -246,6 +304,33 @@ modulemd_profile_remove_rpm (ModulemdProfile *self, const gchar *rpm)
   g_object_notify_by_pspec (G_OBJECT (self),
                             profile_properties[PROFILE_PROP_RPMS]);
 }
+
+
+/**
+ * modulemd_profile_copy:
+ *
+ * Creates a copy of this profile
+ *
+ * Returns: (transfer full): a copy of this #ModulemdProfile
+ *
+ * Since: 1.1
+ */
+ModulemdProfile *
+modulemd_profile_copy (ModulemdProfile *self)
+{
+  ModulemdProfile *new_profile = NULL;
+  g_return_val_if_fail (MODULEMD_IS_PROFILE (self), NULL);
+
+  new_profile = modulemd_profile_new ();
+
+  modulemd_profile_set_description (new_profile,
+                                    modulemd_profile_peek_description (self));
+  modulemd_profile_set_name (new_profile, modulemd_profile_peek_name (self));
+  modulemd_profile_set_rpms (new_profile, modulemd_profile_peek_rpms (self));
+
+  return new_profile;
+}
+
 
 static void
 modulemd_profile_set_property (GObject *gobject,

--- a/modulemd/modulemd-profile.h
+++ b/modulemd/modulemd-profile.h
@@ -43,16 +43,24 @@ modulemd_profile_set_description (ModulemdProfile *self,
 const gchar *
 modulemd_profile_get_description (ModulemdProfile *self);
 
+const gchar *
+modulemd_profile_peek_description (ModulemdProfile *self);
+
 void
 modulemd_profile_set_name (ModulemdProfile *self, const gchar *name);
 const gchar *
 modulemd_profile_get_name (ModulemdProfile *self);
+const gchar *
+modulemd_profile_peek_name (ModulemdProfile *self);
 
 void
 modulemd_profile_set_rpms (ModulemdProfile *self, ModulemdSimpleSet *rpms);
 
 ModulemdSimpleSet *
 modulemd_profile_get_rpms (ModulemdProfile *self);
+
+ModulemdSimpleSet *
+modulemd_profile_peek_rpms (ModulemdProfile *self);
 
 void
 modulemd_profile_add_rpm (ModulemdProfile *self, const gchar *rpm);

--- a/modulemd/modulemd-profile.h
+++ b/modulemd/modulemd-profile.h
@@ -45,6 +45,8 @@ modulemd_profile_get_description (ModulemdProfile *self);
 
 const gchar *
 modulemd_profile_peek_description (ModulemdProfile *self);
+gchar *
+modulemd_profile_dup_description (ModulemdProfile *self);
 
 void
 modulemd_profile_set_name (ModulemdProfile *self, const gchar *name);
@@ -52,6 +54,8 @@ const gchar *
 modulemd_profile_get_name (ModulemdProfile *self);
 const gchar *
 modulemd_profile_peek_name (ModulemdProfile *self);
+gchar *
+modulemd_profile_dup_name (ModulemdProfile *self);
 
 void
 modulemd_profile_set_rpms (ModulemdProfile *self, ModulemdSimpleSet *rpms);
@@ -61,12 +65,17 @@ modulemd_profile_get_rpms (ModulemdProfile *self);
 
 ModulemdSimpleSet *
 modulemd_profile_peek_rpms (ModulemdProfile *self);
+ModulemdSimpleSet *
+modulemd_profile_dup_rpms (ModulemdProfile *self);
 
 void
 modulemd_profile_add_rpm (ModulemdProfile *self, const gchar *rpm);
 
 void
 modulemd_profile_remove_rpm (ModulemdProfile *self, const gchar *rpm);
+
+ModulemdProfile *
+modulemd_profile_copy (ModulemdProfile *self);
 
 G_END_DECLS
 

--- a/modulemd/modulemd-servicelevel.c
+++ b/modulemd/modulemd-servicelevel.c
@@ -78,15 +78,36 @@ modulemd_servicelevel_set_eol (ModulemdServiceLevel *self, const GDate *date)
     }
 }
 
+
 /**
  * modulemd_servicelevel_get_eol:
  *
  * Retrieves the end-of-life date of this service level.
  *
  * Returns: a #GDate representing the end-of-life date of the service level.
+ *
+ * Deprecated: 1.1
+ * Use peek_eol() instead.
  */
+G_DEPRECATED_FOR (modulemd_servicelevel_peek_eol)
 const GDate *
 modulemd_servicelevel_get_eol (ModulemdServiceLevel *self)
+{
+  return modulemd_servicelevel_peek_eol (self);
+}
+
+
+/**
+ * modulemd_servicelevel_peek_eol:
+ *
+ * Retrieves the end-of-life date of this service level.
+ *
+ * Returns: a #GDate representing the end-of-life date of the service level.
+ *
+ * Since: 1.1
+ */
+const GDate *
+modulemd_servicelevel_peek_eol (ModulemdServiceLevel *self)
 {
   g_return_val_if_fail (MODULEMD_IS_SERVICELEVEL (self), NULL);
 
@@ -128,9 +149,30 @@ modulemd_servicelevel_set_name (ModulemdServiceLevel *self, const gchar *name)
  *
  * Returns: a string representing the name of the service level or NULL if not
  * set.
+ *
+ * Deprecated: 1.1
+ * Use peek_name() instead.
  */
+G_DEPRECATED_FOR (modulemd_servicelevel_peek_name)
 const gchar *
 modulemd_servicelevel_get_name (ModulemdServiceLevel *self)
+{
+  return modulemd_servicelevel_peek_name (self);
+}
+
+
+/**
+ * modulemd_servicelevel_peek_name:
+ *
+ * Retrieves the name of this service level
+ *
+ * Returns: a string representing the name of the service level or NULL if not
+ * set.
+ *
+ * Since: 1.1
+ */
+const gchar *
+modulemd_servicelevel_peek_name (ModulemdServiceLevel *self)
 {
   g_return_val_if_fail (MODULEMD_IS_SERVICELEVEL (self), NULL);
 
@@ -178,11 +220,11 @@ modulemd_servicelevel_get_property (GObject *gobject,
   switch (property_id)
     {
     case SL_PROP_EOL:
-      g_value_set_boxed (value, modulemd_servicelevel_get_eol (self));
+      g_value_set_boxed (value, modulemd_servicelevel_peek_eol (self));
       break;
 
     case SL_PROP_NAME:
-      g_value_set_string (value, modulemd_servicelevel_get_name (self));
+      g_value_set_string (value, modulemd_servicelevel_peek_name (self));
       break;
 
     default:

--- a/modulemd/modulemd-servicelevel.c
+++ b/modulemd/modulemd-servicelevel.c
@@ -121,6 +121,31 @@ modulemd_servicelevel_peek_eol (ModulemdServiceLevel *self)
 
 
 /**
+ * modulemd_servicelevel_dup_eol:
+ *
+ * Retrieves a copy of the end-of-life date of this service level.
+ *
+ * Returns: a #GDate representing the end-of-life date of the service level.
+ *
+ * Since: 1.1
+ */
+GDate *
+modulemd_servicelevel_dup_eol (ModulemdServiceLevel *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_SERVICELEVEL (self), NULL);
+
+  if (!g_date_valid (self->eol))
+    {
+      return NULL;
+    }
+
+  return g_date_new_dmy (g_date_get_day (self->eol),
+                         g_date_get_month (self->eol),
+                         g_date_get_year (self->eol));
+}
+
+
+/**
  * modulemd_servicelevel_set_name:
  * @name: (nullable): The name of this servicelevel
  *
@@ -182,6 +207,57 @@ modulemd_servicelevel_peek_name (ModulemdServiceLevel *self)
     }
 
   return self->name;
+}
+
+
+/**
+ * modulemd_servicelevel_dup_name:
+ *
+ * Retrieves a copy of the name of this service level
+ *
+ * Returns: a copy of the string representing the name of the service level or
+ * NULL if not set.
+ *
+ * Since: 1.1
+ */
+gchar *
+modulemd_servicelevel_dup_name (ModulemdServiceLevel *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_SERVICELEVEL (self), NULL);
+
+  if (!self->name)
+    {
+      g_warning ("Servicelevel name requested, but has not been set");
+      return NULL;
+    }
+
+  return g_strdup (self->name);
+}
+
+
+/**
+ * modulemd_servicelevel_copy:
+ *
+ * Create a copy of this #ModulemdServiceLevel object.
+ *
+ * Returns: (transfer full): a copied #ModulemdServiceLevel object
+ *
+ * Since: 1.1
+ */
+ModulemdServiceLevel *
+modulemd_servicelevel_copy (ModulemdServiceLevel *self)
+{
+  ModulemdServiceLevel *new_sl = NULL;
+  g_return_val_if_fail (MODULEMD_IS_SERVICELEVEL (self), NULL);
+
+  new_sl = modulemd_servicelevel_new ();
+
+  modulemd_servicelevel_set_eol (new_sl,
+                                 modulemd_servicelevel_peek_eol (self));
+  modulemd_servicelevel_set_name (new_sl,
+                                  modulemd_servicelevel_peek_name (self));
+
+  return new_sl;
 }
 
 

--- a/modulemd/modulemd-servicelevel.h
+++ b/modulemd/modulemd-servicelevel.h
@@ -46,6 +46,9 @@ modulemd_servicelevel_get_eol (ModulemdServiceLevel *self);
 const GDate *
 modulemd_servicelevel_peek_eol (ModulemdServiceLevel *self);
 
+GDate *
+modulemd_servicelevel_dup_eol (ModulemdServiceLevel *self);
+
 void
 modulemd_servicelevel_set_name (ModulemdServiceLevel *self, const gchar *name);
 
@@ -54,6 +57,12 @@ modulemd_servicelevel_get_name (ModulemdServiceLevel *self);
 
 const gchar *
 modulemd_servicelevel_peek_name (ModulemdServiceLevel *self);
+
+gchar *
+modulemd_servicelevel_dup_name (ModulemdServiceLevel *self);
+
+ModulemdServiceLevel *
+modulemd_servicelevel_copy (ModulemdServiceLevel *self);
 
 G_END_DECLS
 

--- a/modulemd/modulemd-servicelevel.h
+++ b/modulemd/modulemd-servicelevel.h
@@ -43,11 +43,17 @@ modulemd_servicelevel_set_eol (ModulemdServiceLevel *self, const GDate *date);
 const GDate *
 modulemd_servicelevel_get_eol (ModulemdServiceLevel *self);
 
+const GDate *
+modulemd_servicelevel_peek_eol (ModulemdServiceLevel *self);
+
 void
 modulemd_servicelevel_set_name (ModulemdServiceLevel *self, const gchar *name);
 
 const gchar *
 modulemd_servicelevel_get_name (ModulemdServiceLevel *self);
+
+const gchar *
+modulemd_servicelevel_peek_name (ModulemdServiceLevel *self);
 
 G_END_DECLS
 

--- a/modulemd/modulemd-simpleset.c
+++ b/modulemd/modulemd-simpleset.c
@@ -139,9 +139,32 @@ modulemd_simpleset_set (ModulemdSimpleSet *self, gchar **set)
  *
  * Returns: (array zero-terminated=1) (transfer full):
  * A list representing a set of string values.
+ *
+ * Deprecated: 1.1
+ * Use dup() instead.
+ * This function was inconsistent with the other get() methods in libmodulemd
+ * and should have been called dup() all along.
  */
+G_DEPRECATED_FOR (modulemd_simpleset_dup)
 gchar **
 modulemd_simpleset_get (ModulemdSimpleSet *self)
+{
+  return modulemd_simpleset_dup (self);
+}
+
+
+/**
+ * modulemd_simpleset_dup:
+ *
+ * Retrieves the set as a #GPtrArray of strings
+ *
+ * Returns: (array zero-terminated=1) (transfer full):
+ * A list representing a set of string values.
+ *
+ * Since: 1.1
+ */
+gchar **
+modulemd_simpleset_dup (ModulemdSimpleSet *self)
 {
   GPtrArray *sorted_keys = NULL;
   gchar **keys = NULL;
@@ -159,6 +182,7 @@ modulemd_simpleset_get (ModulemdSimpleSet *self)
 
   return keys;
 }
+
 
 /**
  * modulemd_simpleset_add
@@ -272,7 +296,7 @@ modulemd_simpleset_get_property (GObject *gobject,
   switch (property_id)
     {
     case SET_PROP_SET:
-      g_value_take_boxed (value, modulemd_simpleset_get (self));
+      g_value_take_boxed (value, modulemd_simpleset_dup (self));
       break;
 
     default:

--- a/modulemd/modulemd-simpleset.h
+++ b/modulemd/modulemd-simpleset.h
@@ -45,6 +45,8 @@ void
 modulemd_simpleset_set (ModulemdSimpleSet *self, gchar **set);
 gchar **
 modulemd_simpleset_get (ModulemdSimpleSet *self);
+gchar **
+modulemd_simpleset_dup (ModulemdSimpleSet *self);
 
 void
 modulemd_simpleset_add (ModulemdSimpleSet *self, const gchar *value);

--- a/modulemd/test-modulemd-dependencies.c
+++ b/modulemd/test-modulemd-dependencies.c
@@ -148,6 +148,31 @@ modulemd_dependencies_test_get_set_requires (DependenciesFixture *fixture,
 }
 
 
+static void
+modulemd_dependencies_test_dup_set_buildrequires (DependenciesFixture *fixture,
+                                                  gconstpointer user_data)
+{
+  _modulemd_dependencies_test_get_set (
+    fixture,
+    user_data,
+    modulemd_dependencies_add_buildrequires_single,
+    modulemd_dependencies_add_buildrequires,
+    modulemd_dependencies_dup_buildrequires);
+}
+
+static void
+modulemd_dependencies_test_dup_set_requires (DependenciesFixture *fixture,
+                                             gconstpointer user_data)
+{
+  _modulemd_dependencies_test_get_set (
+    fixture,
+    user_data,
+    modulemd_dependencies_add_requires_single,
+    modulemd_dependencies_add_requires,
+    modulemd_dependencies_dup_requires);
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -168,6 +193,18 @@ main (int argc, char *argv[])
               NULL,
               modulemd_dependencies_set_up,
               modulemd_dependencies_test_get_set_requires,
+              modulemd_dependencies_tear_down);
+  g_test_add ("/modulemd/dependencies/test_dependencies_buildrequires_dup",
+              DependenciesFixture,
+              NULL,
+              modulemd_dependencies_set_up,
+              modulemd_dependencies_test_dup_set_buildrequires,
+              modulemd_dependencies_tear_down);
+  g_test_add ("/modulemd/dependencies/test_dependencies_requires_dup",
+              DependenciesFixture,
+              NULL,
+              modulemd_dependencies_set_up,
+              modulemd_dependencies_test_dup_set_requires,
               modulemd_dependencies_tear_down);
 
   return g_test_run ();

--- a/modulemd/test-modulemd-module.c
+++ b/modulemd/test-modulemd-module.c
@@ -496,6 +496,7 @@ static void
 modulemd_module_test_construct_v1 (ModuleFixture *fixture,
                                    gconstpointer user_data)
 {
+  ModulemdModule *copy = NULL;
   ModulemdModule **modules = NULL;
   ModulemdSimpleSet *licenses = NULL;
   GError *error = NULL;
@@ -525,6 +526,11 @@ modulemd_module_test_construct_v1 (ModuleFixture *fixture,
   g_assert_true (result);
   g_assert_nonnull (yaml);
 
+  /* Make sure no errors occur when copying it */
+  copy = modulemd_module_copy (fixture->md);
+  g_assert_nonnull (copy);
+  g_assert_cmpuint (modulemd_module_peek_mdversion(copy), ==, 1);
+
   g_message ("v1 YAML:\n%s", yaml);
 
   g_free (modules);
@@ -535,6 +541,7 @@ static void
 modulemd_module_test_construct_v2 (ModuleFixture *fixture,
                                    gconstpointer user_data)
 {
+  ModulemdModule *copy = NULL;
   ModulemdModule **modules = NULL;
   ModulemdSimpleSet *licenses = NULL;
   GError *error = NULL;
@@ -587,6 +594,11 @@ modulemd_module_test_construct_v2 (ModuleFixture *fixture,
   result = emit_yaml_string (modules, &yaml, &error);
   g_assert_true (result);
   g_assert_nonnull (yaml);
+
+  /* Make sure no errors occur when copying it */
+  copy = modulemd_module_copy (fixture->md);
+  g_assert_nonnull (copy);
+  g_assert_cmpuint (modulemd_module_peek_mdversion(copy), ==, 2);
 
   g_message ("v2 YAML:\n%s", yaml);
 

--- a/modulemd/test-modulemd-yaml.c
+++ b/modulemd/test-modulemd-yaml.c
@@ -96,6 +96,7 @@ static void
 modulemd_yaml_test_v1_load (YamlFixture *fixture, gconstpointer user_data)
 {
   ModulemdModule *module = NULL;
+  ModulemdModule *copy = NULL;
   ModulemdModule **modules = NULL;
   gchar *yaml_path = NULL;
   GHashTable *buildrequires = NULL;
@@ -128,6 +129,12 @@ modulemd_yaml_test_v1_load (YamlFixture *fixture, gconstpointer user_data)
   value = g_hash_table_lookup (buildrequires, "platform");
   g_assert_cmpstr (value, ==, "and-its-stream-name");
   g_hash_table_unref (buildrequires);
+
+  /* Copy this module */
+  copy = modulemd_module_copy (modules[0]);
+  g_assert_nonnull (copy);
+  g_assert_cmpuint (modulemd_module_peek_mdversion (copy), ==, 1);
+
   for (gsize i = 0; modules[i]; i++)
     {
       g_object_unref (modules[i]);
@@ -139,6 +146,7 @@ static void
 modulemd_yaml_test_v2_load (YamlFixture *fixture, gconstpointer user_data)
 {
   ModulemdModule *module = NULL;
+  ModulemdModule *copy = NULL;
   ModulemdModule **modules = NULL;
   gchar *yaml_path = NULL;
   GError *error = NULL;
@@ -156,6 +164,11 @@ modulemd_yaml_test_v2_load (YamlFixture *fixture, gconstpointer user_data)
   g_assert_nonnull (modules[0]);
   g_assert_nonnull (modules[1]);
   g_assert_null (modules[2]);
+
+  /* Copy this module */
+  copy = modulemd_module_copy (modules[0]);
+  g_assert_nonnull (copy);
+  g_assert_cmpuint (modulemd_module_peek_mdversion (copy), ==, 2);
 
   for (gsize i = 0; modules[i]; i++)
     {


### PR DESCRIPTION
Addresses:
https://github.com/fedora-modularity/libmodulemd/issues/19