### PR TITLE
Allocate Modulemd.props.buildopts at object creation

### DIFF
--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -3462,6 +3462,8 @@ static void
 modulemd_module_init (ModulemdModule *self)
 {
   /* Allocate the members */
+  self->buildopts = modulemd_buildopts_new ();
+
   self->buildrequires =
     g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 


### PR DESCRIPTION
Resolves: https://github.com/fedora-modularity/libmodulemd/issues/72

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>