### PR TITLE
Defaults emitter should use the correct name key

### DIFF
--- a/modulemd/modulemd-yaml-emitter-defaults.c
+++ b/modulemd/modulemd-yaml-emitter-defaults.c
@@ -192,7 +192,7 @@ _emit_defaults_data (yaml_emitter_t *emitter,
 
 
   /* Module name */
-  name = g_strdup ("name");
+  name = g_strdup ("module");
   value = modulemd_defaults_dup_module_name (defaults);
   MMD_YAML_EMIT_STR_STR_DICT (&event, name, value, YAML_PLAIN_SCALAR_STYLE);
 


### PR DESCRIPTION
The specification requires that module name is represented as
"module: <modulename>", but the emitter was writing out
"name: <modulename>" instead.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>