### PR TITLE
Proposal for modulemd-defaults v2

### DIFF
--- a/mod-defaults/spec.v2.yaml
+++ b/mod-defaults/spec.v2.yaml
@@ -1,0 +1,24 @@
+# Document type identifier
+document: modulemd-defaults
+
+# Module metadata format version
+version: 2
+
+data:
+    # Module name that the defaults are for, required.
+    module: foo
+
+    # Module stream that is the default for the module, optional.
+    stream: x.y
+
+    # The system intent that this default applies to, optional.
+    # If this is omitted, these are the general defaults. If it is provided,
+    # these are the defaults that apply to a system assigned this intent.
+    intent: server
+
+    # Module profiles indexed by the stream name, optional
+    # This is a dictionary of stream names to a list of default profiles to be
+    # installed.
+    profiles:
+        'x.y': []
+        bar: [baz, snafu]


### PR DESCRIPTION
While working on libmodulemd 2.0, it occurred to me that the implementation of intents in the modulemd-defaults document is extremely redundant (its subheading contains all the same information as the main document except for the module name). I think it would be more reasonable to simply make the intent name a field in the main portion and then just have separate modulemd-defaults documents for each of them.

What do you think, @contyk ?

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>