### PR TITLE
improvements for error messages

### DIFF
--- a/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
+++ b/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
@@ -84,6 +84,19 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     }                                                                         \
   while (0)
 
+#define MMD_YAML_ERROR_EVENT_RETURN_RETHROW(_error, event, ...)               \
+  do                                                                          \
+    {                                                                         \
+      gchar *formatted = g_strdup_printf (__VA_ARGS__);                       \
+      g_debug ("%s [line %zu col %zu]",                                       \
+               formatted,                                                     \
+               event.start_mark.line,                                         \
+               event.start_mark.column);                                      \
+      g_free (formatted);                                                     \
+      goto error;                                                             \
+    }                                                                         \
+  while (0)
+
 #define MMD_ERROR_RETURN_FULL(_error, type, ...)                              \
   do                                                                          \
     {                                                                         \
@@ -105,15 +118,35 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     }                                                                         \
   while (0)
 
+#define MMD_YAML_ERROR_EVENT_RETURN(_error, event, ...)                       \
+  do                                                                          \
+    {                                                                         \
+      gchar *formatted = g_strdup_printf (__VA_ARGS__);                       \
+      gchar *formatted2 = g_strdup_printf ("%s [line %zu col %zu]",           \
+                                           formatted,                         \
+                                           event.start_mark.line,             \
+                                           event.start_mark.column);          \
+      g_free (formatted);                                                     \
+      g_debug (formatted2);                                                   \
+      g_set_error (                                                           \
+        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_PARSE, formatted2);  \
+      g_free (formatted2);                                                    \
+      result = FALSE;                                                         \
+      goto error;                                                             \
+    }                                                                         \
+  while (0)
+
 #define YAML_EMITTER_EMIT_WITH_ERROR_RETURN(emitter, event, _error, ...)      \
   do                                                                          \
     {                                                                         \
       if (!yaml_emitter_emit (emitter, event))                                \
         {                                                                     \
           gchar *formatted = g_strdup_printf (__VA_ARGS__);                   \
-          g_debug ("Error: %s - event type: %s",                              \
+          g_debug ("Error: %s - event type: %s [line %zu col %zu]",           \
                    formatted,                                                 \
-                   mmd_yaml_get_event_name ((event)->type));                  \
+                   mmd_yaml_get_event_name ((event)->type),                   \
+                   (event)->start_mark.line,                                  \
+                   (event)->start_mark.column);                               \
           g_set_error_literal (_error,                                        \
                                MODULEMD_YAML_ERROR,                           \
                                MODULEMD_YAML_ERROR_EMIT,                      \
@@ -151,6 +184,22 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
       g_debug (__VA_ARGS__);                                                  \
       g_set_error (                                                           \
         _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, __VA_ARGS__);  \
+      result = FALSE;                                                         \
+      goto error;                                                             \
+    }                                                                         \
+  while (0)
+
+#define MMD_YAML_EMITTER_ERROR_EVENT_RETURN(_error, event, ...)               \
+  do                                                                          \
+    {                                                                         \
+      gchar *formatted = g_strdup_printf ("%s [line %zu col %zu]",            \
+                                          __VA_ARGS__,                        \
+                                          event.start_mark.line,              \
+                                          event.start_mark.column);           \
+      g_debug (formatted);                                                    \
+      g_set_error (                                                           \
+        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, formatted);    \
+      g_free (formatted);                                                     \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \

--- a/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
+++ b/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
@@ -90,12 +90,11 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
 #define MMD_YAML_ERROR_EVENT_RETURN_RETHROW(_error, event, ...)               \
   do                                                                          \
     {                                                                         \
-      gchar *formatted = g_strdup_printf (__VA_ARGS__);                       \
+      g_autofree gchar *formatted = g_strdup_printf (__VA_ARGS__);            \
       g_debug ("%s [line %zu col %zu]",                                       \
                formatted,                                                     \
                event.start_mark.line + 1,                                     \
                event.start_mark.column + 1);                                  \
-      g_free (formatted);                                                     \
       goto error;                                                             \
     }                                                                         \
   while (0)
@@ -124,16 +123,15 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
 #define MMD_YAML_ERROR_EVENT_RETURN(_error, event, ...)                       \
   do                                                                          \
     {                                                                         \
-      gchar *formatted = g_strdup_printf (__VA_ARGS__);                       \
-      gchar *formatted2 = g_strdup_printf ("%s [line %zu col %zu]",           \
-                                           formatted,                         \
-                                           event.start_mark.line + 1,         \
-                                           event.start_mark.column + 1);      \
-      g_free (formatted);                                                     \
+      g_autofree gchar *formatted = g_strdup_printf (__VA_ARGS__);            \
+      g_autofree gchar *formatted2 =                                          \
+        g_strdup_printf ("%s [line %zu col %zu]",                             \
+                         formatted,                                           \
+                         event.start_mark.line + 1,                           \
+                         event.start_mark.column + 1);                        \
       g_debug (formatted2);                                                   \
       g_set_error (                                                           \
         _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_PARSE, formatted2);  \
-      g_free (formatted2);                                                    \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \
@@ -144,7 +142,7 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     {                                                                         \
       if (!yaml_emitter_emit (emitter, event))                                \
         {                                                                     \
-          gchar *formatted = g_strdup_printf (__VA_ARGS__);                   \
+          g_autofree gchar *formatted = g_strdup_printf (__VA_ARGS__);        \
           g_debug ("Error: %s - event type: %s [line %zu col %zu]",           \
                    formatted,                                                 \
                    mmd_yaml_get_event_name ((event)->type),                   \
@@ -154,7 +152,6 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
                                MODULEMD_YAML_ERROR,                           \
                                MODULEMD_YAML_ERROR_EMIT,                      \
                                formatted);                                    \
-          g_free (formatted);                                                 \
           result = FALSE;                                                     \
           goto error;                                                         \
         }                                                                     \
@@ -195,14 +192,14 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
 #define MMD_YAML_EMITTER_ERROR_EVENT_RETURN(_error, event, ...)               \
   do                                                                          \
     {                                                                         \
-      gchar *formatted = g_strdup_printf ("%s [line %zu col %zu]",            \
-                                          __VA_ARGS__,                        \
-                                          event.start_mark.line + 1,          \
-                                          event.start_mark.column + 1);       \
+      g_autofree gchar *formatted =                                           \
+        g_strdup_printf ("%s [line %zu col %zu]",                             \
+                         __VA_ARGS__,                                         \
+                         event.start_mark.line + 1,                           \
+                         event.start_mark.column + 1);                        \
       g_debug (formatted);                                                    \
       g_set_error (                                                           \
         _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, formatted);    \
-      g_free (formatted);                                                     \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \

--- a/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
+++ b/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
@@ -42,16 +42,16 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
                                          guint64 version,
                                          GError **error);
 
-#define YAML_PARSER_PARSE_WITH_ERROR_RETURN(parser, event, _error, msg)       \
+#define YAML_PARSER_PARSE_WITH_ERROR_RETURN(parser, event, _error, ...)       \
   do                                                                          \
     {                                                                         \
       if (!yaml_parser_parse (parser, event))                                 \
         {                                                                     \
-          g_debug (msg);                                                      \
-          g_set_error_literal (_error,                                        \
-                               MODULEMD_YAML_ERROR,                           \
-                               MODULEMD_YAML_ERROR_UNPARSEABLE,               \
-                               msg);                                          \
+          g_debug (__VA_ARGS__);                                              \
+          g_set_error (_error,                                                \
+                       MODULEMD_YAML_ERROR,                                   \
+                       MODULEMD_YAML_ERROR_UNPARSEABLE,                       \
+                       __VA_ARGS__);                                          \
           result = FALSE;                                                     \
           goto error;                                                         \
         }                                                                     \
@@ -75,46 +75,50 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     }                                                                         \
   while (0)
 
-#define MMD_YAML_ERROR_RETURN_RETHROW(_error, msg)                            \
+#define MMD_YAML_ERROR_RETURN_RETHROW(_error, ...)                            \
   do                                                                          \
     {                                                                         \
-      g_debug (msg);                                                          \
+      g_debug (__VA_ARGS__);                                                  \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \
   while (0)
 
-#define MMD_ERROR_RETURN_FULL(_error, type, msg)                              \
+#define MMD_ERROR_RETURN_FULL(_error, type, ...)                              \
   do                                                                          \
     {                                                                         \
-      g_debug (msg);                                                          \
-      g_set_error_literal (_error, MODULEMD_YAML_ERROR, type, msg);           \
+      g_debug (__VA_ARGS__);                                                  \
+      g_set_error (_error, MODULEMD_YAML_ERROR, type, __VA_ARGS__);           \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \
   while (0)
 
-#define MMD_YAML_ERROR_RETURN(_error, msg)                                    \
+#define MMD_YAML_ERROR_RETURN(_error, ...)                                    \
   do                                                                          \
     {                                                                         \
-      g_debug (msg);                                                          \
-      g_set_error_literal (                                                   \
-        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_PARSE, msg);         \
+      g_debug (__VA_ARGS__);                                                  \
+      g_set_error (                                                           \
+        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_PARSE, __VA_ARGS__); \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \
   while (0)
 
-#define YAML_EMITTER_EMIT_WITH_ERROR_RETURN(emitter, event, _error, msg)      \
+#define YAML_EMITTER_EMIT_WITH_ERROR_RETURN(emitter, event, _error, ...)      \
   do                                                                          \
     {                                                                         \
       if (!yaml_emitter_emit (emitter, event))                                \
         {                                                                     \
+          gchar *formatted = g_strdup_printf (__VA_ARGS__);                   \
           g_debug ("Error: %s - event type: %s",                              \
-                   msg,                                                       \
+                   formatted,                                                 \
                    mmd_yaml_get_event_name ((event)->type));                  \
-          g_set_error_literal (                                               \
-            _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, msg);      \
+          g_set_error_literal (_error,                                        \
+                               MODULEMD_YAML_ERROR,                           \
+                               MODULEMD_YAML_ERROR_EMIT,                      \
+                               formatted);                                    \
+          g_free (formatted);                                                 \
           result = FALSE;                                                     \
           goto error;                                                         \
         }                                                                     \
@@ -141,12 +145,12 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     }                                                                         \
   while (0)
 
-#define MMD_YAML_EMITTER_ERROR_RETURN(_error, msg)                            \
+#define MMD_YAML_EMITTER_ERROR_RETURN(_error, ...)                            \
   do                                                                          \
     {                                                                         \
-      g_debug (msg);                                                          \
-      g_set_error_literal (                                                   \
-        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, msg);          \
+      g_debug (__VA_ARGS__);                                                  \
+      g_set_error (                                                           \
+        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, __VA_ARGS__);  \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \
@@ -242,12 +246,12 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     }                                                                         \
   while (0)
 
-#define MMD_YAML_NOEVENT_ERROR_RETURN(_error, msg)                            \
+#define MMD_YAML_NOEVENT_ERROR_RETURN(_error, ...)                            \
   do                                                                          \
     {                                                                         \
-      g_debug (msg);                                                          \
-      g_set_error_literal (                                                   \
-        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_PARSE, msg);         \
+      g_debug (__VA_ARGS__);                                                  \
+      g_set_error (                                                           \
+        _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_PARSE, __VA_ARGS__); \
       result = FALSE;                                                         \
       goto error;                                                             \
     }                                                                         \

--- a/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
+++ b/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
@@ -55,7 +55,10 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
           result = FALSE;                                                     \
           goto error;                                                         \
         }                                                                     \
-      g_debug ("Parser event: %s", mmd_yaml_get_event_name ((event)->type));  \
+      g_debug ("Parser event: %s (%zu/%zu)",                                  \
+               mmd_yaml_get_event_name ((event)->type),                       \
+               (event)->start_mark.line,                                      \
+               (event)->start_mark.column);                                   \
     }                                                                         \
   while (0)
 

--- a/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
+++ b/modulemd/include/modulemd-1.0/private/modulemd-yaml.h
@@ -90,8 +90,8 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
       gchar *formatted = g_strdup_printf (__VA_ARGS__);                       \
       g_debug ("%s [line %zu col %zu]",                                       \
                formatted,                                                     \
-               event.start_mark.line,                                         \
-               event.start_mark.column);                                      \
+               event.start_mark.line + 1,                                     \
+               event.start_mark.column + 1);                                  \
       g_free (formatted);                                                     \
       goto error;                                                             \
     }                                                                         \
@@ -124,8 +124,8 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
       gchar *formatted = g_strdup_printf (__VA_ARGS__);                       \
       gchar *formatted2 = g_strdup_printf ("%s [line %zu col %zu]",           \
                                            formatted,                         \
-                                           event.start_mark.line,             \
-                                           event.start_mark.column);          \
+                                           event.start_mark.line + 1,         \
+                                           event.start_mark.column + 1);      \
       g_free (formatted);                                                     \
       g_debug (formatted2);                                                   \
       g_set_error (                                                           \
@@ -145,8 +145,8 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
           g_debug ("Error: %s - event type: %s [line %zu col %zu]",           \
                    formatted,                                                 \
                    mmd_yaml_get_event_name ((event)->type),                   \
-                   (event)->start_mark.line,                                  \
-                   (event)->start_mark.column);                               \
+                   (event)->start_mark.line + 1,                              \
+                   (event)->start_mark.column + 1);                           \
           g_set_error_literal (_error,                                        \
                                MODULEMD_YAML_ERROR,                           \
                                MODULEMD_YAML_ERROR_EMIT,                      \
@@ -194,8 +194,8 @@ typedef gboolean (*ModulemdParsingFunc) (yaml_parser_t *parser,
     {                                                                         \
       gchar *formatted = g_strdup_printf ("%s [line %zu col %zu]",            \
                                           __VA_ARGS__,                        \
-                                          event.start_mark.line,              \
-                                          event.start_mark.column);           \
+                                          event.start_mark.line + 1,          \
+                                          event.start_mark.column + 1);       \
       g_debug (formatted);                                                    \
       g_set_error (                                                           \
         _error, MODULEMD_YAML_ERROR, MODULEMD_YAML_ERROR_EMIT, formatted);    \

--- a/modulemd/v1/modulemd-yaml-parser-defaults.c
+++ b/modulemd/v1/modulemd-yaml-parser-defaults.c
@@ -115,7 +115,8 @@ _parse_defaults (yaml_parser_t *parser,
                              "modulemd-defaults"))
                 {
                   yaml_event_delete (&value_event);
-                  MMD_YAML_ERROR_RETURN (error, "Document type mismatch");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, event, "Document type mismatch");
                 }
               yaml_event_delete (&value_event);
             }
@@ -128,7 +129,8 @@ _parse_defaults (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Unknown modulemd version");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Unknown modulemd version");
                 }
 
               mdversion = g_ascii_strtoull (
@@ -136,8 +138,8 @@ _parse_defaults (yaml_parser_t *parser,
               yaml_event_delete (&value_event);
               if (!mdversion)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Unknown modulemd defaults version");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, event, "Unknown modulemd defaults version");
                 }
 
               if (mdversion != version)
@@ -145,8 +147,9 @@ _parse_defaults (yaml_parser_t *parser,
                   /* Preprocessing and real parser don't match!
                    * This should be impossible
                    */
-                  MMD_YAML_ERROR_RETURN (
+                  MMD_YAML_ERROR_EVENT_RETURN (
                     error,
+                    event,
                     "ModuleMD defaults version doesn't match preprocessing");
                 }
               modulemd_defaults_set_version (defaults, mdversion);
@@ -163,13 +166,15 @@ _parse_defaults (yaml_parser_t *parser,
             {
               g_debug ("Unexpected key in root: %s",
                        (const gchar *)event.data.scalar.value);
-              MMD_YAML_ERROR_RETURN (error, "Unexpected key in root");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unexpected key in root");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in root");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in root");
           break;
         }
 
@@ -235,7 +240,8 @@ _parse_defaults_data (ModulemdDefaults *defaults,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Failed to parse module name");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse module name");
                 }
 
               modulemd_defaults_set_module_name (
@@ -251,8 +257,8 @@ _parse_defaults_data (ModulemdDefaults *defaults,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse module stream");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse module stream");
                 }
 
               modulemd_defaults_set_default_stream (
@@ -278,7 +284,8 @@ _parse_defaults_data (ModulemdDefaults *defaults,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in data");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in data");
           break;
         }
 
@@ -334,8 +341,8 @@ _parse_defaults_profiles (ModulemdDefaults *defaults,
           if (!in_map)
             {
               /* We got a scalar where we expected a map */
-              MMD_YAML_ERROR_RETURN (error,
-                                     "Malformed YAML in intent profiles");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Malformed YAML in intent profiles");
               break;
             }
 
@@ -344,7 +351,8 @@ _parse_defaults_profiles (ModulemdDefaults *defaults,
 
           if (!_simpleset_from_sequence (parser, &set, error))
             {
-              MMD_YAML_ERROR_RETURN_RETHROW (error, "Invalid sequence");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Invalid sequence");
             }
           modulemd_defaults_assign_profiles_for_stream (
             defaults, stream_name, set);
@@ -354,8 +362,8 @@ _parse_defaults_profiles (ModulemdDefaults *defaults,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error,
-                                 "Unexpected YAML event in default profiles");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in default profiles");
           break;
         }
       yaml_event_delete (&event);
@@ -407,7 +415,8 @@ _parse_defaults_intents (ModulemdDefaults *defaults,
           if (!in_map)
             {
               /* We got a scalar where we expected a map */
-              MMD_YAML_ERROR_RETURN (error, "Malformed YAML in intents");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Malformed YAML in intents");
               break;
             }
 
@@ -417,7 +426,8 @@ _parse_defaults_intents (ModulemdDefaults *defaults,
                               &intent,
                               error))
             {
-              MMD_YAML_ERROR_RETURN_RETHROW (error, "Could not parse intent");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Could not parse intent");
               break;
             }
 
@@ -428,7 +438,8 @@ _parse_defaults_intents (ModulemdDefaults *defaults,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Malformed YAML in intents");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Malformed YAML in intents");
           break;
         }
       yaml_event_delete (&event);
@@ -480,7 +491,8 @@ _parse_intent (yaml_parser_t *parser,
           if (!in_map)
             {
               /* We got a scalar where we expected a map */
-              MMD_YAML_ERROR_RETURN (error, "Malformed YAML in intents");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Malformed YAML in intents");
               break;
             }
 
@@ -493,8 +505,10 @@ _parse_intent (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (
-                    error, "Failed to parse default module stream");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error,
+                    value_event,
+                    "Failed to parse default module stream");
                 }
 
               modulemd_intent_set_default_stream (
@@ -507,14 +521,15 @@ _parse_intent (yaml_parser_t *parser,
             {
               if (!_parse_intent_profiles (_intent, parser, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (
-                    error, "Could not parse intent profiles");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Could not parse intent profiles");
                 }
             }
           else
             {
               /* Unexpected key in the map */
-              MMD_YAML_ERROR_RETURN (error, "Unexpected key in intent");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unexpected key in intent");
               break;
             }
 
@@ -522,7 +537,8 @@ _parse_intent (yaml_parser_t *parser,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Malformed YAML in intents");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Malformed YAML in intents");
           break;
         }
       yaml_event_delete (&event);
@@ -577,8 +593,8 @@ _parse_intent_profiles (ModulemdIntent *intent,
           if (!in_map)
             {
               /* We got a scalar where we expected a map */
-              MMD_YAML_ERROR_RETURN (error,
-                                     "Malformed YAML in intent profiles");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Malformed YAML in intent profiles");
               break;
             }
 
@@ -587,7 +603,8 @@ _parse_intent_profiles (ModulemdIntent *intent,
 
           if (!_simpleset_from_sequence (parser, &set, error))
             {
-              MMD_YAML_ERROR_RETURN_RETHROW (error, "Invalid sequence");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Invalid sequence");
             }
           modulemd_intent_assign_profiles_for_stream (
             intent, stream_name, set);
@@ -597,8 +614,8 @@ _parse_intent_profiles (ModulemdIntent *intent,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error,
-                                 "Unexpected YAML event in intent profiles");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in intent profiles");
           break;
         }
       yaml_event_delete (&event);

--- a/modulemd/v1/modulemd-yaml-parser-modulemd.c
+++ b/modulemd/v1/modulemd-yaml-parser-modulemd.c
@@ -177,7 +177,8 @@ _parse_module_stream (yaml_parser_t *parser,
                   g_strcmp0 ((const gchar *)value_event.data.scalar.value,
                              "modulemd"))
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Unknown document type");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Unknown document type");
                 }
               yaml_event_delete (&value_event);
             }
@@ -191,14 +192,16 @@ _parse_module_stream (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Unknown modulemd version");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Unknown modulemd version");
                 }
 
               mdversion = g_ascii_strtoull (
                 (const gchar *)value_event.data.scalar.value, NULL, 10);
               if (!mdversion)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Unknown modulemd version");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Unknown modulemd version");
                 }
               yaml_event_delete (&value_event);
 
