### PR TITLE
Don't return ModuleStream objects from modulemd_module_new_all_*_ext

### DIFF
--- a/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
+++ b/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
@@ -270,6 +270,9 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
 ModulemdModule **
 mmd_yaml_dup_modules (GPtrArray *objects);
 
+GPtrArray *
+mmd_yaml_convert_modulestreams (GPtrArray *objects);
+
 gboolean
 parse_yaml_file (const gchar *path,
                  GPtrArray **data,

--- a/modulemd/v1/modulemd-common.c
+++ b/modulemd/v1/modulemd-common.c
@@ -27,35 +27,6 @@ modulemd_objects_from_file (const gchar *yaml_file, GError **error)
 }
 
 
-static GPtrArray *
-convert_modulestream_to_module (GPtrArray *objects)
-{
-  GPtrArray *compat_data = NULL;
-  GObject *object = NULL;
-  gsize i;
-
-
-  compat_data = g_ptr_array_new_full (objects->len, g_object_unref);
-
-  for (i = 0; i < objects->len; i++)
-    {
-      object = g_ptr_array_index (objects, i);
-      if (MODULEMD_IS_MODULESTREAM (object))
-        {
-          g_ptr_array_add (objects,
-                           modulemd_module_new_from_modulestream (
-                             MODULEMD_MODULESTREAM (object)));
-        }
-      else
-        {
-          g_ptr_array_add (compat_data, g_object_ref (object));
-        }
-    }
-
-  return compat_data;
-}
-
-
 GPtrArray *
 modulemd_objects_from_file_ext (const gchar *yaml_file,
                                 GPtrArray **failures,
@@ -73,7 +44,7 @@ modulemd_objects_from_file_ext (const gchar *yaml_file,
   /* For backwards-compatibility, we need to return Modulemd.Module objects,
    * not Modulemd.ModuleStream objects
    */
-  compat_data = convert_modulestream_to_module (data);
+  compat_data = mmd_yaml_convert_modulestreams (data);
 
   return compat_data;
 }
@@ -114,7 +85,7 @@ modulemd_objects_from_stream_ext (FILE *stream,
   /* For backwards-compatibility, we need to return Modulemd.Module objects,
    * not Modulemd.ModuleStream objects
    */
-  compat_data = convert_modulestream_to_module (data);
+  compat_data = mmd_yaml_convert_modulestreams (data);
 
   return compat_data;
 }
@@ -155,7 +126,7 @@ modulemd_objects_from_string_ext (const gchar *yaml_string,
   /* For backwards-compatibility, we need to return Modulemd.Module objects,
    * not Modulemd.ModuleStream objects
    */
-  compat_data = convert_modulestream_to_module (data);
+  compat_data = mmd_yaml_convert_modulestreams (data);
 
   return compat_data;
 }

--- a/modulemd/v1/modulemd-module.c
+++ b/modulemd/v1/modulemd-module.c
@@ -3010,13 +3010,20 @@ modulemd_module_new_all_from_file_ext (const gchar *yaml_file,
                                        GPtrArray **data)
 {
   GError *error = NULL;
+  g_autoptr (GPtrArray) to_convert = NULL;
 
-  if (!parse_yaml_file (yaml_file, data, NULL, &error))
+  if (!parse_yaml_file (yaml_file, &to_convert, NULL, &error))
     {
       g_debug ("Error parsing YAML: %s", error->message);
       g_error_free (error);
       return;
     }
+
+  /* For backwards-compatibility, we need to return Modulemd.Module objects,
+   * not Modulemd.ModuleStream objects
+   */
+  if (data)
+    *data = mmd_yaml_convert_modulestreams (to_convert);
 }
 
 
@@ -3129,13 +3136,20 @@ modulemd_module_new_all_from_string_ext (const gchar *yaml_string,
                                          GPtrArray **data)
 {
   GError *error = NULL;
+  g_autoptr (GPtrArray) to_convert = NULL;
 
-  if (!parse_yaml_string (yaml_string, data, NULL, &error))
+  if (!parse_yaml_string (yaml_string, &to_convert, NULL, &error))
     {
       g_debug ("Error parsing YAML: %s", error->message);
       g_error_free (error);
       return;
     }
+
+  /* For backwards-compatibility, we need to return Modulemd.Module objects,
+   * not Modulemd.ModuleStream objects
+   */
+  if (data)
+    *data = mmd_yaml_convert_modulestreams (to_convert);
 }
 
 

--- a/modulemd/v1/modulemd-yaml-utils.c
+++ b/modulemd/v1/modulemd-yaml-utils.c
@@ -375,6 +375,33 @@ mmd_yaml_dup_modules (GPtrArray *objects)
   return modules;
 }
 
+GPtrArray *
+mmd_yaml_convert_modulestreams (GPtrArray *objects)
+{
+  GPtrArray *compat_data = NULL;
+  GObject *object = NULL;
+  gsize i;
+
+  compat_data = g_ptr_array_new_full (objects->len, g_object_unref);
+
+  for (i = 0; i < objects->len; i++)
+    {
+      object = g_ptr_array_index (objects, i);
+      if (MODULEMD_IS_MODULESTREAM (object))
+        {
+          g_ptr_array_add (objects,
+                           modulemd_module_new_from_modulestream (
+                             MODULEMD_MODULESTREAM (object)));
+        }
+      else
+        {
+          g_ptr_array_add (compat_data, g_object_ref (object));
+        }
+    }
+
+  return compat_data;
+}
+
 const gchar *
 mmd_yaml_get_event_name (yaml_event_type_t type)
 {


### PR DESCRIPTION
These older, deprecated functions should not have been changed to
return ModuleStream objects rather than Module objects.