### PR TITLE
Validate the data.artifacts.rpm contents

### DIFF
--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -10,6 +10,7 @@ modulemd_srcs = [
     'modulemd-profile.c',
     'modulemd-simpleset.c',
     'modulemd-servicelevel.c',
+    'modulemd-subdocument.c',
     'modulemd-util.c',
     'modulemd-yaml-emitter.c',
     'modulemd-yaml-emitter-defaults.c',
@@ -32,11 +33,13 @@ modulemd_hdrs = [
     'modulemd-profile.h',
     'modulemd-simpleset.h',
     'modulemd-servicelevel.h',
+    'modulemd-subdocument.h',
 ]
 
 modulemd_priv_hdrs = [
     'modulemd-util.h',
     'modulemd-yaml.h',
+    'modulemd-subdocument-private.h',
 ]
 
 libmodulemd_version = meson.project_version()
@@ -161,6 +164,17 @@ test_modulemd_simpleset = executable(
     install : false,
 )
 test('test_modulemd_simpleset', test_modulemd_simpleset,
+     env : test_env)
+
+test_modulemd_subdocument = executable(
+    'test_modulemd_subdocument',
+    'test-modulemd-subdocument.c',
+    dependencies : [
+        modulemd_dep,
+    ],
+    install : false,
+)
+test('test_modulemd_subdocument', test_modulemd_subdocument,
      env : test_env)
 
 test_modulemd_yaml = executable(

--- a/modulemd/modulemd-common.c
+++ b/modulemd/modulemd-common.c
@@ -47,10 +47,38 @@
 GPtrArray *
 modulemd_objects_from_file (const gchar *yaml_file, GError **error)
 {
+  return modulemd_objects_from_file_ext (yaml_file, NULL, error);
+}
+
+
+/**
+ * modulemd_objects_from_file_ext:
+ * @yaml_file: A YAML file containing the module metadata and other related
+ * information such as default streams.
+ * @failures: (element-type ModulemdSubdocument) (transfer container) (out):
+ * An array containing any subdocuments from the YAML file that failed to
+ * parse. This must be freed with g_ptr_array_unref().
+ * @error: (out): A #GError containing additional information if this function
+ * fails.
+ *
+ * Allocates a #GPtrArray of various supported subdocuments from a file.
+ *
+ * Returns: (array zero-terminated=1) (element-type GObject) (transfer container):
+ * A #GPtrArray of various supported subdocuments from a YAML file. These
+ * subdocuments will all be GObjects and their type can be identified with
+ * G_OBJECT_TYPE(object). This array must be freed with g_ptr_array_unref().
+ *
+ * Since: 1.4
+ */
+GPtrArray *
+modulemd_objects_from_file_ext (const gchar *yaml_file,
+                                GPtrArray **failures,
+                                GError **error)
+{
   GPtrArray *data = NULL;
   g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
-  if (!parse_yaml_file (yaml_file, &data, error))
+  if (!parse_yaml_file (yaml_file, &data, failures, error))
     {
       return NULL;
     }
@@ -78,10 +106,38 @@ modulemd_objects_from_file (const gchar *yaml_file, GError **error)
 GPtrArray *
 modulemd_objects_from_stream (FILE *stream, GError **error)
 {
+  return modulemd_objects_from_stream_ext (stream, NULL, error);
+}
+
+
+/**
+ * modulemd_objects_from_stream_ext:
+ * @stream: A YAML stream containing the module metadata and other related
+ * information such as default streams.
+ * @failures: (element-type ModulemdSubdocument) (transfer container) (out):
+ * An array containing any subdocuments from the YAML file that failed to
+ * parse. This must be freed with g_ptr_array_unref().
+ * @error: (out): A #GError containing additional information if this function
+ * fails.
+ *
+ * Allocates a #GPtrArray of various supported subdocuments from a file.
+ *
+ * Returns: (array zero-terminated=1) (element-type GObject) (transfer container):
+ * A #GPtrArray of various supported subdocuments from a YAML file. These
+ * subdocuments will all be GObjects and their type can be identified with
+ * G_OBJECT_TYPE(object)
+ *
+ * Since: 1.4
+ */
+GPtrArray *
+modulemd_objects_from_stream_ext (FILE *stream,
+                                  GPtrArray **failures,
+                                  GError **error)
+{
   GPtrArray *data = NULL;
   g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
-  if (!parse_yaml_stream (stream, &data, error))
+  if (!parse_yaml_stream (stream, &data, failures, error))
     {
       return NULL;
     }
@@ -109,10 +165,38 @@ modulemd_objects_from_stream (FILE *stream, GError **error)
 GPtrArray *
 modulemd_objects_from_string (const gchar *yaml_string, GError **error)
 {
+  return modulemd_objects_from_string_ext (yaml_string, NULL, error);
+}
+
+
+/**
+ * modulemd_objects_from_string_ext:
+ * @yaml_string: A YAML string containing the module metadata and other related
+ * information such as default streams.
+ * @failures: (element-type ModulemdSubdocument) (transfer container) (out):
+ * An array containing any subdocuments from the YAML file that failed to
+ * parse. This must be freed with g_ptr_array_unref().
+ * @error: (out): A #GError containing additional information if this function
+ * fails.
+ *
+ * Allocates a #GPtrArray of various supported subdocuments from a file.
+ *
+ * Returns: (array zero-terminated=1) (element-type GObject) (transfer container):
+ * A #GPtrArray of various supported subdocuments from a YAML file. These
+ * subdocuments will all be GObjects and their type can be identified with
+ * G_OBJECT_TYPE(object)
+ *
+ * Since: 1.4
+ */
+GPtrArray *
+modulemd_objects_from_string_ext (const gchar *yaml_string,
+                                  GPtrArray **failures,
+                                  GError **error)
+{
   GPtrArray *data = NULL;
   g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
-  if (!parse_yaml_string (yaml_string, &data, error))
+  if (!parse_yaml_string (yaml_string, &data, failures, error))
     {
       return NULL;
     }

--- a/modulemd/modulemd-defaults.c
+++ b/modulemd/modulemd-defaults.c
@@ -437,11 +437,41 @@ modulemd_defaults_dup_profile_defaults (ModulemdDefaults *self)
 ModulemdDefaults *
 modulemd_defaults_new_from_file (const gchar *yaml_file, GError **error)
 {
+  return modulemd_defaults_new_from_file_ext (yaml_file, NULL, error);
+}
+
+
+/**
+ * modulemd_defaults_new_from_file_ext:
+ * @yaml_file: A YAML file containing the module metadata and other related
+ * information such as default streams.
+ * @failures: (element-type ModulemdSubdocument) (transfer container) (out):
+ * An array containing any subdocuments from the YAML file that failed to
+ * parse. This must be freed with g_ptr_array_unref().
+ * @error: (out): A #GError containing additional information if this function
+ * fails.
+ *
+ * Constructs a new #ModulemdDefaults object from the first valid
+ * modulemd-defaults document in the given module stream. This will ignore any
+ * documents of other types, malformed documents and defaults that appear later
+ * in the stream.
+ *
+ * Returns: A #ModulemdDefaults object constructed the first valid
+ * modulemd-defaults document in the given module stream. This must be freed
+ * with g_object_unref() when no longer needed.
+ *
+ * Since: 1.4
+ */
+ModulemdDefaults *
+modulemd_defaults_new_from_file_ext (const gchar *yaml_file,
+                                     GPtrArray **failures,
+                                     GError **error)
+{
   GObject *object = NULL;
   GPtrArray *data = NULL;
   ModulemdDefaults *defaults = NULL;
 
-  if (!parse_yaml_file (yaml_file, &data, error))
+  if (!parse_yaml_file (yaml_file, &data, failures, error))
     {
       return NULL;
     }
@@ -491,11 +521,41 @@ modulemd_defaults_new_from_file (const gchar *yaml_file, GError **error)
 ModulemdDefaults *
 modulemd_defaults_new_from_string (const gchar *yaml_string, GError **error)
 {
+  return modulemd_defaults_new_from_string_ext (yaml_string, NULL, error);
+}
+
+
+/**
+ * modulemd_defaults_new_from_string_ext:
+ * @yaml_string: A YAML string containing the module metadata and other related
+ * information such as default streams.
+ * @failures: (element-type ModulemdSubdocument) (transfer container) (out):
+ * An array containing any subdocuments from the YAML file that failed to
+ * parse. This must be freed with g_ptr_array_unref().
+ * @error: (out): A #GError containing additional information if this function
+ * fails.
+ *
+ * Constructs a new #ModulemdDefaults object from the first valid
+ * modulemd-defaults document in the given module stream. This will ignore any
+ * documents of other types, malformed documents and defaults that appear later
+ * in the stream.
+ *
+ * Returns: A #ModulemdDefaults object constructed the first valid
+ * modulemd-defaults document in the given module stream. This must be freed
+ * with g_object_unref() when no longer needed.
+ *
+ * Since: 1.4
+ */
+ModulemdDefaults *
+modulemd_defaults_new_from_string_ext (const gchar *yaml_string,
+                                       GPtrArray **failures,
+                                       GError **error)
+{
   GObject *object = NULL;
   GPtrArray *data = NULL;
   ModulemdDefaults *defaults = NULL;
 
-  if (!parse_yaml_string (yaml_string, &data, error))
+  if (!parse_yaml_string (yaml_string, &data, failures, error))
     {
       return NULL;
     }
@@ -545,11 +605,41 @@ modulemd_defaults_new_from_string (const gchar *yaml_string, GError **error)
 ModulemdDefaults *
 modulemd_defaults_new_from_stream (FILE *stream, GError **error)
 {
+  return modulemd_defaults_new_from_stream_ext (stream, NULL, error);
+}
+
+
+/**
+ * modulemd_defaults_new_from_stream_ext:
+ * @stream: A YAML stream containing the module metadata and other related
+ * information such as default streams.
+ * @failures: (element-type ModulemdSubdocument) (transfer container) (out):
+ * An array containing any subdocuments from the YAML file that failed to
+ * parse. This must be freed with g_ptr_array_unref().
+ * @error: (out): A #GError containing additional information if this function
+ * fails.
+ *
+ * Constructs a new #ModulemdDefaults object from the first valid
+ * modulemd-defaults document in the given module stream. This will ignore any
+ * documents of other types, malformed documents and defaults that appear later
+ * in the stream.
+ *
+ * Returns: A #ModulemdDefaults object constructed the first valid
+ * modulemd-defaults document in the given module stream. This must be freed
+ * with g_object_unref() when no longer needed.
+ *
+ * Since: 1.4
+ */
+ModulemdDefaults *
+modulemd_defaults_new_from_stream_ext (FILE *stream,
+                                       GPtrArray **failures,
+                                       GError **error)
+{
   GObject *object = NULL;
   g_autoptr (GPtrArray) data = NULL;
   ModulemdDefaults *defaults = NULL;
 
-  if (!parse_yaml_stream (stream, &data, error))
+  if (!parse_yaml_stream (stream, &data, failures, error))
     {
       return NULL;
     }

--- a/modulemd/modulemd-defaults.h
+++ b/modulemd/modulemd-defaults.h
@@ -109,10 +109,25 @@ ModulemdDefaults *
 modulemd_defaults_new_from_file (const gchar *yaml_file, GError **error);
 
 ModulemdDefaults *
+modulemd_defaults_new_from_file_ext (const gchar *yaml_file,
+                                     GPtrArray **failures,
+                                     GError **error);
+
+ModulemdDefaults *
 modulemd_defaults_new_from_string (const gchar *yaml_string, GError **error);
 
 ModulemdDefaults *
+modulemd_defaults_new_from_string_ext (const gchar *yaml_string,
+                                       GPtrArray **failures,
+                                       GError **error);
+
+ModulemdDefaults *
 modulemd_defaults_new_from_stream (FILE *stream, GError **error);
+
+ModulemdDefaults *
+modulemd_defaults_new_from_stream_ext (FILE *stream,
+                                       GPtrArray **failures,
+                                       GError **error);
 
 
 void

--- a/modulemd/modulemd-docs.xml
+++ b/modulemd/modulemd-docs.xml
@@ -44,6 +44,7 @@
     <xi:include href="xml/modulemd-profile.xml"/>
     <xi:include href="xml/modulemd-servicelevel.xml"/>
     <xi:include href="xml/modulemd-simpleset.xml"/>
+    <xi:include href="xml/modulemd-subdocument.xml"/>
   </reference>
 
 </book>

--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -3435,15 +3435,36 @@ modulemd_module_new (void)
 ModulemdModule *
 modulemd_module_new_from_file (const gchar *yaml_file)
 {
-  GError *error = NULL;
+  return modulemd_module_new_from_file_ext (yaml_file, NULL, NULL);
+}
+
+
+/**
+ * modulemd_module_new_from_file_ext:
+ * @yaml_file: A YAML file containing the module metadata. If this file
+ * contains more than one module, only the first will be loaded.
+ * @failures: (element-type ModulemdSubdocument) (transfer container) (out):
+ * An array containing any subdocuments from the YAML file that failed to
+ * parse. This must be freed with g_ptr_array_unref().
+ *
+ * Allocates a new #ModulemdModule from a file.
+ *
+ * Return value: a new #ModulemdModule. When no longer needed, free it with
+ * g_object_unref().
+ *
+ * Since: 1.4
+ */
+ModulemdModule *
+modulemd_module_new_from_file_ext (const gchar *yaml_file,
+                                   GPtrArray **failures,
+                                   GError **error)
+{
   ModulemdModule *module = NULL;
   ModulemdModule **modules = NULL;
   GPtrArray *data = NULL;
 
-  if (!parse_yaml_file (yaml_file, &data, &error))
+  if (!parse_yaml_file (yaml_file, &data, failures, error))
     {
-      g_debug ("Error parsing YAML: %s", error->message);
-      g_error_free (error);
       return NULL;
     }
 
@@ -3485,7 +3506,7 @@ modulemd_module_new_all_from_file (const gchar *yaml_file,
   GError *error = NULL;
   GPtrArray *data = NULL;
 
-  if (!parse_yaml_file (yaml_file, &data, &error))
+  if (!parse_yaml_file (yaml_file, &data, NULL, &error))
     {
       g_debug ("Error parsing YAML: %s", error->message);
       g_error_free (error);
@@ -3517,7 +3538,7 @@ modulemd_module_new_all_from_file_ext (const gchar *yaml_file,
 {
   GError *error = NULL;
 
-  if (!parse_yaml_file (yaml_file, data, &error))
+  if (!parse_yaml_file (yaml_file, data, NULL, &error))
     {
       g_debug ("Error parsing YAML: %s", error->message);
       g_error_free (error);
@@ -3540,15 +3561,35 @@ modulemd_module_new_all_from_file_ext (const gchar *yaml_file,
 ModulemdModule *
 modulemd_module_new_from_string (const gchar *yaml_string)
 {
-  GError *error = NULL;
+  return modulemd_module_new_from_string_ext (yaml_string, NULL, NULL);
+}
+
+
+/**
+ * modulemd_module_new_from_string_ext:
+ * @yaml_string: A YAML string containing the module metadata. If this string
+ * contains more than one module, only the first will be loaded.
+ * @failures: (element-type ModulemdSubdocument) (transfer container) (out):
+ * An array containing any subdocuments from the YAML file that failed to
+ * parse. This must be freed with g_ptr_array_unref().
+ *
+ * Allocates a new #ModulemdModule from a string.
+ *
+ * Return value: a new #ModulemdModule.
+ *
+ * Since: 1.4
+ */
+ModulemdModule *
+modulemd_module_new_from_string_ext (const gchar *yaml_string,
+                                     GPtrArray **failures,
+                                     GError **error)
+{
   ModulemdModule *module = NULL;
   ModulemdModule **modules = NULL;
   GPtrArray *data = NULL;
 
-  if (!parse_yaml_string (yaml_string, &data, &error))
+  if (!parse_yaml_string (yaml_string, &data, failures, error))
     {
-      g_debug ("Error parsing YAML: %s", error->message);
-      g_error_free (error);
       return NULL;
     }
 
@@ -3571,6 +3612,7 @@ modulemd_module_new_from_string (const gchar *yaml_string)
   return module;
 }
 
+
 /**
  * modulemd_module_new_all_from_string:
  * @yaml_string: A YAML string containing the module metadata.
@@ -3590,7 +3632,7 @@ modulemd_module_new_all_from_string (const gchar *yaml_string,
   GError *error = NULL;
   GPtrArray *data = NULL;
 
-  if (!parse_yaml_string (yaml_string, &data, &error))
+  if (!parse_yaml_string (yaml_string, &data, NULL, &error))
     {
       g_debug ("Error parsing YAML: %s", error->message);
       g_error_free (error);
@@ -3622,7 +3664,7 @@ modulemd_module_new_all_from_string_ext (const gchar *yaml_string,
 {
   GError *error = NULL;
 
-  if (!parse_yaml_string (yaml_string, data, &error))
+  if (!parse_yaml_string (yaml_string, data, NULL, &error))
     {
       g_debug ("Error parsing YAML: %s", error->message);
       g_error_free (error);
@@ -3646,11 +3688,35 @@ modulemd_module_new_all_from_string_ext (const gchar *yaml_string,
 ModulemdModule *
 modulemd_module_new_from_stream (FILE *stream, GError **error)
 {
+  return modulemd_module_new_from_stream_ext (stream, NULL, error);
+}
+
+
+/**
+ * modulemd_module_new_from_stream_ext:
+ * @stream: A YAML stream containing the module metadata. If this file
+ * contains more than one module, only the first will be loaded.
+ * @failures: (element-type ModulemdSubdocument) (transfer container) (out):
+ * An array containing any subdocuments from the YAML file that failed to
+ * parse. This must be freed with g_ptr_array_unref().
+ *
+ * Allocates a new #ModulemdModule from a file.
+ *
+ * Return value: a new #ModulemdModule. When no longer needed, free it with
+ * g_object_unref().
+ *
+ * Since: 1.4
+ */
+ModulemdModule *
+modulemd_module_new_from_stream_ext (FILE *stream,
+                                     GPtrArray **failures,
+                                     GError **error)
+{
   GObject *object = NULL;
   ModulemdModule *module = NULL;
   g_autoptr (GPtrArray) data = NULL;
 
-  if (!parse_yaml_stream (stream, &data, error))
+  if (!parse_yaml_stream (stream, &data, failures, error))
     {
       return NULL;
     }

--- a/modulemd/modulemd-module.h
+++ b/modulemd/modulemd-module.h
@@ -67,6 +67,11 @@ modulemd_module_new (void);
 ModulemdModule *
 modulemd_module_new_from_file (const gchar *yaml_file);
 
+ModulemdModule *
+modulemd_module_new_from_file_ext (const gchar *yaml_file,
+                                   GPtrArray **failures,
+                                   GError **error);
+
 void
 modulemd_module_new_all_from_file (const gchar *yaml_file,
                                    ModulemdModule ***_modules);
@@ -77,6 +82,11 @@ modulemd_module_new_all_from_file_ext (const gchar *yaml_file,
 
 ModulemdModule *
 modulemd_module_new_from_string (const gchar *yaml_string);
+
+ModulemdModule *
+modulemd_module_new_from_string_ext (const gchar *yaml_string,
+                                     GPtrArray **failures,
+                                     GError **error);
 
 void
 modulemd_module_new_all_from_string (const gchar *yaml_string,
@@ -89,6 +99,11 @@ modulemd_module_new_all_from_string_ext (const gchar *yaml_string,
 
 ModulemdModule *
 modulemd_module_new_from_stream (FILE *stream, GError **error);
+
+ModulemdModule *
+modulemd_module_new_from_stream_ext (FILE *stream,
+                                     GPtrArray **failures,
+                                     GError **error);
 
 void
 modulemd_module_dump (ModulemdModule *self, const gchar *yaml_file);

--- a/modulemd/modulemd-simpleset.h
+++ b/modulemd/modulemd-simpleset.h
@@ -61,6 +61,23 @@ gboolean
 modulemd_simpleset_is_equal (ModulemdSimpleSet *self,
                              ModulemdSimpleSet *other);
 
+/**
+ * SimpleSetValidationFn:
+ * @str: The current string being validated from the set
+ *
+ * This function is called once for each string in a #ModulemdSimpleSet
+ * when the validate_contents() routine is invoked. It must return TRUE
+ * if the string passes validation or FALSE if it does not.
+ *
+ * Since: 1.4
+ */
+typedef gboolean (*ModulemdSimpleSetValidationFn) (const gchar *str);
+
+gboolean
+modulemd_simpleset_validate_contents (ModulemdSimpleSet *self,
+                                      ModulemdSimpleSetValidationFn func,
+                                      GPtrArray **failures);
+
 G_END_DECLS
 
 #endif /* MODULEMD_SIMPLESET_H */

--- a/modulemd/modulemd-subdocument-private.h
+++ b/modulemd/modulemd-subdocument-private.h
@@ -1,6 +1,6 @@
-/* modulemd.h
+/* modulemd-subdocument-private.h
  *
- * Copyright (C) 2017 Stephen Gallagher
+ * Copyright (C) 2018 Stephen Gallagher
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -22,47 +22,36 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef MODULEMD_H
-#define MODULEMD_H
+/*
+ * This header includes functions for this object that should be considered
+ * internal to libmodulemd
+ */
+
+#pragma once
 
 #include <glib.h>
-#include <stdio.h>
-
-#include "modulemd-component.h"
-#include "modulemd-component-module.h"
-#include "modulemd-component-rpm.h"
-#include "modulemd-defaults.h"
-#include "modulemd-dependencies.h"
-#include "modulemd-module.h"
-#include "modulemd-prioritizer.h"
-#include "modulemd-profile.h"
-#include "modulemd-simpleset.h"
-#include "modulemd-servicelevel.h"
-#include "modulemd-subdocument.h"
+#include <modulemd-subdocument.h>
 
 G_BEGIN_DECLS
 
-GPtrArray *
-modulemd_objects_from_file (const gchar *yaml_file, GError **error);
+void
+modulemd_subdocument_set_doctype (ModulemdSubdocument *self, const GType type);
 
-GPtrArray *
-modulemd_objects_from_string (const gchar *yaml_string, GError **error);
-
-GPtrArray *
-modulemd_objects_from_stream (FILE *stream, GError **error);
+const GType
+modulemd_subdocument_get_doctype (ModulemdSubdocument *self);
 
 void
-modulemd_dump (GPtrArray *objects, const gchar *yaml_file, GError **error);
+modulemd_subdocument_set_version (ModulemdSubdocument *self,
+                                  const guint64 version);
 
-gchar *
-modulemd_dumps (GPtrArray *objects, GError **error);
+const GType
+modulemd_subdocument_get_version (ModulemdSubdocument *self);
 
-GPtrArray *
-modulemd_merge_defaults (const GPtrArray *first,
-                         const GPtrArray *second,
-                         gboolean override,
-                         GError **error);
+void
+modulemd_subdocument_set_yaml (ModulemdSubdocument *self, const gchar *yaml);
+
+void
+modulemd_subdocument_set_gerror (ModulemdSubdocument *self,
+                                 const GError *gerror);
 
 G_END_DECLS
-
-#endif /* MODULEMD_H */

--- a/modulemd/modulemd-subdocument.c
+++ b/modulemd/modulemd-subdocument.c
@@ -1,0 +1,247 @@
+/* modulemd-subdocument.c
+ *
+ * Copyright (C) 2018 Stephen Gallagher
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE X CONSORTIUM BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "modulemd-subdocument.h"
+#include "modulemd-subdocument-private.h"
+
+struct _ModulemdSubdocument
+{
+  GObject parent_instance;
+
+  GType doctype;
+  guint64 version;
+  gchar *yaml;
+  GError *gerror;
+};
+
+G_DEFINE_TYPE (ModulemdSubdocument, modulemd_subdocument, G_TYPE_OBJECT)
+
+enum
+{
+  PROP_0,
+  PROP_YAML,
+  PROP_GERROR,
+  N_PROPS
+};
+
+static GParamSpec *properties[N_PROPS];
+
+ModulemdSubdocument *
+modulemd_subdocument_new (void)
+{
+  return g_object_new (MODULEMD_TYPE_SUBDOCUMENT, NULL);
+}
+
+static void
+modulemd_subdocument_finalize (GObject *object)
+{
+  ModulemdSubdocument *self = (ModulemdSubdocument *)object;
+
+  g_clear_pointer (&self->yaml, g_free);
+  g_clear_error (&self->gerror);
+
+  G_OBJECT_CLASS (modulemd_subdocument_parent_class)->finalize (object);
+}
+
+void
+modulemd_subdocument_set_doctype (ModulemdSubdocument *self, const GType type)
+{
+  g_return_if_fail (MODULEMD_IS_SUBDOCUMENT (self));
+
+  self->doctype = type;
+}
+
+
+/**
+ * modulemd_subdocument_get_doctype:
+ *
+ * Returns: A #GType of the GObject that represents this subdocument
+ *
+ * Since: 1.4
+ */
+const GType
+modulemd_subdocument_get_doctype (ModulemdSubdocument *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_SUBDOCUMENT (self), G_TYPE_INVALID);
+
+  return self->doctype;
+}
+
+void
+modulemd_subdocument_set_version (ModulemdSubdocument *self,
+                                  const guint64 version)
+{
+  g_return_if_fail (MODULEMD_IS_SUBDOCUMENT (self));
+
+  self->version = version;
+}
+
+
+/**
+ * modulemd_subdocument_get_version:
+ *
+ * Returns: A 64-bit integer describing the document version
+ *
+ * Since: 1.4
+ */
+const GType
+modulemd_subdocument_get_version (ModulemdSubdocument *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_SUBDOCUMENT (self), 0);
+
+  return self->version;
+}
+
+
+void
+modulemd_subdocument_set_yaml (ModulemdSubdocument *self, const gchar *yaml)
+{
+  g_return_if_fail (MODULEMD_IS_SUBDOCUMENT (self));
+
+  g_clear_pointer (&self->yaml, g_free);
+
+  if (yaml)
+    {
+      self->yaml = g_strdup (yaml);
+    }
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_YAML]);
+}
+
+
+/**
+ * modulemd_subdocument_get_yaml:
+ *
+ * Returns: A string containing the YAML document
+ *
+ * Since: 1.4
+ */
+const gchar *
+modulemd_subdocument_get_yaml (ModulemdSubdocument *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_SUBDOCUMENT (self), NULL);
+
+  return self->yaml;
+}
+
+
+void
+modulemd_subdocument_set_gerror (ModulemdSubdocument *self,
+                                 const GError *gerror)
+{
+  g_return_if_fail (MODULEMD_IS_SUBDOCUMENT (self));
+
+  g_clear_error (&self->gerror);
+  if (gerror)
+    self->gerror = g_error_copy (gerror);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_GERROR]);
+}
+
+
+/**
+ * modulemd_subdocument_get_gerror:
+ *
+ * Returns: The #GError associated with this subdocument
+ *
+ * Since: 1.4
+ */
+const GError *
+modulemd_subdocument_get_gerror (ModulemdSubdocument *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_SUBDOCUMENT (self), NULL);
+
+  return self->gerror;
+}
+
+
+static void
+modulemd_subdocument_get_property (GObject *object,
+                                   guint prop_id,
+                                   GValue *value,
+                                   GParamSpec *pspec)
+{
+  ModulemdSubdocument *self = MODULEMD_SUBDOCUMENT (object);
+
+  switch (prop_id)
+    {
+    case PROP_YAML:
+      g_value_set_string (value, modulemd_subdocument_get_yaml (self));
+      break;
+
+    case PROP_GERROR:
+      g_value_set_boxed (value, modulemd_subdocument_get_gerror (self));
+      break;
+
+    default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec); break;
+    }
+}
+
+
+static void
+modulemd_subdocument_set_property (GObject *object,
+                                   guint prop_id,
+                                   const GValue *value,
+                                   GParamSpec *pspec)
+{
+  switch (prop_id)
+    {
+    default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec); break;
+    }
+}
+
+
+static void
+modulemd_subdocument_class_init (ModulemdSubdocumentClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = modulemd_subdocument_finalize;
+  object_class->get_property = modulemd_subdocument_get_property;
+  object_class->set_property = modulemd_subdocument_set_property;
+
+  properties[PROP_YAML] =
+    g_param_spec_string ("yaml",
+                         "YAML document string",
+                         "A string containing the YAML subdocument",
+                         NULL,
+                         G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
+  properties[PROP_GERROR] =
+    g_param_spec_boxed ("gerror",
+                        "Error information",
+                        "A GError containing an error code and message about "
+                        "why this subdocument failed parsing",
+                        G_TYPE_ERROR,
+                        G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, N_PROPS, properties);
+}
+
+static void
+modulemd_subdocument_init (ModulemdSubdocument *self)
+{
+  self->doctype = G_TYPE_INVALID;
+  self->version = 0;
+}

--- a/modulemd/modulemd-subdocument.h
+++ b/modulemd/modulemd-subdocument.h
@@ -1,0 +1,45 @@
+/* modulemd-subdocument.h
+ *
+ * Copyright (C) 2018 Stephen Gallagher
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE X CONSORTIUM BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define MODULEMD_TYPE_SUBDOCUMENT (modulemd_subdocument_get_type ())
+
+G_DECLARE_FINAL_TYPE (
+  ModulemdSubdocument, modulemd_subdocument, MODULEMD, SUBDOCUMENT, GObject)
+
+ModulemdSubdocument *
+modulemd_subdocument_new (void);
+
+const gchar *
+modulemd_subdocument_get_yaml (ModulemdSubdocument *self);
+
+const GError *
+modulemd_subdocument_get_gerror (ModulemdSubdocument *self);
+
+G_END_DECLS

--- a/modulemd/modulemd-util.c
+++ b/modulemd/modulemd-util.c
@@ -145,3 +145,100 @@ modulemd_variant_unref (void *ptr)
 {
   g_variant_unref ((GVariant *)ptr);
 }
+
+gboolean
+modulemd_validate_nevra (const gchar *nevra)
+{
+  g_autofree gchar *tmp = g_strdup (nevra);
+  gsize len = strlen (nevra);
+  gchar *i;
+  gchar *endptr;
+
+  /* Since the "name" portion of a NEVRA can have an infinite number of
+   * hyphens, we need to parse from the end backwards.
+   */
+  i = &tmp[len - 1];
+
+  /* Everything after the last '.' must be the architecture */
+  while (i >= tmp)
+    {
+      if (*i == '.')
+        {
+          break;
+        }
+      i--;
+    }
+
+  if (i < tmp)
+    {
+      /* We hit the start of the string without hitting '.' */
+      return FALSE;
+    }
+
+  /*
+   * TODO: Compare the architecture suffix with a list of known-valid ones
+   * This needs to come from an external source that's kept up to date or
+   * this will regularly break.
+   */
+
+  /* Process the "release" tag */
+  while (i > 0)
+    {
+      if (*i == '-')
+        {
+          break;
+        }
+      i--;
+    }
+
+  if (i <= 0)
+    {
+      /* We hit the start of the string without hitting '-' */
+      return FALSE;
+    }
+
+  /* No need to validate Release; it's fairly arbitrary */
+
+  /* Process the version */
+  while (i >= tmp)
+    {
+      if (*i == ':')
+        {
+          break;
+        }
+      i--;
+    }
+  if (i <= 0)
+    {
+      /* We hit the start of the string without hitting ':' */
+      return FALSE;
+    }
+
+  /* Process the epoch */
+  *i = '\0';
+  while (i >= tmp)
+    {
+      if (*i == '-')
+        {
+          break;
+        }
+      i--;
+    }
+  if (i < tmp)
+    {
+      /* We hit the start of the string without hitting '-' */
+      return FALSE;
+    }
+
+  /* Validate that this section is a number */
+  g_ascii_strtoll (i, &endptr, 10);
+  if (endptr == i)
+    {
+      /* String conversion failed */
+      return FALSE;
+    }
+
+  /* No need to specifically parse the name section here */
+
+  return TRUE;
+}

--- a/modulemd/modulemd-util.h
+++ b/modulemd/modulemd-util.h
@@ -50,6 +50,9 @@ _modulemd_ordered_int64_keys (GHashTable *htable);
 void
 modulemd_variant_unref (void *ptr);
 
+gboolean
+modulemd_validate_nevra (const gchar *nevra);
+
 G_END_DECLS
 
 #endif /* MODULEMD_UTIL_H */

--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -143,7 +143,7 @@ main (int argc, char *argv[])
           fprintf (stdout, "Validating %s\n", filename);
         }
 
-      if (!parse_yaml_file (filename, NULL, &error))
+      if (!parse_yaml_file (filename, NULL, NULL, &error))
         {
           fprintf (stderr, "%s failed to validate\n", filename);
           if (options.verbosity >= MMD_VERBOSE)

--- a/modulemd/modulemd-yaml-emitter.c
+++ b/modulemd/modulemd-yaml-emitter.c
@@ -110,7 +110,7 @@ emit_yaml_string (GPtrArray *objects, gchar **_yaml, GError **error)
   gboolean result = FALSE;
   yaml_emitter_t emitter;
   yaml_event_t event;
-  struct modulemd_yaml_string *yaml_string = NULL;
+  g_autoptr (modulemd_yaml_string) yaml_string = NULL;
   GObject *object;
 
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
@@ -118,7 +118,7 @@ emit_yaml_string (GPtrArray *objects, gchar **_yaml, GError **error)
 
   g_debug ("TRACE: entering emit_yaml_string");
 
-  yaml_string = g_malloc0_n (1, sizeof (struct modulemd_yaml_string));
+  yaml_string = g_malloc0_n (1, sizeof (modulemd_yaml_string));
 
   yaml_emitter_initialize (&emitter);
 
@@ -166,16 +166,12 @@ emit_yaml_string (GPtrArray *objects, gchar **_yaml, GError **error)
     &emitter, &event, error, "Error ending stream");
 
   *_yaml = yaml_string->str;
+  yaml_string->str = NULL;
 
   result = TRUE;
 
 error:
   yaml_emitter_delete (&emitter);
-  if (!result)
-    {
-      g_clear_pointer (&yaml_string->str, g_free);
-    }
-  g_free (yaml_string);
 
   g_debug ("TRACE: exiting emit_yaml_string");
   return result;

--- a/modulemd/modulemd-yaml-parser-modulemd.c
+++ b/modulemd/modulemd-yaml-parser-modulemd.c
@@ -1999,6 +1999,14 @@ _parse_modulemd_artifacts (ModulemdModule *module,
                   MMD_YAML_ERROR_RETURN_RETHROW (error,
                                                  "Parse error in artifacts");
                 }
+
+              if (!modulemd_simpleset_validate_contents (
+                    set, modulemd_validate_nevra, NULL))
+                {
+                  MMD_YAML_ERROR_RETURN (error,
+                                         "RPM artifacts not in NEVRA format");
+                }
+
               modulemd_module_set_rpm_artifacts (module, set);
             }
           else

--- a/modulemd/modulemd-yaml-parser.c
+++ b/modulemd/modulemd-yaml-parser.c
@@ -42,7 +42,6 @@ struct yaml_subdocument
 {
   GType type;
   guint64 version;
-  GObject *subdocument;
   char *yaml;
 };
 
@@ -201,7 +200,6 @@ static void
 modulemd_subdocument_free (gpointer mem)
 {
   struct yaml_subdocument *document = (struct yaml_subdocument *)mem;
-  g_clear_pointer (&document->subdocument, g_object_unref);
   g_clear_pointer (&document->yaml, g_free);
   g_free (document);
 }

--- a/modulemd/modulemd-yaml-parser.c
+++ b/modulemd/modulemd-yaml-parser.c
@@ -356,7 +356,7 @@ _read_yaml_and_type (yaml_parser_t *parser, ModulemdSubdocument **subdocument)
   gboolean done = FALSE;
   gboolean finish_invalid_document = FALSE;
   gsize depth = 0;
-  g_autofree struct modulemd_yaml_string *yaml_string = NULL;
+  g_autoptr (modulemd_yaml_string) yaml_string = NULL;
   yaml_event_t event;
   yaml_event_t value_event;
   yaml_emitter_t emitter;
@@ -365,7 +365,7 @@ _read_yaml_and_type (yaml_parser_t *parser, ModulemdSubdocument **subdocument)
 
   document = modulemd_subdocument_new ();
 
-  yaml_string = g_malloc0_n (1, sizeof (struct modulemd_yaml_string));
+  yaml_string = g_malloc0_n (1, sizeof (modulemd_yaml_string));
   yaml_emitter_initialize (&emitter);
 
   yaml_emitter_set_output (&emitter, _write_yaml_string, (void *)yaml_string);

--- a/modulemd/modulemd-yaml-utils.c
+++ b/modulemd/modulemd-yaml-utils.c
@@ -25,6 +25,16 @@
 #include "modulemd.h"
 #include "modulemd-yaml.h"
 
+void
+modulemd_yaml_string_free (gpointer mem)
+{
+  struct modulemd_yaml_string *yaml_string =
+    (struct modulemd_yaml_string *)mem;
+
+  g_clear_pointer (&yaml_string->str, g_free);
+  g_clear_pointer (&yaml_string, g_free);
+}
+
 int
 _write_yaml_string (void *data, unsigned char *buffer, size_t size)
 {

--- a/modulemd/modulemd-yaml-utils.c
+++ b/modulemd/modulemd-yaml-utils.c
@@ -26,11 +26,8 @@
 #include "modulemd-yaml.h"
 
 void
-modulemd_yaml_string_free (gpointer mem)
+modulemd_yaml_string_free (modulemd_yaml_string *yaml_string)
 {
-  struct modulemd_yaml_string *yaml_string =
-    (struct modulemd_yaml_string *)mem;
-
   g_clear_pointer (&yaml_string->str, g_free);
   g_clear_pointer (&yaml_string, g_free);
 }
@@ -38,8 +35,7 @@ modulemd_yaml_string_free (gpointer mem)
 int
 _write_yaml_string (void *data, unsigned char *buffer, size_t size)
 {
-  struct modulemd_yaml_string *yaml_string =
-    (struct modulemd_yaml_string *)data;
+  modulemd_yaml_string *yaml_string = (modulemd_yaml_string *)data;
 
   yaml_string->str =
     g_realloc_n (yaml_string->str, yaml_string->len + size + 1, sizeof (char));

--- a/modulemd/modulemd-yaml.h
+++ b/modulemd/modulemd-yaml.h
@@ -212,17 +212,19 @@ emit_yaml_file (GPtrArray *objects, const gchar *path, GError **error);
 gboolean
 emit_yaml_string (GPtrArray *objects, gchar **_yaml, GError **error);
 
-struct modulemd_yaml_string
+typedef struct _modulemd_yaml_string
 {
   char *str;
   size_t len;
-};
+} modulemd_yaml_string;
 
 int
 _write_yaml_string (void *data, unsigned char *buffer, size_t size);
 
 void
-modulemd_yaml_string_free (gpointer mem);
+modulemd_yaml_string_free (modulemd_yaml_string *yaml_string);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (modulemd_yaml_string,
+                               modulemd_yaml_string_free);
 
 gboolean
 parse_raw_yaml_mapping (yaml_parser_t *parser,

--- a/modulemd/modulemd-yaml.h
+++ b/modulemd/modulemd-yaml.h
@@ -188,13 +188,22 @@ ModulemdModule **
 mmd_yaml_dup_modules (GPtrArray *objects);
 
 gboolean
-parse_yaml_file (const gchar *path, GPtrArray **data, GError **error);
+parse_yaml_file (const gchar *path,
+                 GPtrArray **data,
+                 GPtrArray **failures,
+                 GError **error);
 
 gboolean
-parse_yaml_string (const gchar *yaml, GPtrArray **data, GError **error);
+parse_yaml_string (const gchar *yaml,
+                   GPtrArray **data,
+                   GPtrArray **failures,
+                   GError **error);
 
 gboolean
-parse_yaml_stream (FILE *stream, GPtrArray **data, GError **error);
+parse_yaml_stream (FILE *stream,
+                   GPtrArray **data,
+                   GPtrArray **failures,
+                   GError **error);
 
 
 gboolean

--- a/modulemd/modulemd-yaml.h
+++ b/modulemd/modulemd-yaml.h
@@ -52,13 +52,13 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
                                          guint64 version,
                                          GError **error);
 
-#define YAML_PARSER_PARSE_WITH_ERROR_RETURN(parser, event, error, msg)        \
+#define YAML_PARSER_PARSE_WITH_ERROR_RETURN(parser, event, _error, msg)       \
   do                                                                          \
     {                                                                         \
       if (!yaml_parser_parse (parser, event))                                 \
         {                                                                     \
           g_debug (msg);                                                      \
-          g_set_error_literal (error,                                         \
+          g_set_error_literal (_error,                                        \
                                MODULEMD_YAML_ERROR,                           \
                                MODULEMD_YAML_ERROR_UNPARSEABLE,               \
                                msg);                                          \
@@ -69,7 +69,7 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     }                                                                         \
   while (0)
 
-#define MMD_YAML_ERROR_RETURN_RETHROW(error, msg)                             \
+#define MMD_YAML_ERROR_RETURN_RETHROW(_error, msg)                            \
   do                                                                          \
     {                                                                         \
       g_debug (msg);                                                          \
@@ -78,28 +78,28 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     }                                                                         \
   while (0)
 
-#define MMD_ERROR_RETURN_FULL(error, type, msg)                               \
+#define MMD_ERROR_RETURN_FULL(_error, type, msg)                              \
   do                                                                          \
     {                                                                         \
       g_debug (msg);                                                          \
-      g_set_error_literal (error, MODULEMD_YAML_ERROR, type, msg);            \
+      g_set_error_literal (_error, MODULEMD_YAML_ERROR, type, msg);           \
       goto error;                                                             \
       result = FALSE;                                                         \
     }                                                                         \
   while (0)
 
-#define MMD_YAML_ERROR_RETURN(error, msg)                                     \
+#define MMD_YAML_ERROR_RETURN(_error, msg)                                    \
   do                                                                          \
     {                                                                         \
       g_debug (msg);                                                          \
       g_set_error_literal (                                                   \
-        error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_PARSE, msg);          \
+        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_PARSE, msg);         \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \
   while (0)
 
-#define YAML_EMITTER_EMIT_WITH_ERROR_RETURN(emitter, event, error, msg)       \
+#define YAML_EMITTER_EMIT_WITH_ERROR_RETURN(emitter, event, _error, msg)      \
   do                                                                          \
     {                                                                         \
       if (!yaml_emitter_emit (emitter, event))                                \
@@ -108,7 +108,7 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
                    msg,                                                       \
                    mmd_yaml_get_event_name ((event)->type));                  \
           g_set_error_literal (                                               \
-            error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, msg);       \
+            _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, msg);      \
           result = FALSE;                                                     \
           goto error;                                                         \
         }                                                                     \
@@ -116,12 +116,12 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     }                                                                         \
   while (0)
 
-#define MMD_YAML_EMITTER_ERROR_RETURN(error, msg)                             \
+#define MMD_YAML_EMITTER_ERROR_RETURN(_error, msg)                            \
   do                                                                          \
     {                                                                         \
       g_debug (msg);                                                          \
       g_set_error_literal (                                                   \
-        error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, msg);           \
+        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, msg);          \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \
@@ -173,12 +173,12 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     }                                                                         \
   while (0)
 
-#define MMD_YAML_NOEVENT_ERROR_RETURN(error, msg)                             \
+#define MMD_YAML_NOEVENT_ERROR_RETURN(_error, msg)                            \
   do                                                                          \
     {                                                                         \
       g_debug (msg);                                                          \
       g_set_error_literal (                                                   \
-        error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_PARSE, msg);          \
+        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_PARSE, msg);         \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \

--- a/modulemd/modulemd-yaml.h
+++ b/modulemd/modulemd-yaml.h
@@ -212,6 +212,9 @@ struct modulemd_yaml_string
 int
 _write_yaml_string (void *data, unsigned char *buffer, size_t size);
 
+void
+modulemd_yaml_string_free (gpointer mem);
+
 gboolean
 parse_raw_yaml_mapping (yaml_parser_t *parser,
                         GVariant **variant,

--- a/modulemd/modulemd.h
+++ b/modulemd/modulemd.h
@@ -46,10 +46,25 @@ GPtrArray *
 modulemd_objects_from_file (const gchar *yaml_file, GError **error);
 
 GPtrArray *
+modulemd_objects_from_file_ext (const gchar *yaml_file,
+                                GPtrArray **failures,
+                                GError **error);
+
+GPtrArray *
 modulemd_objects_from_string (const gchar *yaml_string, GError **error);
 
 GPtrArray *
+modulemd_objects_from_string_ext (const gchar *yaml_string,
+                                  GPtrArray **failures,
+                                  GError **error);
+
+GPtrArray *
 modulemd_objects_from_stream (FILE *stream, GError **error);
+
+GPtrArray *
+modulemd_objects_from_stream_ext (FILE *stream,
+                                  GPtrArray **failures,
+                                  GError **error);
 
 void
 modulemd_dump (GPtrArray *objects, const gchar *yaml_file, GError **error);

--- a/modulemd/test-modulemd-defaults.c
+++ b/modulemd/test-modulemd-defaults.c
@@ -112,7 +112,7 @@ modulemd_defaults_test_good_ex2 (DefaultsFixture *fixture,
                                g_getenv ("MESON_SOURCE_ROOT"));
   g_assert_nonnull (yaml_path);
 
-  result = parse_yaml_file (yaml_path, &objects, &error);
+  result = parse_yaml_file (yaml_path, &objects, NULL, &error);
   g_free (yaml_path);
   g_assert_true (result);
 
@@ -217,7 +217,7 @@ modulemd_defaults_test_good_ex3 (DefaultsFixture *fixture,
                                g_getenv ("MESON_SOURCE_ROOT"));
   g_assert_nonnull (yaml_path);
 
-  result = parse_yaml_file (yaml_path, &objects, &error);
+  result = parse_yaml_file (yaml_path, &objects, NULL, &error);
   g_free (yaml_path);
   g_assert_true (result);
 
@@ -366,7 +366,7 @@ modulemd_defaults_test_good_ex4 (DefaultsFixture *fixture,
                                g_getenv ("MESON_SOURCE_ROOT"));
   g_assert_nonnull (yaml_path);
 
-  result = parse_yaml_file (yaml_path, &objects, &error);
+  result = parse_yaml_file (yaml_path, &objects, NULL, &error);
   g_free (yaml_path);
   g_assert_true (result);
 

--- a/modulemd/test-modulemd-subdocument.c
+++ b/modulemd/test-modulemd-subdocument.c
@@ -1,0 +1,73 @@
+/* test-modulemd-subdocument.c
+ *
+ * Copyright (C) 2018 Stephen Gallagher
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE X CONSORTIUM BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <glib.h>
+#include <locale.h>
+
+#include "modulemd.h"
+#include "modulemd-subdocument-private.h"
+
+typedef struct _SubdocumentFixture
+{
+} SubdocumentFixture;
+
+
+static void
+modulemd_subdocument_basic (SubdocumentFixture *fixture,
+                            gconstpointer user_data)
+{
+  const gchar *yaml = "document: modulemd\nversion: 1";
+  g_autoptr (ModulemdSubdocument) document = NULL;
+
+  document = modulemd_subdocument_new ();
+
+  modulemd_subdocument_set_doctype (document, MODULEMD_TYPE_MODULE);
+  g_assert_cmpuint (
+    modulemd_subdocument_get_doctype (document), ==, MODULEMD_TYPE_MODULE);
+
+  modulemd_subdocument_set_version (document, 1);
+  g_assert_cmpuint (modulemd_subdocument_get_version (document), ==, 1);
+
+  modulemd_subdocument_set_yaml (document, yaml);
+  g_assert_cmpstr (modulemd_subdocument_get_yaml (document), ==, yaml);
+}
+
+
+int
+main (int argc, char *argv[])
+{
+  setlocale (LC_ALL, "");
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
+
+  g_test_add ("/modulemd/regressions/issue14_v1",
+              SubdocumentFixture,
+              NULL,
+              NULL,
+              modulemd_subdocument_basic,
+              NULL);
+
+  return g_test_run ();
+}

--- a/modulemd/test-modulemd-yaml.c
+++ b/modulemd/test-modulemd-yaml.c
@@ -55,7 +55,7 @@ modulemd_yaml_test_parse_v1_file (YamlFixture *fixture,
 
   yaml_path = g_strdup_printf ("%s/test_data/good-v1.yaml",
                                g_getenv ("MESON_SOURCE_ROOT"));
-  result = parse_yaml_file (yaml_path, &data, &error);
+  result = parse_yaml_file (yaml_path, &data, NULL, &error);
   g_clear_pointer (&yaml_path, g_free);
   g_assert_true (result);
 
@@ -89,7 +89,7 @@ modulemd_yaml_test_parse_v1_file (YamlFixture *fixture,
 
   yaml_path = g_strdup_printf ("%s/test_data/bad-document.yaml",
                                g_getenv ("MESON_SOURCE_ROOT"));
-  result = parse_yaml_file (yaml_path, &data, &error);
+  result = parse_yaml_file (yaml_path, &data, NULL, &error);
   g_clear_pointer (&yaml_path, g_free);
   g_assert_true (result);
   g_assert_null (error);
@@ -102,7 +102,7 @@ modulemd_yaml_test_parse_v1_file (YamlFixture *fixture,
   g_info ("Reference YAML v1");
   yaml_path =
     g_strdup_printf ("%s/spec.v1.yaml", g_getenv ("MESON_SOURCE_ROOT"));
-  result = parse_yaml_file (yaml_path, &data, &error);
+  result = parse_yaml_file (yaml_path, &data, NULL, &error);
   g_free (yaml_path);
   g_assert_true (result);
 
@@ -232,7 +232,7 @@ modulemd_yaml_test_v2_load (YamlFixture *fixture, gconstpointer user_data)
   g_info ("Reference YAML v2");
   yaml_path =
     g_strdup_printf ("%s/spec.v2.yaml", g_getenv ("MESON_SOURCE_ROOT"));
-  result = parse_yaml_file (yaml_path, &data, &error);
+  result = parse_yaml_file (yaml_path, &data, NULL, &error);
   g_free (yaml_path);
   g_assert_true (result);
 
@@ -397,7 +397,7 @@ modulemd_yaml_test_v2_stream (YamlFixture *fixture, gconstpointer user_data)
   g_info ("Reference YAML v2");
   yaml_path =
     g_strdup_printf ("%s/spec.v2.yaml", g_getenv ("MESON_SOURCE_ROOT"));
-  result = parse_yaml_file (yaml_path, &data, &error);
+  result = parse_yaml_file (yaml_path, &data, NULL, &error);
   g_free (yaml_path);
   g_assert_true (result);
 

--- a/modulemd/test-modulemd-yaml.c
+++ b/modulemd/test-modulemd-yaml.c
@@ -23,6 +23,7 @@
  */
 
 #include "modulemd-yaml.h"
+#include "modulemd-util.h"
 
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -414,6 +415,28 @@ modulemd_yaml_test_v2_stream (YamlFixture *fixture, gconstpointer user_data)
 }
 
 
+static void
+modulemd_yaml_test_validate_nevra (YamlFixture *fixture,
+                                   gconstpointer user_data)
+{
+  const gchar *good = "nodejs-devel-1:8.10.0-3.module_1572+d7ec111e.x86_64";
+  const gchar *garbage = "DEADBEEF";
+  const gchar *garbage2 = "DEAD.BEEF";
+  const gchar *garbage3 = "MORE-DEAD.BEEF";
+  const gchar *missing_epoch =
+    "nodejs-devel-8.10.0-3.module_1572+d7ec111e.x86_64";
+  const gchar *nonint_epoch =
+    "nodejs-devel-FOO:8.10.0-3.module_1572+d7ec111e.x86_64";
+
+  g_assert_true (modulemd_validate_nevra (good));
+  g_assert_false (modulemd_validate_nevra (garbage));
+  g_assert_false (modulemd_validate_nevra (garbage2));
+  g_assert_false (modulemd_validate_nevra (garbage3));
+  g_assert_false (modulemd_validate_nevra (missing_epoch));
+  g_assert_false (modulemd_validate_nevra (nonint_epoch));
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -465,6 +488,13 @@ main (int argc, char *argv[])
               modulemd_yaml_set_up,
               modulemd_yaml_test_v2_stream,
               modulemd_yaml_tear_down);
+
+  g_test_add ("/modulemd/yaml/test_validate_nevra",
+              YamlFixture,
+              NULL,
+              NULL,
+              modulemd_yaml_test_validate_nevra,
+              NULL);
 
   return g_test_run ();
 }

--- a/test_data/issue46.yaml
+++ b/test_data/issue46.yaml
@@ -1,0 +1,66 @@
+---
+document: modulemd
+version: 2
+data:
+  name: django
+  stream: 1.6
+  version: 20180307130104
+  context: c2c572ec
+  summary: A high-level Python Web framework
+  description: >-
+    Django is a high-level Python Web framework that encourages rapid development
+    and a clean, pragmatic design. It focuses on automating as much as possible and
+    adhering to the DRY (Don't Repeat Yourself) principle.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/django.git?#90c50f8ad1cb5ca41d62632699c375dce6353adf
+      commit: 90c50f8ad1cb5ca41d62632699c375dce6353adf
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+      rpms:
+        python-django:
+          ref: 1c3a01558a435b56f8ef4f8fc0e5c1cd35f006a5
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+  dependencies:
+  - buildrequires:
+      platform: [f28]
+    requires:
+      platform: [f28]
+  references:
+    community: https://www.djangoproject.com
+    documentation: https://docs.djangoproject.com
+    tracker: https://code.djangoproject.com/query
+  profiles:
+    default:
+      rpms:
+      - python2-django
+    python2_development:
+      rpms:
+      - python2-django
+  api:
+    rpms:
+    - python2-django
+  components:
+    rpms:
+      python-django:
+        rationale: The Django python web framework
+        repository: git://pkgs.fedoraproject.org/rpms/python-django
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django
+        ref: 1.6
+  artifacts:
+    rpms:
+    - python-django-bash-completion-1.6.11.7-1.module_1560+089ce146.noarch
+    - python2-django-1.6.11.7-1.module_1560+089ce146.noarch
+...


### PR DESCRIPTION
These patches add validation that the contents of data.artifacts.rpm read from a modulemd YAML stream are in the prescribed NEVRA format.

In the future it might also validate that the "A" part of the NEVRA is a recognized architecture, but at the moment there is no reliable place to get the list of valid architectures against which to compare.

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/46