### PR TITLE
Run tests against installed libraries, too

### DIFF
--- a/.travis/travis-tasks.sh
+++ b/.travis/travis-tasks.sh
@@ -25,4 +25,26 @@ pushd coverity
 
 popd #coverity
 
+
+# Always install and run the installed RPM tests last so we don't pollute the
+# testing environment above.
+
+meson --buildtype=debug build_rpm
+pushd build_rpm
+
+ninja
+./make_rpms.sh
+dnf -y install rpmbuild/RPMS/*/*.rpm
+
+popd #build_rpm
+
+
+meson --buildtype=debug -Dtest_installed_lib=true installed_lib_tests
+pushd installed_lib_tests
+
+# Run the tests against the installed RPMs
+ninja test
+
+popd #installed_lib_tests
+
 popd #builddir

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -22,6 +22,7 @@ RUN dnf -y --setopt=install_weak_deps=False install \
 	python3-GitPython \
 	python3-gobject-base \
 	redhat-rpm-config \
+	rpm-build \
 	ruby \
 	"rubygem(json)" \
 	rubygems \

--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -31,6 +31,7 @@ more details.
 
 %package -n python3-%{name}
 Summary: Python 3 bindings for %{name}
+BuildArch: noarch
 Requires: libmodulemd = %{version}-%{release}
 Requires: python3-gobject-base
 Obsoletes: python3-modulemd < 1.3.4

--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -1,0 +1,105 @@
+Name:           libmodulemd
+Version:        @VERSION@
+Release:        0%{?dist}.@DATETIME@
+Summary:        Module metadata manipulation library
+
+License:        MIT
+URL:            https://github.com/fedora-modularity/libmodulemd
+Source0:        %{url}/releases/download/%{name}-%{version}/modulemd-%{version}.tar.xz
+
+BuildRequires:  meson
+BuildRequires:  pkgconfig
+BuildRequires:  gcc
+BuildRequires:  pkgconfig(gobject-2.0)
+BuildRequires:  pkgconfig(gobject-introspection-1.0)
+BuildRequires:  pkgconfig(yaml-0.1)
+BuildRequires:  pkgconfig(gtk-doc)
+BuildRequires:  python3-gobject-base
+BuildRequires:  valgrind
+
+Obsoletes:      python2-modulemd < 1.3.4
+
+
+# Patches
+
+
+%description
+C Library for manipulating module metadata files.
+See https://github.com/fedora-modularity/libmodulemd/blob/master/README.md for
+more details.
+
+
+%package -n python3-%{name}
+Summary: Python 3 bindings for %{name}
+Requires: libmodulemd = %{version}-%{release}
+Requires: python3-gobject-base
+Obsoletes: python3-modulemd < 1.3.4
+
+%description -n python3-%{name}
+Python 3 bindings for %{name}
+
+Also provides utility module ModulemdUtils.
+
+
+%package devel
+Summary:        Development files for libmodulemd
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+
+%description devel
+Development files for libmodulemd.
+
+
+%prep
+%autosetup -p1 -n modulemd-%{version}
+
+
+%build
+%meson -Ddeveloper_build=false
+%meson_build
+
+
+%check
+
+export LC_CTYPE=C.utf8
+
+%ifarch %{power64}
+# Valgrind is broken on ppc64[le] with GCC7:
+# https://bugs.kde.org/show_bug.cgi?id=386945
+export MMD_SKIP_VALGRIND=1
+%endif
+
+%meson_test
+
+
+%install
+%meson_install
+
+
+%ldconfig_scriptlets
+
+
+%files
+%license COPYING
+%doc README.md
+%{_bindir}/modulemd-validator
+%{_libdir}/%{name}.so.1*
+%dir %{_libdir}/girepository-1.0
+%{_libdir}/girepository-1.0/Modulemd-1.0.typelib
+
+
+%files -n python3-%{name}
+
+
+%files devel
+%{_libdir}/%{name}.so
+%{_libdir}/pkgconfig/modulemd.pc
+%{_includedir}/modulemd/
+%dir %{_datadir}/gir-1.0
+%{_datadir}/gir-1.0/Modulemd-1.0.gir
+%dir %{_datadir}/gtk-doc
+%dir %{_datadir}/gtk-doc/html
+%{_datadir}/gtk-doc/html/modulemd-1.0/
+
+
+%changelog

--- a/make_rpms.sh.in
+++ b/make_rpms.sh.in
@@ -1,0 +1,11 @@
+#!/usr/bin/sh
+
+set -e
+
+echo "Creating tarball. This may take a while."
+
+MMD_SKIP_VALGRIND=True ninja dist > /dev/null
+
+ln -sf ../meson-dist/ ./rpmbuild/SOURCES
+
+rpmbuild @BUILDFLAG@ libmodulemd.spec --define "_topdir $(pwd)/rpmbuild"

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,19 @@ spec_tmpl = find_program('spec_tmpl.sh')
 
 specfile_template = files('libmodulemd.spec.in')
 
+mkdir = find_program('mkdir')
+
+rpmsetup_target = custom_target(
+    'rpmsetup',
+    command: [
+        mkdir, '-p',
+        'rpmbuild/BUILD',
+        'rpmbuild/RPMS',
+        'rpmbuild/SPECS',
+        'rpmbuild/SRPMS'],
+    output: 'rpmbuild',
+)
+
 spec_target = custom_target(
     'specfile',
     capture: true,
@@ -62,6 +75,27 @@ spec_target = custom_target(
     command: [spec_tmpl, meson.project_version(), '@INPUT@'],
     input: specfile_template,
     output: 'libmodulemd.spec',
+    depends: rpmsetup_target,
+)
+
+rpm_cdata = configuration_data()
+rpm_cdata.set('VERSION', meson.project_version())
+rpm_cdata.set('BUILDFLAG', '-bb')
+
+srpm_cdata = configuration_data()
+srpm_cdata.set('VERSION', meson.project_version())
+srpm_cdata.set('BUILDFLAG', '-bs')
+
+configure_file(
+    input: 'make_rpms.sh.in',
+    output: 'make_srpm.sh',
+    configuration: srpm_cdata,
+)
+
+configure_file(
+    input: 'make_rpms.sh.in',
+    output: 'make_rpms.sh',
+    configuration: rpm_cdata,
 )
 
 subdir('modulemd')

--- a/meson.build
+++ b/meson.build
@@ -51,4 +51,17 @@ gobject = dependency('gobject-2.0')
 yaml = dependency('yaml-0.1')
 gtkdoc = dependency('gtk-doc')
 
+spec_tmpl = find_program('spec_tmpl.sh')
+
+specfile_template = files('libmodulemd.spec.in')
+
+spec_target = custom_target(
+    'specfile',
+    capture: true,
+    build_always: true,
+    command: [spec_tmpl, meson.project_version(), '@INPUT@'],
+    input: specfile_template,
+    output: 'libmodulemd.spec',
+)
+
 subdir('modulemd')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,3 +12,4 @@
 option('developer_build', type : 'boolean', value : true)
 option('build_api_v1', type : 'boolean', value : true)
 option('test_dirty_git', type : 'boolean', value : false)
+option('test_installed_lib', type: 'boolean', value : false)

--- a/modulemd/v1/meson.build
+++ b/modulemd/v1/meson.build
@@ -47,22 +47,16 @@ install_headers(
   subdir : v1_header_path,
 )
 
-# Test env with fatal warnings and criticals
-test_env = environment()
-test_env.set('G_DEBUG', 'fatal-warnings,fatal-criticals')
-test_env.set('G_MESSAGES_DEBUG', 'all')
-test_env.set ('MESON_SOURCE_ROOT', meson.source_root())
-test_env.set ('GI_TYPELIB_PATH', meson.build_root() + '/modulemd/v1')
-test_env.set ('MODULEMD_VERSION', libmodulemd_version)
-test_env.set ('LD_LIBRARY_PATH', meson.build_root() + '/modulemd/v1')
 
 # Test env with release values
 test_release_env = environment()
 test_release_env.set('G_MESSAGES_DEBUG', 'all')
 test_release_env.set ('MESON_SOURCE_ROOT', meson.source_root())
-test_release_env.set ('GI_TYPELIB_PATH', meson.build_root() + '/modulemd/v1')
-test_release_env.set ('MODULEMD_VERSION', libmodulemd_version)
-test_release_env.set ('LD_LIBRARY_PATH', meson.build_root() + '/modulemd/v1')
+
+
+# Test env with fatal warnings and criticals
+test_env = test_release_env
+test_env.set('G_DEBUG', 'fatal-warnings,fatal-criticals')
 
 test_v1_modulemd_buildopts = executable(
     'test_v1_modulemd_buildopts',
@@ -255,12 +249,22 @@ test('test_v1_modulemd_yaml', test_v1_modulemd_yaml,
 test('test_v1_release_modulemd_yaml', test_v1_modulemd_yaml,
      env : test_release_env)
 
+# Test env with fatal warnings and criticals
+py_test_env = test_env
+py_test_env.set ('GI_TYPELIB_PATH', meson.build_root() + '/modulemd/v1')
+py_test_env.set ('MODULEMD_VERSION', libmodulemd_version)
+py_test_env.set ('LD_LIBRARY_PATH', meson.build_root() + '/modulemd/v1')
+
+# Test env with release values
+py_test_release_env = py_test_env
+py_test_release_env.set('G_DEBUG', 'fatal-warnings,fatal-criticals')
+
 modulemd_python_scripts = files('tests/test-modulemd-python.py')
 test ('test_v1_modulemd_python', python3,
-      env : test_env,
+      env : py_test_env,
       args : modulemd_python_scripts)
 test ('test_v1_release_modulemd_python', python3,
-      env : test_release_env,
+      env : py_test_release_env,
       args : modulemd_python_scripts)
 
 import_header_script = find_program('tests/test-import-headers.sh')

--- a/modulemd/v1/meson.build
+++ b/modulemd/v1/meson.build
@@ -54,7 +54,6 @@ test_env.set('G_MESSAGES_DEBUG', 'all')
 test_env.set ('MESON_SOURCE_ROOT', meson.source_root())
 test_env.set ('GI_TYPELIB_PATH', meson.build_root() + '/modulemd/v1')
 test_env.set ('MODULEMD_VERSION', libmodulemd_version)
-test_env.set ('MODULEMD_NSVERSION', '.'.join([libmodulemd_version_array[0], '0']))
 test_env.set ('LD_LIBRARY_PATH', meson.build_root() + '/modulemd/v1')
 
 # Test env with release values
@@ -63,7 +62,6 @@ test_release_env.set('G_MESSAGES_DEBUG', 'all')
 test_release_env.set ('MESON_SOURCE_ROOT', meson.source_root())
 test_release_env.set ('GI_TYPELIB_PATH', meson.build_root() + '/modulemd/v1')
 test_release_env.set ('MODULEMD_VERSION', libmodulemd_version)
-test_release_env.set ('MODULEMD_NSVERSION', '.'.join([libmodulemd_version_array[0], '0']))
 test_release_env.set ('LD_LIBRARY_PATH', meson.build_root() + '/modulemd/v1')
 
 test_v1_modulemd_buildopts = executable(

--- a/modulemd/v1/meson.build
+++ b/modulemd/v1/meson.build
@@ -9,6 +9,16 @@
 # For more information on the license, see COPYING.
 # For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
 
+test_installed_lib = get_option('test_installed_lib')
+
+if test_installed_lib
+    # If we're just running the tests on a library that's already installed,
+    # don't bother building it again.
+    build_lib = disabler()
+else
+    build_lib = declare_dependency()
+endif
+
 modulemd_v1_lib = library(
     'modulemd',
     sources : modulemd_v1_srcs,
@@ -16,19 +26,31 @@ modulemd_v1_lib = library(
     dependencies : [
         gobject,
         yaml,
+        build_lib,
     ],
     install : true,
     soversion: libmodulemd_version_array[0],
     version: libmodulemd_version,
 )
 
-modulemd_v1_dep = declare_dependency(
-    include_directories : v1_include_dirs,
-    link_with : modulemd_v1_lib,
-    dependencies : [
-        gobject,
-    ]
-)
+if test_installed_lib
+    # Run tests against an installed library instead of in-tree
+    modulemd_v1_dep = declare_dependency(
+        include_directories : v1_include_dirs,
+        dependencies : [
+            gobject,
+            dependency('modulemd'),
+        ]
+    )
+else
+    modulemd_v1_dep = declare_dependency(
+        include_directories : v1_include_dirs,
+        link_with : modulemd_v1_lib,
+        dependencies : [
+            gobject,
+        ]
+    )
+endif
 
 
 modulemd_validator = executable(
@@ -66,6 +88,7 @@ test_v1_modulemd_buildopts = executable(
     ],
     install : false,
 )
+
 test('test_v1_modulemd_buildopts', test_v1_modulemd_buildopts,
      env : test_env)
 test('test_v1_release_modulemd_buildopts', test_v1_modulemd_buildopts,
@@ -251,9 +274,17 @@ test('test_v1_release_modulemd_yaml', test_v1_modulemd_yaml,
 
 # Test env with fatal warnings and criticals
 py_test_env = test_env
-py_test_env.set ('GI_TYPELIB_PATH', meson.build_root() + '/modulemd/v1')
-py_test_env.set ('MODULEMD_VERSION', libmodulemd_version)
-py_test_env.set ('LD_LIBRARY_PATH', meson.build_root() + '/modulemd/v1')
+
+if not test_installed_lib
+    # If we're testing an installed version, we want to use the default
+    # locations for these paths.
+    py_test_env.set ('GI_TYPELIB_PATH', meson.build_root() + '/modulemd/v1')
+    py_test_env.set ('LD_LIBRARY_PATH', meson.build_root() + '/modulemd/v1')
+
+    # This test is just to catch whether we are accidentally not testing
+    # the built version.
+    py_test_env.set ('MODULEMD_VERSION', libmodulemd_version)
+endif
 
 # Test env with release values
 py_test_release_env = py_test_env

--- a/modulemd/v1/tests/test-modulemd-defaults.c
+++ b/modulemd/v1/tests/test-modulemd-defaults.c
@@ -412,6 +412,7 @@ modulemd_defaults_test_copy (DefaultsFixture *fixture, gconstpointer user_data)
                                g_getenv ("MESON_SOURCE_ROOT"));
   g_assert_nonnull (yaml_path);
   orig = modulemd_defaults_new_from_file (yaml_path, &error);
+  g_assert_nonnull (orig);
 
   copy = modulemd_defaults_copy (orig);
   g_assert_nonnull (copy);

--- a/modulemd/v1/tests/test-modulemd-python.py
+++ b/modulemd/v1/tests/test-modulemd-python.py
@@ -31,7 +31,8 @@ class TestStandard(unittest.TestCase):
 
     def test_version(self):
         # Make sure that we are linking against the correct version
-        assert os.getenv('MODULEMD_VERSION') == Modulemd.get_version()
+        expected_version = os.getenv('MODULEMD_VERSION')
+        assert expected_version is None or expected_version == Modulemd.get_version()
 
     def test_failures(self):
         (objects, failures) = Modulemd.objects_from_file_ext(

--- a/modulemd/v1/tests/test-modulemd-python.py
+++ b/modulemd/v1/tests/test-modulemd-python.py
@@ -18,7 +18,7 @@ import sys
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', os.getenv('MODULEMD_NSVERSION'))
+    gi.require_version('Modulemd', '1.0')
     from gi.repository import Modulemd
     from gi.repository import GLib
 except ImportError:

--- a/spec_tmpl.sh
+++ b/spec_tmpl.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/sh
+
+version=$1
+template=$2
+datetime=$(date +%Y%m%d%H%M%S)
+
+sed -e "s/@VERSION@/$1/" -e "s/@DATETIME@/$datetime/" $2


### PR DESCRIPTION
Many changes to enable running the unit tests against a library installed on the local system (rather than the in-tree build).

Also extends the Travis test suite to install a set of built RPMs and run the tests against them.

This pull request is mainly to validate that the Travis suite works properly in production.