@@ -207,8 +210,10 @@ _parse_module_stream (yaml_parser_t *parser,
                   /* Preprocessing and real parser don't match!
                    * This should be impossible
                    */
-                  MMD_YAML_ERROR_RETURN (
-                    error, "ModuleMD version doesn't match preprocessing");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error,
+                    event,
+                    "ModuleMD version doesn't match preprocessing");
                 }
               modulemd_modulestream_set_mdversion (modulestream, mdversion);
             }
@@ -224,13 +229,15 @@ _parse_module_stream (yaml_parser_t *parser,
             {
               g_debug ("Unexpected key in root: %s",
                        (const gchar *)event.data.scalar.value);
-              MMD_YAML_ERROR_RETURN (error, "Unexpected key in root");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unexpected key in root");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in root");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in root");
           break;
         }
       yaml_event_delete (&event);
@@ -283,7 +290,8 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Failed to parse module name");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse module name");
                 }
 
               modulemd_modulestream_set_name (
@@ -299,8 +307,8 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse module stream");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse module stream");
                 }
 
               modulemd_modulestream_set_stream (
@@ -316,15 +324,16 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse module version");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse module version");
                 }
 
               version = g_ascii_strtoull (
                 (const gchar *)value_event.data.scalar.value, NULL, 10);
               if (!version)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Unknown module version");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Unknown module version");
                 }
 
               modulemd_modulestream_set_version (modulestream, version);
