### PR TITLE
Specification: Allow overriding the default component whitelist

### DIFF
--- a/spec.v2.yaml
+++ b/spec.v2.yaml
@@ -229,6 +229,18 @@ data:
             macros: |
                 %demomacro 1
                 %demomacro2 %{demomacro}23
+            # Explicit list of package build names this module will produce.
+            # By default the build system only allows components listed under
+            # data.components.rpms to be built as part of this module.
+            # In case the expected RPM build names do not match the component
+            # names, the list can be defined here.
+            # This list overrides rather then just extends the default.
+            # Optional, list of package build names without versions.
+            whitelist:
+                - fooscl-1-bar
+                - fooscl-1-baz
+                - xxx
+                - xyz
     # Functional components of the module, optional
     components:
         # RPM content of the module, optional


### PR DESCRIPTION
Some packages rename the SRPM and therefore the package build name
during the SRPM build phase.  Module Build Service takes care of package
whitelisting in the tags in manages and therefore it needs to know the
names of the builds when it's setting up the build environment.

This list provides the necessary information to the build system if the
build names do not match the component names.

Signed-off-by: Petr Šabata <contyk@redhat.com>