### PR TITLE
Fixes to re-enable CI tests against libmodulemd 2.0+

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -6,6 +6,7 @@ ARG TARBALL
 
 RUN dnf -y --setopt=install_weak_deps=False install \
 	clang \
+	createrepo_c \
 	curl \
 	gcc \
 	git-core \

--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -1,5 +1,8 @@
+%global libmodulemd_version @VERSION@
+%global libmodulemd_v1_version @V1_VERSION@
+
 Name:           libmodulemd
-Version:        @VERSION@
+Version:        %{libmodulemd_version}
 Release:        0%{?dist}.@DATETIME@
 Summary:        Module metadata manipulation library
 
@@ -39,8 +42,6 @@ Obsoletes: python3-modulemd < 1.3.4
 %description -n python3-%{name}
 Python 3 bindings for %{name}
 
-Also provides utility module ModulemdUtils.
-
 
 %package devel
 Summary:        Development files for libmodulemd
@@ -51,12 +52,48 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 Development files for libmodulemd.
 
 
+%package -n compat-libmodulemd1
+Summary: Compatibility package for libmodulemd 1.x
+Version: %{libmodulemd_v1_version}
+Obsoletes: libmodulemd < 2
+Provides: libmodulemd = %{libmodulemd_v1_version}-%{release}
+Provides: libmodulemd%{?_isa} = %{libmodulemd_v1_version}-%{release}
+
+%description -n compat-libmodulemd1
+Compatibility library for libmodulemd 1.x
+
+
+%package -n compat-libmodulemd1-devel
+Summary: Compatibility development package for libmodulemd 1.x
+Version: %{libmodulemd_v1_version}
+Requires: compat-libmodulemd1 = %{version}-%{release}
+Conflicts: %{name}-devel
+Obsoletes: libmodulemd-devel < 2
+Provides: libmodulemd-devel = %{version}-%{release}
+RemovePathPostfixes: .compat
+
+
+%description -n compat-libmodulemd1-devel
+Development files for libmodulemd 1.x
+
+
+%package -n python3-compat-libmodulemd1
+Summary: Python 3 bindings for %{name}
+Version: %{libmodulemd_v1_version}
+BuildArch: noarch
+Requires: compat-libmodulemd1 = %{version}-%{release}
+Requires: python3-gobject-base
+
+%description -n python3-compat-libmodulemd1
+Python 3 bindings for compat-libmodulemd1
+
+
 %prep
-%autosetup -p1 -n modulemd-%{version}
+%autosetup -p1 -n modulemd-%{libmodulemd_version}
 
 
 %build
-%meson -Ddeveloper_build=false
+%meson -Ddeveloper_build=false -Dbuild_api_v1=true -Dbuild_api_v2=true
 %meson_build
 
 
@@ -76,31 +113,51 @@ export MMD_SKIP_VALGRIND=1
 %install
 %meson_install
 
-
-%ldconfig_scriptlets
+ln -s libmodulemd.so.%{libmodulemd_v1_version} \
+      %{buildroot}%{_libdir}/%{name}.so.compat
 
 
 %files
 %license COPYING
 %doc README.md
 %{_bindir}/modulemd-validator
+%{_libdir}/%{name}.so.2*
+%dir %{_libdir}/girepository-1.0
+%{_libdir}/girepository-1.0/Modulemd-2.0.typelib
+
+%files devel
+%{_libdir}/%{name}.so
+%{_libdir}/pkgconfig/modulemd-2.0.pc
+%{_includedir}/modulemd-2.0/
+%dir %{_datadir}/gir-1.0
+%{_datadir}/gir-1.0/Modulemd-2.0.gir
+%dir %{_datadir}/gtk-doc
+%dir %{_datadir}/gtk-doc/html
+%{_datadir}/gtk-doc/html/modulemd-2.0/
+
+
+%files -n python3-%{name}
+
+%files -n python3-compat-libmodulemd1
+
+%files -n compat-libmodulemd1
+%license COPYING
+%doc README.md
 %{_libdir}/%{name}.so.1*
 %dir %{_libdir}/girepository-1.0
 %{_libdir}/girepository-1.0/Modulemd-1.0.typelib
 
 
-%files -n python3-%{name}
 
