### PR TITLE
Properly write out the ref for module components

### DIFF
--- a/modulemd/v1/modulemd-yaml-emitter-modulemd.c
+++ b/modulemd/v1/modulemd-yaml-emitter-modulemd.c
@@ -1355,7 +1355,7 @@ _emit_modulemd_module_components (yaml_emitter_t *emitter,
     }
 
   /* Ref */
-  value = modulemd_component_module_dup_repository (module_component);
+  value = modulemd_component_module_dup_ref (module_component);
   if (value)
     {
       name = g_strdup ("ref");

--- a/modulemd/v1/tests/test-modulemd-python.py
+++ b/modulemd/v1/tests/test-modulemd-python.py
@@ -216,6 +216,56 @@ class TestIssues(unittest.TestCase):
             # A proper exception is expected here
             pass
 
+    def test_issue85(self):
+        """
+        Component module refs are lost when dumping to YAML
+        """
+        mmd = Modulemd.Module().new_from_string("""
+document: modulemd
+version: 1
+data:
+    summary: A test module in all its beautiful beauty.
+    description: This module demonstrates how to write simple modulemd files And can be used for testing the build and release pipeline.
+    license:
+        module: [ MIT ]
+    dependencies:
+        buildrequires:
+            platform: el8
+        requires:
+            platform: el8
+    references:
+        community: https://fedoraproject.org/wiki/Modularity
+        documentation: https://fedoraproject.org/wiki/Fedora_Packaging_Guidelines_for_Modules
+        tracker: https://taiga.fedorainfracloud.org/project/modularity
+    profiles:
+        default:
+            rpms:
+                - acl
+    api:
+        rpms:
+            - acl
+    components:
+        rpms:
+            acl:
+                rationale: needed
+                ref: rhel-8.0
+        modules:
+            testmodule:
+                ref: private-x
+                rationale: Testing module inclusion.
+                buildorder: 10
+""")
+        assert mmd.get_module_components(
+        )['testmodule'].peek_ref() == 'private-x'
+
+        mmd2 = Modulemd.Module.copy(mmd)
+        assert mmd2.get_module_components(
+        )['testmodule'].peek_ref() == 'private-x'
+
+        mmd3 = Modulemd.Module.new_from_string(mmd.dumps())
+        assert mmd3.get_module_components(
+        )['testmodule'].peek_ref() == 'private-x'
+
 
 class TestIntent(unittest.TestCase):
 

--- a/modulemd/v1/tests/test-modulemd-translation.c
+++ b/modulemd/v1/tests/test-modulemd-translation.c
@@ -352,7 +352,7 @@ modulemd_translation_test_index (TranslationFixture *fixture,
     "dependency of xxx.\n        buildorder: 10\n    modules:\n      "
     "includedmodule:\n        rationale: Included in the stack, just "
     "because.\n        repository: https://pagure.io/includedmodule.git\n     "
-    "   ref: https://pagure.io/includedmodule.git\n        buildorder: 100\n  "
+    "   ref: somecoolbranchname\n        buildorder: 100\n  "
     "artifacts:\n    rpms:\n    - bar-0:1.23-1.module_deadbeef.x86_64\n    - "
     "bar-devel-0:1.23-1.module_deadbeef.x86_64\n    - "
     "bar-extras-0:1.23-1.module_deadbeef.x86_64\n    - "


### PR DESCRIPTION
Fixes: https://github.com/fedora-modularity/libmodulemd/issues/85

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>