### PR TITLE
Fix API-breakage for Modulemd.Module.new_all_from_*_ext()

### DIFF
--- a/modulemd/include/modulemd-1.0/private/modulemd-util.h
+++ b/modulemd/include/modulemd-1.0/private/modulemd-util.h
@@ -87,6 +87,10 @@ GHashTable *
 module_index_from_data (GPtrArray *data, GError **error);
 
 
+GPtrArray *
+convert_modulestream_to_module (GPtrArray *objects);
+
+
 G_END_DECLS
 
 #endif /* MODULEMD_UTIL_H */

--- a/modulemd/v1/modulemd-common.c
+++ b/modulemd/v1/modulemd-common.c
@@ -27,35 +27,6 @@ modulemd_objects_from_file (const gchar *yaml_file, GError **error)
 }
 
 
-static GPtrArray *
-convert_modulestream_to_module (GPtrArray *objects)
-{
-  GPtrArray *compat_data = NULL;
-  GObject *object = NULL;
-  gsize i;
-
-
-  compat_data = g_ptr_array_new_full (objects->len, g_object_unref);
-
-  for (i = 0; i < objects->len; i++)
-    {
-      object = g_ptr_array_index (objects, i);
-      if (MODULEMD_IS_MODULESTREAM (object))
-        {
-          g_ptr_array_add (objects,
-                           modulemd_module_new_from_modulestream (
-                             MODULEMD_MODULESTREAM (object)));
-        }
-      else
-        {
-          g_ptr_array_add (compat_data, g_object_ref (object));
-        }
-    }
-
-  return compat_data;
-}
-
-
 GPtrArray *
 modulemd_objects_from_file_ext (const gchar *yaml_file,
                                 GPtrArray **failures,

--- a/modulemd/v1/modulemd-module.c
+++ b/modulemd/v1/modulemd-module.c
@@ -3009,14 +3009,16 @@ void
 modulemd_module_new_all_from_file_ext (const gchar *yaml_file,
                                        GPtrArray **data)
 {
-  GError *error = NULL;
+  g_autoptr (GPtrArray) tmp_data = NULL;
+  g_autoptr (GError) error = NULL;
 
-  if (!parse_yaml_file (yaml_file, data, NULL, &error))
+  if (!parse_yaml_file (yaml_file, &tmp_data, NULL, &error))
     {
       g_debug ("Error parsing YAML: %s", error->message);
-      g_error_free (error);
       return;
     }
+
+  *data = convert_modulestream_to_module (tmp_data);
 }
 
 
@@ -3128,14 +3130,16 @@ void
 modulemd_module_new_all_from_string_ext (const gchar *yaml_string,
                                          GPtrArray **data)
 {
-  GError *error = NULL;
+  g_autoptr (GPtrArray) tmp_data = NULL;
+  g_autoptr (GError) error = NULL;
 
-  if (!parse_yaml_string (yaml_string, data, NULL, &error))
+  if (!parse_yaml_string (yaml_string, &tmp_data, NULL, &error))
     {
       g_debug ("Error parsing YAML: %s", error->message);
-      g_error_free (error);
       return;
     }
+
+  *data = convert_modulestream_to_module (tmp_data);
 }
 
 

--- a/modulemd/v1/modulemd-util.c
+++ b/modulemd/v1/modulemd-util.c
@@ -480,3 +480,32 @@ module_index_from_data (GPtrArray *data, GError **error)
 
   return g_hash_table_ref (module_index);
 }
+
+
+GPtrArray *
+convert_modulestream_to_module (GPtrArray *objects)
+{
+  GPtrArray *compat_data = NULL;
+  GObject *object = NULL;
+  gsize i;
+
+
+  compat_data = g_ptr_array_new_full (objects->len, g_object_unref);
+
+  for (i = 0; i < objects->len; i++)
+    {
+      object = g_ptr_array_index (objects, i);
+      if (MODULEMD_IS_MODULESTREAM (object))
+        {
+          g_ptr_array_add (objects,
+                           modulemd_module_new_from_modulestream (
+                             MODULEMD_MODULESTREAM (object)));
+        }
+      else
+        {
+          g_ptr_array_add (compat_data, g_object_ref (object));
+        }
+    }
+
+  return compat_data;
+}


### PR DESCRIPTION
These functions were not properly converting ModuleStream to Module for backwards-compatibility.
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1607083
