### PR TITLE
Properly manage memory for Module.new_all_from_*()

### DIFF
--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -3463,7 +3463,7 @@ modulemd_module_new_from_file (const gchar *yaml_file)
 /**
  * modulemd_module_new_all_from_file:
  * @yaml_file: A YAML file containing the module metadata.
- * @_modules: (out) (array zero-terminated=1) (element-type ModulemdModule) (transfer full):
+ * @_modules: (out) (array zero-terminated=1) (element-type ModulemdModule) (transfer container):
  * A zero-terminated array of modules contained in this document.
  *
  * Allocates a list of new #ModulemdModule from a file.
@@ -3494,7 +3494,7 @@ modulemd_module_new_all_from_file (const gchar *yaml_file,
 /**
  * modulemd_module_new_all_from_file_ext:
  * @yaml_file: A YAML file containing the module metadata.
- * @data: (out) (array zero-terminated=1) (element-type GObject) (transfer full):
+ * @data: (out) (array zero-terminated=1) (element-type GObject) (transfer container):
  * A #GPtrArray of objects read from the YAML stream.
  *
  * Allocates a #GPtrArray of various supported subdocuments from a file.
@@ -3564,7 +3564,7 @@ modulemd_module_new_from_string (const gchar *yaml_string)
 /**
  * modulemd_module_new_all_from_string:
  * @yaml_string: A YAML string containing the module metadata.
- * @_modules: (out) (array zero-terminated=1) (element-type ModulemdModule) (transfer full):
+ * @_modules: (out) (array zero-terminated=1) (element-type ModulemdModule) (transfer container):
  * A zero-terminated array of modules contained in this document.
  *
  * Allocates a list of new #ModulemdModule from a string.
@@ -3595,7 +3595,7 @@ modulemd_module_new_all_from_string (const gchar *yaml_string,
 /**
  * modulemd_module_new_all_from_string_ext:
  * @yaml_string: A YAML string containing the module metadata.
- * @data: (out) (array zero-terminated=1) (element-type GObject) (transfer full):
+ * @data: (out) (array zero-terminated=1) (element-type GObject) (transfer container):
  * A #GPtrArray of objects read from the YAML stream.
  *
  * Allocates a #GPtrArray of various supported subdocuments from a file.

--- a/modulemd/test-modulemd-python.py
+++ b/modulemd/test-modulemd-python.py
@@ -54,5 +54,13 @@ class TestIssues(unittest.TestCase):
         assert mmd2.peek_rpm_buildopts() != {}
         assert mmd2.peek_rpm_buildopts()['macros'] == '%my_macro 1'
 
+    def test_issue33(self):
+        # We had a bug where this was returning an array as (transfer full)
+        # instead of (transfer container) which resulted in the GI python
+        # double-freeing memory.
+        defs = Modulemd.Module.new_all_from_file_ext(
+            "%s/mod-defaults/spec.v1.yaml" % os.getenv('MESON_SOURCE_ROOT'))
+        print (defs)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The array manages its own contents, but (transfer full) was instructing
the Python binding to free them as well, causing double-free and
use-after-free issues.

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/33

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>