### PR TITLE
modulemd-yaml-parser: error is not set though it's expected

### DIFF
--- a/modulemd/v1/modulemd-yaml-parser.c
+++ b/modulemd/v1/modulemd-yaml-parser.c
@@ -434,8 +434,8 @@ _parse_yaml (yaml_parser_t *parser,
 
         default:
           /* We received a YAML event we shouldn't expect at this level */
-          MMD_YAML_ERROR_EVENT_RETURN_RETHROW (
-            error, event, "Unexpected YAML event during preprocessing");
+          MMD_YAML_ERROR_RETURN (
+            error, "Unexpected YAML event during preprocessing");
           break;
         }
 


### PR DESCRIPTION
When parsing the YAML file in _parse_yaml, if an unexpected event is
received, no error is set by YAML_PARSER_PARSE_WITH_ERROR_RETURN (if it
was, it would have already goto "error" label) but
MMD_YAML_ERROR_EVENT_RETURN_RETHROW was used. This means in some cases
`error` could be NULL, though the caller expect it to be set when the
result of the function is false.