@@ -340,8 +349,8 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse module context");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse module context");
                 }
 
               modulemd_modulestream_set_context (
@@ -356,8 +365,10 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (
-                    error, "Failed to parse module artifact architecture");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error,
+                    value_event,
+                    "Failed to parse module artifact architecture");
                 }
 
               modulemd_modulestream_set_arch (
@@ -374,8 +385,8 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse module summary");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse module summary");
                 }
 
               modulemd_modulestream_set_summary (
@@ -392,8 +403,8 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse module description");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse module description");
                 }
 
               modulemd_modulestream_set_description (
@@ -409,16 +420,17 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
                   MD_VERSION_1)
                 {
                   /* EOL is not supported in v2 or later; use servicelevel */
-                  MMD_YAML_ERROR_RETURN (
+                  MMD_YAML_ERROR_EVENT_RETURN (
                     error,
+                    event,
                     "EOL is not supported in v2 or later; use servicelevel");
                 }
 
               /* Get the EOL date */
               if (!_parse_modulemd_date (parser, &eol, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (
-                    error, "Failed to parse module EOL date");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Failed to parse module EOL date");
                 }
 
               modulemd_modulestream_set_eol (modulestream, eol);
@@ -515,13 +527,15 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
             {
               g_debug ("Unexpected key in data: %s",
                        (const gchar *)event.data.scalar.value);
-              MMD_YAML_ERROR_RETURN (error, "Unexpected key in data");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unexpected key in data");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in data");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in data");
           break;
         }
 
@@ -570,7 +584,8 @@ _parse_modulemd_licenses (ModulemdModuleStream *modulestream,
           /* Each scalar event represents a license type */
           if (!_simpleset_from_sequence (parser, &set, error))
             {
-              MMD_YAML_ERROR_RETURN_RETHROW (error, "Invalid sequence");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Invalid sequence");
             }
 
           if (!g_strcmp0 ((const gchar *)event.data.scalar.value, "module"))
@@ -584,7 +599,8 @@ _parse_modulemd_licenses (ModulemdModuleStream *modulestream,
             }
           else
             {
-              MMD_YAML_ERROR_RETURN (error, "Unknown license type");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unknown license type");
             }
 
           g_clear_pointer (&set, g_object_unref);
@@ -592,7 +608,8 @@ _parse_modulemd_licenses (ModulemdModuleStream *modulestream,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in licenses");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in licenses");
           break;
         }
 
@@ -626,18 +643,18 @@ _parse_modulemd_xmd (ModulemdModuleStream *modulestream,
   YAML_PARSER_PARSE_WITH_ERROR_RETURN (parser, &event, error, "Parser error");
   if (!(event.type == YAML_MAPPING_START_EVENT))
     {
-      MMD_YAML_ERROR_RETURN (error, "Invalid mapping");
+      MMD_YAML_ERROR_EVENT_RETURN (error, event, "Invalid mapping");
     }
   yaml_event_delete (&event);
 
   if (!parse_raw_yaml_mapping (parser, &variant, error))
     {
-      MMD_YAML_ERROR_RETURN (error, "Invalid raw mapping");
+      MMD_YAML_ERROR_EVENT_RETURN (error, event, "Invalid raw mapping");
     }
 
   if (!g_variant_is_of_type (variant, G_VARIANT_TYPE_DICTIONARY))
     {
-      MMD_YAML_ERROR_RETURN (error, "XMD wasn't a dictionary");
+      MMD_YAML_ERROR_EVENT_RETURN (error, event, "XMD wasn't a dictionary");
     }
 
   xmd = g_hash_table_new_full (
@@ -693,7 +710,8 @@ _parse_modulemd_deps_v1 (ModulemdModuleStream *modulestream,
         case YAML_SCALAR_EVENT:
           if (!_hashtable_from_mapping (parser, &reqs, error))
             {
-              MMD_YAML_ERROR_RETURN_RETHROW (error, "Invalid mapping");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Invalid mapping");
             }
 
           if (!g_strcmp0 ((const gchar *)event.data.scalar.value,
@@ -708,7 +726,8 @@ _parse_modulemd_deps_v1 (ModulemdModuleStream *modulestream,
             }
           else
             {
-              MMD_YAML_ERROR_RETURN (error, "Unknown dependency type");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unknown dependency type");
             }
 
           g_clear_pointer (&reqs, g_hash_table_unref);
@@ -770,8 +789,8 @@ _parse_modulemd_deps_v2 (ModulemdModuleStream *modulestream,
         case YAML_MAPPING_START_EVENT:
           if (!_parse_modulemd_v2_dep (modulestream, parser, error))
             {
-              MMD_YAML_ERROR_RETURN_RETHROW (
-                error, "Failed to parse requires/buildrequires");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Failed to parse requires/buildrequires");
               break;
             }
           break;
@@ -850,23 +869,25 @@ _parse_modulemd_v2_dep (ModulemdModuleStream *modulestream,
             }
           else
             {
-              MMD_YAML_ERROR_RETURN (error,
-                                     "Dependency map had key other than "
-                                     "'requires' or 'buildrequires'");
+              MMD_YAML_ERROR_EVENT_RETURN (error,
+                                           event,
+                                           "Dependency map had key other than "
+                                           "'requires' or 'buildrequires'");
             }
 
           if (!_parse_modulemd_v2_dep_map (
                 modulestream, parser, reqtype, dep, error))
             {
-              MMD_YAML_ERROR_RETURN_RETHROW (
-                error, "Error processing dependency map.");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Error processing dependency map.");
             }
 
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in v2_dep");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in v2_dep");
           break;
         }
 
@@ -922,16 +943,16 @@ _parse_modulemd_v2_dep_map (ModulemdModuleStream *modulestream,
         case YAML_SCALAR_EVENT:
           if (!in_map)
             {
-              MMD_YAML_ERROR_RETURN (error,
-                                     "Unexpected YAML event in v2_dep_map");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unexpected YAML event in v2_dep_map");
             }
 
           module_name = g_strdup ((const gchar *)event.data.scalar.value);
 
           if (!_simpleset_from_sequence (parser, &set, error))
             {
-              MMD_YAML_ERROR_RETURN_RETHROW (error,
-                                             "Could not parse set of streams");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Could not parse set of streams");
             }
           dep_set = (const gchar **)modulemd_simpleset_dup (set);
 
@@ -958,7 +979,8 @@ _parse_modulemd_v2_dep_map (ModulemdModuleStream *modulestream,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in v2_dep_map");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in v2_dep_map");
           break;
         }
 
@@ -1099,14 +1121,16 @@ _parse_modulemd_profiles (ModulemdModuleStream *modulestream,
           if (!_parse_modulemd_profile (parser, name, &profile, error))
             {
               g_free (name);
-              MMD_YAML_ERROR_RETURN_RETHROW (error, "Invalid profile");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Invalid profile");
             }
           g_hash_table_insert (profiles, name, profile);
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in profiles");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in profiles");
           break;
         }
 
@@ -1166,8 +1190,8 @@ _parse_modulemd_profile (yaml_parser_t *parser,
               /* Get the set of RPMs */
               if (!_simpleset_from_sequence (parser, &set, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (
-                    error, "Could not parse profile RPMs");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Could not parse profile RPMs");
                 }
               modulemd_profile_set_rpms (profile, set);
               g_object_unref (set);
@@ -1180,7 +1204,8 @@ _parse_modulemd_profile (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "No value for description");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "No value for description");
                 }
 
               modulemd_profile_set_description (
@@ -1191,13 +1216,15 @@ _parse_modulemd_profile (yaml_parser_t *parser,
           else
             {
               /* Unknown field in profile */
-              MMD_YAML_ERROR_RETURN (error, "Unknown key in profile body");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unknown key in profile body");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in profiles");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in profiles");
           break;
         }
 
@@ -1251,19 +1278,21 @@ _parse_modulemd_api (ModulemdModuleStream *modulestream,
             {
               if (!_simpleset_from_sequence (parser, &set, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (error, "Parse error in API");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Parse error in API");
                 }
               modulemd_modulestream_set_rpm_api (modulestream, set);
             }
           else
             {
-              MMD_YAML_ERROR_RETURN (error, "Unknown API type");
+              MMD_YAML_ERROR_EVENT_RETURN (error, event, "Unknown API type");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in api");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in api");
           break;
         }
 
@@ -1315,20 +1344,22 @@ _parse_modulemd_filters (ModulemdModuleStream *modulestream,
             {
               if (!_simpleset_from_sequence (parser, &set, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (error,
-                                                 "Parse error in filters");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Parse error in filters");
                 }
               modulemd_modulestream_set_rpm_filter (modulestream, set);
             }
           else
             {
-              MMD_YAML_ERROR_RETURN (error, "Unknown filter type");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unknown filter type");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in filters");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in filters");
           break;
         }
 
@@ -1382,19 +1413,21 @@ _parse_modulemd_buildopts (ModulemdModuleStream *modulestream,
             {
               if (!_parse_modulemd_rpm_buildopts (buildopts, parser, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (
-                    error, "Parse error in RPM buildopts");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Parse error in RPM buildopts");
                 }
             }
           else
             {
-              MMD_YAML_ERROR_RETURN (error, "Unknown buildopt type");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unknown buildopt type");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in buildopts");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in buildopts");
           break;
         }
 
@@ -1448,8 +1481,8 @@ _parse_modulemd_rpm_buildopts (ModulemdBuildopts *buildopts,
         case YAML_SCALAR_EVENT:
           if (!in_mapping)
             {
-              MMD_YAML_ERROR_RETURN (
-                error, "Received a scalar when a map was expected.");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Received a scalar when a map was expected.");
               break;
             }
 
@@ -1459,7 +1492,8 @@ _parse_modulemd_rpm_buildopts (ModulemdBuildopts *buildopts,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Failed to parse RPM macros");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse RPM macros");
                 }
               modulemd_buildopts_set_rpm_macros (
                 buildopts, (const gchar *)value_event.data.scalar.value);
@@ -1470,22 +1504,23 @@ _parse_modulemd_rpm_buildopts (ModulemdBuildopts *buildopts,
             {
               if (!_simpleset_from_sequence (parser, &set, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (
-                    error, "Parse error in RPM whitelist");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Parse error in RPM whitelist");
                 }
               modulemd_buildopts_set_rpm_whitelist_simpleset (buildopts, set);
             }
           else
             {
-              MMD_YAML_ERROR_RETURN (error, "Unknown RPM buildopt key");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unknown RPM buildopt key");
             }
 
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error,
-                                 "Unexpected YAML event in RPM buildopts");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in RPM buildopts");
           break;
         }
       yaml_event_delete (&event);
@@ -1536,8 +1571,8 @@ _parse_modulemd_components (ModulemdModuleStream *modulestream,
             {
               if (!_parse_modulemd_rpm_components (parser, &components, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (
-                    error, "Could not parse RPM components");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Could not parse RPM components");
                 }
               modulemd_modulestream_set_rpm_components (modulestream,
                                                         components);
@@ -1549,8 +1584,8 @@ _parse_modulemd_components (ModulemdModuleStream *modulestream,
               if (!_parse_modulemd_modulestream_components (
                     parser, &components, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (
-                    error, "Could not parse module components");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Could not parse module components");
                 }
               modulemd_modulestream_set_module_components (modulestream,
                                                            components);
@@ -1558,13 +1593,15 @@ _parse_modulemd_components (ModulemdModuleStream *modulestream,
             }
           else
             {
-              MMD_YAML_ERROR_RETURN (error, "Unknown component type");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unknown component type");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in components");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in components");
           break;
         }
 
@@ -1617,8 +1654,8 @@ _parse_modulemd_rpm_components (yaml_parser_t *parser,
           name = g_strdup ((const gchar *)event.data.scalar.value);
           if (!_parse_modulemd_rpm_component (parser, name, &component, error))
             {
-              MMD_YAML_ERROR_RETURN_RETHROW (error,
-                                             "Parse error in RPM component");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Parse error in RPM component");
             }
 
           /* Set this key and value to the hash table */
@@ -1628,7 +1665,8 @@ _parse_modulemd_rpm_components (yaml_parser_t *parser,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in sequence");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in sequence");
           break;
         }
 
@@ -1689,8 +1727,8 @@ _parse_modulemd_rpm_component (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse buildorder value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse buildorder value");
                 }
 
               buildorder = g_ascii_strtoull (
@@ -1708,8 +1746,8 @@ _parse_modulemd_rpm_component (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse rationale value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse rationale value");
                 }
 
               modulemd_component_set_rationale (
@@ -1724,8 +1762,8 @@ _parse_modulemd_rpm_component (yaml_parser_t *parser,
             {
               if (!_simpleset_from_sequence (parser, &set, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (
-                    error, "Error parsing component arches");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Error parsing component arches");
                 }
               modulemd_component_rpm_set_arches (component, set);
             }
@@ -1737,7 +1775,8 @@ _parse_modulemd_rpm_component (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Failed to parse cache value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse cache value");
                 }
 
               modulemd_component_rpm_set_cache (
@@ -1751,8 +1790,8 @@ _parse_modulemd_rpm_component (yaml_parser_t *parser,
             {
               if (!_simpleset_from_sequence (parser, &set, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (
-                    error, "Error parsing multilib arches");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Error parsing multilib arches");
                 }
               modulemd_component_rpm_set_multilib (component, set);
             }
@@ -1763,7 +1802,8 @@ _parse_modulemd_rpm_component (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Failed to parse ref value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse ref value");
                 }
 
               modulemd_component_rpm_set_ref (
@@ -1779,8 +1819,8 @@ _parse_modulemd_rpm_component (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse repository value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse repository value");
                 }
 
               modulemd_component_rpm_set_repository (
@@ -1791,14 +1831,16 @@ _parse_modulemd_rpm_component (yaml_parser_t *parser,
 
           else
             {
-              MMD_YAML_ERROR_RETURN (error, "Unexpected key in component");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unexpected key in component");
             }
 
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in component");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in component");
           break;
         }
 
@@ -1855,8 +1897,8 @@ _parse_modulemd_modulestream_components (yaml_parser_t *parser,
           if (!_parse_modulemd_modulestream_component (
                 parser, name, &component, error))
             {
-              MMD_YAML_ERROR_RETURN_RETHROW (
-                error, "Parse error in module component");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Parse error in module component");
             }
 
           /* Set this key and value to the hash table */
@@ -1866,7 +1908,8 @@ _parse_modulemd_modulestream_components (yaml_parser_t *parser,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in sequence");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in sequence");
           break;
         }
 
@@ -1926,8 +1969,8 @@ _parse_modulemd_modulestream_component (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse buildorder value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse buildorder value");
                 }
 
               buildorder = g_ascii_strtoull (
@@ -1945,8 +1988,8 @@ _parse_modulemd_modulestream_component (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse rationale value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse rationale value");
                 }
 
               modulemd_component_set_rationale (
@@ -1962,7 +2005,8 @@ _parse_modulemd_modulestream_component (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error, "Failed to parse ref value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse ref value");
                 }
 
               modulemd_component_module_set_ref (
@@ -1978,8 +2022,8 @@ _parse_modulemd_modulestream_component (yaml_parser_t *parser,
                 parser, &value_event, error, "Parser error");
               if (value_event.type != YAML_SCALAR_EVENT)
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse repository value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, value_event, "Failed to parse repository value");
                 }
 
               modulemd_component_module_set_repository (
@@ -1990,14 +2034,16 @@ _parse_modulemd_modulestream_component (yaml_parser_t *parser,
 
           else
             {
-              MMD_YAML_ERROR_RETURN (error, "Unexpected key in component");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unexpected key in component");
             }
 
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in component");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in component");
           break;
         }
 
@@ -2050,28 +2096,30 @@ _parse_modulemd_artifacts (ModulemdModuleStream *modulestream,
             {
               if (!_simpleset_from_sequence (parser, &set, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (error,
-                                                 "Parse error in artifacts");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Parse error in artifacts");
                 }
 
               if (!modulemd_simpleset_validate_contents (
                     set, modulemd_validate_nevra, NULL))
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "RPM artifacts not in NEVRA format");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, event, "RPM artifacts not in NEVRA format");
                 }
 
               modulemd_modulestream_set_rpm_artifacts (modulestream, set);
             }
           else
             {
-              MMD_YAML_ERROR_RETURN (error, "Unknown artifact type");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unknown artifact type");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in artifacts");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in artifacts");
           break;
         }
 
@@ -2130,15 +2178,16 @@ _parse_modulemd_servicelevels (ModulemdModuleStream *modulestream,
           if (!_parse_modulemd_servicelevel (parser, name, &sl, error))
             {
               g_free (name);
-              MMD_YAML_ERROR_RETURN_RETHROW (error, "Invalid service level");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Invalid service level");
             }
           g_hash_table_insert (servicelevels, name, sl);
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error,
-                                 "Unexpected YAML event in service levels");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in service levels");
           break;
         }
 
@@ -2197,8 +2246,8 @@ _parse_modulemd_servicelevel (yaml_parser_t *parser,
               /* Get the EOL date */
               if (!_parse_modulemd_date (parser, &eol, error))
                 {
-                  MMD_YAML_ERROR_RETURN_RETHROW (
-                    error, "Failed to parse EOL date in service level");
+                  MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                    error, event, "Failed to parse EOL date in service level");
                 }
 
               modulemd_servicelevel_set_eol (sl, eol);
@@ -2208,15 +2257,15 @@ _parse_modulemd_servicelevel (yaml_parser_t *parser,
           else
             {
               /* Unknown field in service level */
-              MMD_YAML_ERROR_RETURN (error,
-                                     "Unknown key in service level body");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unknown key in service level body");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error,
-                                 "Unexpected YAML event in service level");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in service level");
           break;
         }
 

--- a/modulemd/v1/modulemd-yaml-parser-modulemd.c
+++ b/modulemd/v1/modulemd-yaml-parser-modulemd.c
@@ -716,7 +716,8 @@ _parse_modulemd_deps_v1 (ModulemdModuleStream *modulestream,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in deps");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in deps");
           break;
         }
 
@@ -777,7 +778,8 @@ _parse_modulemd_deps_v2 (ModulemdModuleStream *modulestream,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in deps");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in deps");
           break;
         }
 

--- a/modulemd/v1/modulemd-yaml-parser.c
+++ b/modulemd/v1/modulemd-yaml-parser.c
@@ -414,8 +414,8 @@ _parse_yaml (yaml_parser_t *parser,
                   *error =
                     g_error_copy (modulemd_subdocument_get_gerror (document));
                 }
-              MMD_YAML_ERROR_RETURN_RETHROW (
-                error, "Parse error during preprocessing");
+              MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+                error, event, "Parse error during preprocessing");
             }
 
           /* Add all valid documents to the list */
@@ -434,8 +434,8 @@ _parse_yaml (yaml_parser_t *parser,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN_RETHROW (
-            error, "Unexpected YAML event during preprocessing");
+          MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
+            error, event, "Unexpected YAML event during preprocessing");
           break;
         }
 
@@ -845,7 +845,8 @@ _parse_subdocument (ModulemdSubdocument *subdocument,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event at toplevel");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event at toplevel");
           break;
         }
 
@@ -872,14 +873,15 @@ _parse_modulemd_date (yaml_parser_t *parser, GDate **_date, GError **error)
   YAML_PARSER_PARSE_WITH_ERROR_RETURN (parser, &event, error, "Parser error");
   if (event.type != YAML_SCALAR_EVENT)
     {
-      MMD_YAML_ERROR_RETURN (error, "Failed to parse date");
+      MMD_YAML_ERROR_EVENT_RETURN (error, event, "Failed to parse date");
     }
 
   strv = g_strsplit ((const gchar *)event.data.scalar.value, "-", 4);
 
   if (!strv[0] || !strv[1] || !strv[2])
     {
-      MMD_YAML_ERROR_RETURN (error, "Date not in the form YYYY-MM-DD");
+      MMD_YAML_ERROR_EVENT_RETURN (
+        error, event, "Date not in the form YYYY-MM-DD");
     }
 
   *_date = g_date_new_dmy (g_ascii_strtoull (strv[2], NULL, 10), /* Day */
@@ -938,7 +940,8 @@ _simpleset_from_sequence (yaml_parser_t *parser,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in sequence");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in sequence");
           break;
         }
       yaml_event_delete (&event);
@@ -991,8 +994,8 @@ _hashtable_from_mapping (yaml_parser_t *parser,
         case YAML_SCALAR_EVENT:
           if (!started)
             {
-              MMD_YAML_ERROR_RETURN (error,
-                                     "Received scalar where mapping expected");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Received scalar where mapping expected");
             }
           name = g_strdup ((const gchar *)event.data.scalar.value);
           YAML_PARSER_PARSE_WITH_ERROR_RETURN (
@@ -1000,8 +1003,8 @@ _hashtable_from_mapping (yaml_parser_t *parser,
           if (value_event.type != YAML_SCALAR_EVENT)
             {
               g_free (name);
-              MMD_YAML_ERROR_RETURN (error,
-                                     "Non-scalar value for dictionary.");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, value_event, "Non-scalar value for dictionary.");
             }
           value = g_strdup ((const gchar *)value_event.data.scalar.value);
           yaml_event_delete (&value_event);
@@ -1014,7 +1017,8 @@ _hashtable_from_mapping (yaml_parser_t *parser,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error, "Unexpected YAML event in sequence");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in sequence");
           break;
         }
 

--- a/modulemd/v1/modulemd-yaml-parser.c
+++ b/modulemd/v1/modulemd-yaml-parser.c
@@ -673,7 +673,10 @@ _read_yaml_and_type (yaml_parser_t *parser, ModulemdSubdocument **subdocument)
                       g_set_error (&error,
                                    MODULEMD_YAML_ERROR,
                                    MODULEMD_YAML_ERROR_PARSE,
-                                   "Document type is not recognized");
+                                   "Document type is not recognized "
+                                   "[line %zu col %zu]",
+                                   event.start_mark.line,
+                                   event.start_mark.column);
                     }
 
                   g_debug (
@@ -927,8 +930,8 @@ _simpleset_from_sequence (yaml_parser_t *parser,
         case YAML_SCALAR_EVENT:
           if (!started)
             {
-              MMD_YAML_ERROR_RETURN (
-                error, "Received scalar where sequence expected");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Received scalar where sequence expected");
             }
           modulemd_simpleset_add (set, (const gchar *)event.data.scalar.value);
           break;

--- a/modulemd/v1/modulemd-yaml-utils.c
+++ b/modulemd/v1/modulemd-yaml-utils.c
@@ -109,23 +109,23 @@ parse_raw_yaml_mapping (yaml_parser_t *parser,
             case YAML_MAPPING_START_EVENT:
               if (!parse_raw_yaml_mapping (parser, &value, error))
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse mapping value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, event, "Failed to parse mapping value");
                 }
               break;
 
             case YAML_SEQUENCE_START_EVENT:
               if (!parse_raw_yaml_sequence (parser, &value, error))
                 {
-                  MMD_YAML_ERROR_RETURN (error,
-                                         "Failed to parse sequence value");
+                  MMD_YAML_ERROR_EVENT_RETURN (
+                    error, event, "Failed to parse sequence value");
                 }
               break;
 
             default:
               /* We received a YAML event we shouldn't expect at this level */
-              MMD_YAML_ERROR_RETURN (error,
-                                     "Unexpected YAML event in raw mapping");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Unexpected YAML event in raw mapping");
               break;
             }
 
@@ -137,8 +137,8 @@ parse_raw_yaml_mapping (yaml_parser_t *parser,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error,
-                                 "Unexpected YAML event in raw mapping");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in raw mapping");
           break;
         }
 
@@ -193,21 +193,23 @@ parse_raw_yaml_sequence (yaml_parser_t *parser,
         case YAML_MAPPING_START_EVENT:
           if (!parse_raw_yaml_mapping (parser, &value, error))
             {
-              MMD_YAML_ERROR_RETURN (error, "Failed to parse mapping value");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Failed to parse mapping value");
             }
           break;
 
         case YAML_SEQUENCE_START_EVENT:
           if (!parse_raw_yaml_sequence (parser, &value, error))
             {
-              MMD_YAML_ERROR_RETURN (error, "Failed to parse sequence value");
+              MMD_YAML_ERROR_EVENT_RETURN (
+                error, event, "Failed to parse sequence value");
             }
           break;
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_RETURN (error,
-                                 "Unexpected YAML event in raw sequence");
+          MMD_YAML_ERROR_EVENT_RETURN (
+            error, event, "Unexpected YAML event in raw sequence");
           break;
         }
 
@@ -328,7 +330,7 @@ emit_yaml_variant (yaml_emitter_t *emitter, GVariant *variant, GError **error)
       g_debug ("Unhandled variant type: %s",
                g_variant_get_type_string (variant));
       event.type = YAML_NO_EVENT;
-      MMD_YAML_ERROR_RETURN (error, "Unhandled variant type");
+      MMD_YAML_ERROR_EVENT_RETURN (error, event, "Unhandled variant type");
     }
 
   result = TRUE;

--- a/modulemd/v1/tests/test-modulemd-python.py
+++ b/modulemd/v1/tests/test-modulemd-python.py
@@ -48,7 +48,8 @@ class TestStandard(unittest.TestCase):
             assert failure.props.gerror.code == 3
 
         assert failures[
-            0].props.gerror.message == 'Document type is not recognized'
+            0].props.gerror.message.startswith(
+                'Document type is not recognized [')
         assert failures[
             1].props.gerror.message == 'Document type was specified more than once'
         assert failures[
@@ -56,9 +57,11 @@ class TestStandard(unittest.TestCase):
         assert failures[
             3].props.gerror.message == 'Document type was not a scalar value'
         assert failures[
-            4].props.gerror.message == 'Document type is not recognized'
+            4].props.gerror.message.startswith(
+                'Document type is not recognized [')
         assert failures[
-            5].props.gerror.message == 'Document type is not recognized'
+            5].props.gerror.message.startswith(
+                'Document type is not recognized [')
         assert failures[
             6].props.gerror.message == 'Unknown modulemd defaults version'
 
@@ -79,7 +82,8 @@ class TestStandard(unittest.TestCase):
         assert len(failures) == 1
 
         assert failures[
-            0].props.gerror.message == 'Received scalar where sequence expected'
+            0].props.gerror.message.startswith(
+                'Received scalar where sequence expected [')
 
 
 class TestDefaults(unittest.TestCase):

--- a/modulemd/v1/tests/test-modulemd-yaml.c
+++ b/modulemd/v1/tests/test-modulemd-yaml.c
@@ -447,10 +447,9 @@ modulemd_yaml_test_artifact_validation (YamlFixture *fixture,
   g_assert_null (error);
   g_assert_nonnull (failures);
   g_assert_cmpint (failures->len, ==, 1);
-  g_assert_cmpstr (
+  g_assert_true (g_str_has_prefix (
     modulemd_subdocument_get_gerror (g_ptr_array_index (failures, 0))->message,
-    ==,
-    "RPM artifacts not in NEVRA format");
+    "RPM artifacts not in NEVRA format ["));
 }
 
 


### PR DESCRIPTION
As discussed (and long due), here are changes to the parser which:

1. allow printf-style messages in parsing macros and
2. report line/column numbers on errors

As previously discussed, I've implemented v2 linting in `fedmod`, so removed all changes I wrote for linting in `modulemd-validator`. Therefore the patch for printf-style messages is currently unused but I left it in anyway because it's userful on its own.