### PR TITLE
Write out defaults data when dumping all

### DIFF
--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -3673,7 +3673,7 @@ modulemd_module_dumps (ModulemdModule *self)
 
 /**
  * modulemd_module_dump_all:
- * @module_array: (array zero-terminated=1) (element-type ModulemdModule) (transfer none):
+ * @module_array: (array zero-terminated=1) (element-type GObject) (transfer none):
  * A zero-terminated array of modules to be output
  *
  * This function writes out a file containing one or more YAML documents
@@ -3695,7 +3695,7 @@ modulemd_module_dump_all (GPtrArray *module_array, const gchar *yaml_file)
 
 /**
  * modulemd_module_dumps_all:
- * @module_array: (array zero-terminated=1) (element-type ModulemdModule) (transfer none):
+ * @module_array: (array zero-terminated=1) (element-type GObject) (transfer none):
  * A zero-terminated array of modules to be output
  *
  * This function returns an allocated string containing one or more YAML

--- a/modulemd/modulemd-yaml-emitter.c
+++ b/modulemd/modulemd-yaml-emitter.c
@@ -77,6 +77,13 @@ emit_yaml_file (GPtrArray *objects, const gchar *path, GError **error)
               MMD_YAML_ERROR_RETURN_RETHROW (error, "Could not emit YAML");
             }
         }
+      else if (G_OBJECT_TYPE (object) == MODULEMD_TYPE_DEFAULTS)
+        {
+          if (!_emit_defaults (&emitter, MODULEMD_DEFAULTS (object), error))
+            {
+              MMD_YAML_ERROR_RETURN_RETHROW (error, "Could not emit defaults YAML");
+            }
+        }
     }
 
   yaml_stream_end_event_initialize (&event);


### PR DESCRIPTION
There were two bugs here:
1) The annotations for the dump_all() and dumps_all() only accepted
Module objects. It now will accept any GObject
2) The emit_yaml() function didn't properly check for the presence
of the Defaults type and emit it.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>