### PR TITLE
Prioritizer: Throw an error on resolve() of nothing

### DIFF
--- a/modulemd/modulemd-prioritizer.c
+++ b/modulemd/modulemd-prioritizer.c
@@ -25,6 +25,12 @@
 #include "modulemd.h"
 #include "modulemd-util.h"
 
+GQuark
+modulemd_prioritizer_error_quark (void)
+{
+  return g_quark_from_static_string ("modulemd-prioritizer-error-quark");
+}
+
 struct _ModulemdPrioritizer
 {
   GObject parent_instance;
@@ -183,6 +189,17 @@ modulemd_prioritizer_resolve (ModulemdPrioritizer *self, GError **error)
 
   current_level = priority_levels =
     _modulemd_ordered_int64_keys (self->priorities);
+
+  if (!current_level)
+    {
+      /* Nothing has been added to the resolver. */
+      g_set_error (error,
+                   MODULEMD_PRIORITIZER_ERROR,
+                   MODULEMD_PRIORITIZER_NOTHING_TO_PRIORITIZE,
+                   "No module objects have been added to the prioritizer. Use "
+                   "modulemd_prioritizer_add() first.");
+      return NULL;
+    }
 
   current = g_ptr_array_ref (
     g_hash_table_lookup (self->priorities, priority_levels->data));

--- a/modulemd/modulemd-prioritizer.h
+++ b/modulemd/modulemd-prioritizer.h
@@ -29,6 +29,15 @@
 
 G_BEGIN_DECLS
 
+#define MODULEMD_PRIORITIZER_ERROR modulemd_prioritizer_error_quark ()
+GQuark
+modulemd_prioritizer_error_quark (void);
+
+enum ModulemdPrioritizerError
+{
+  MODULEMD_PRIORITIZER_NOTHING_TO_PRIORITIZE
+};
+
 #define MODULEMD_TYPE_PRIORITIZER (modulemd_prioritizer_get_type ())
 
 G_DECLARE_FINAL_TYPE (

--- a/modulemd/test-modulemd-defaults.c
+++ b/modulemd/test-modulemd-defaults.c
@@ -776,6 +776,22 @@ modulemd_defaults_test_prioritizer (DefaultsFixture *fixture,
     modulemd_defaults_peek_profile_defaults (defaults), "8.1"));
 }
 
+static void
+modulemd_regressions_issue42 (DefaultsFixture *fixture,
+                              gconstpointer user_data)
+{
+  g_autoptr (ModulemdPrioritizer) prioritizer = NULL;
+  g_autoptr (GPtrArray) objects = NULL;
+  g_autoptr (GError) error = NULL;
+  prioritizer = modulemd_prioritizer_new ();
+
+  /* Test that the prioritizer doesn't crash if it resolves zero documents */
+  objects = modulemd_prioritizer_resolve (prioritizer, &error);
+  g_assert_null (objects);
+  g_assert_nonnull (error);
+  g_assert_cmpint (error->code, ==, MODULEMD_PRIORITIZER_NOTHING_TO_PRIORITIZE);
+}
+
 
 int
 main (int argc, char *argv[])
@@ -834,6 +850,13 @@ main (int argc, char *argv[])
               NULL,
               NULL,
               modulemd_defaults_test_prioritizer,
+              NULL);
+
+  g_test_add ("/modulemd/defaults/modulemd_regressions_issue42",
+              DefaultsFixture,
+              NULL,
+              NULL,
+              modulemd_regressions_issue42,
               NULL);
 
   g_test_add (


### PR DESCRIPTION
Previously, we would segfault if someone called resolve() without
first calling at least one add().

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/42

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>