-
-%files devel
-%{_libdir}/%{name}.so
+%files -n compat-libmodulemd1-devel
+%{_libdir}/%{name}.so.compat
 %{_libdir}/pkgconfig/modulemd.pc
 %{_includedir}/modulemd/
 %dir %{_datadir}/gir-1.0
 %{_datadir}/gir-1.0/Modulemd-1.0.gir
 %dir %{_datadir}/gtk-doc
 %dir %{_datadir}/gtk-doc/html
-%{_datadir}/gtk-doc/html/modulemd/
+%{_datadir}/gtk-doc/html/modulemd-1.0/
 
 
 %changelog

--- a/make_rpms.sh.in
+++ b/make_rpms.sh.in
@@ -1,5 +1,8 @@
 #!/usr/bin/sh
 
+# optionally call this function with --nocheck to skip the test suite while
+# building RPMs.
+
 set -e
 
 echo "Creating tarball. This may take a while."
@@ -8,4 +11,4 @@ MMD_SKIP_VALGRIND=True ninja dist > /dev/null
 
 ln -sf ../meson-dist/ ./rpmbuild/SOURCES
 
-rpmbuild @BUILDFLAG@ libmodulemd.spec --define "_topdir $(pwd)/rpmbuild"
+rpmbuild @BUILDFLAG@ $1 libmodulemd.spec --define "_topdir $(pwd)/rpmbuild"

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,8 @@ project('modulemd', 'c',
         license : 'MIT',
         meson_version : '>=0.44.0')
 
+libmodulemd_v1_version = '1.7.1'
+
 cc = meson.get_compiler('c')
 test_cflags = [
   '-Wpointer-arith',
@@ -75,7 +77,10 @@ spec_target = custom_target(
     'specfile',
     capture: true,
     build_always: true,
-    command: [sh, spec_tmpl, meson.project_version(), '@INPUT@'],
+    command: [sh, spec_tmpl,
+              meson.project_version(),
+              libmodulemd_v1_version,
+              '@INPUT@'],
     input: specfile_template,
     output: 'libmodulemd.spec',
     depends: rpmsetup_target,
@@ -83,10 +88,12 @@ spec_target = custom_target(
 
 rpm_cdata = configuration_data()
 rpm_cdata.set('VERSION', meson.project_version())
+rpm_cdata.set('V1_VERSION', libmodulemd_v1_version)
 rpm_cdata.set('BUILDFLAG', '-bb')
 
 srpm_cdata = configuration_data()
 srpm_cdata.set('VERSION', meson.project_version())
+srpm_cdata.set('V1_VERSION', libmodulemd_v1_version)
 srpm_cdata.set('BUILDFLAG', '-bs')
 
 configure_file(

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -115,8 +115,6 @@ test_v1_srcs = files(
     'v1/tests/test-modulemd-yaml.c',
 )
 
-libmodulemd_v1_version = '1.7.0'
-
 
 modulemd_v2_srcs = files(
     'v2/modulemd-service-level.c',

--- a/modulemd/v2/meson.build
+++ b/modulemd/v2/meson.build
@@ -40,9 +40,9 @@ if test_installed_lib
         include_directories : v2_include_dirs,
         dependencies : [
             gobject,
+            yaml,
             dependency(
-                'modulemd',
-                version: ['>= 2.0.0', '< 3.0.0']
+                'modulemd-2.0',
             ),
         ]
     )
@@ -156,8 +156,8 @@ pkg.generate(
     libraries : modulemd_v2_lib,
     subdirs : v2_header_path,
     version : libmodulemd_v2_version,
-    name : 'modulemd',
-    filebase : 'modulemd',
+    name : 'modulemd-2.0',
+    filebase : 'modulemd-2.0',
     description : 'Module metadata manipulation library',
     requires: [ 'glib-2.0', 'gobject-2.0' ],
 )

--- a/spec_tmpl.sh
+++ b/spec_tmpl.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/sh
 
 version=$1
-template=$2
+libmodulemd_v1_version=$2
+template=$3
 datetime=$(date +%Y%m%d%H%M%S)
 
-sed -e "s/@VERSION@/$1/" -e "s/@DATETIME@/$datetime/" $2
+sed -e "s/@VERSION@/$version/" \
+    -e "s/@V1_VERSION@/$libmodulemd_v1_version/" \
+    -e "s/@DATETIME@/$datetime/" $template


### PR DESCRIPTION
These patches fix the pkgconfig setup, add the compat subpackages to the RPM spec and finally update the Travis tasks to run both v1 and v2 tests.

I will merge these assuming the CI test run associated with this PR passes successfully.