### PR TITLE
yaml-emitter-modulemd: name/description are automatically freed

### DIFF
--- a/modulemd/v1/modulemd-yaml-emitter-modulemd.c
+++ b/modulemd/v1/modulemd-yaml-emitter-modulemd.c
@@ -949,8 +949,6 @@ _emit_modulemd_profile_entry (yaml_emitter_t *emitter,
 
   result = TRUE;
 error:
-  g_free (name);
-  g_free (description);
   return result;
 }
 


### PR DESCRIPTION
name/description in _emit_modulemd_profile_entry are marked with
g_autofree, which calls g_free when the function exits, so there's no
need to manually call g_free.