### PR TITLE
Rename ServiceLevel.get_eol_string() to ServiceLevel.get_eol_as_string()

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-service-level.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-service-level.h
@@ -127,7 +127,7 @@ GDate *
 modulemd_service_level_get_eol (ModulemdServiceLevel *self);
 
 /**
- * modulemd_service_level_get_eol_string:
+ * modulemd_service_level_get_eol_as_string:
  * @self: This #ModulemdServiceLevel
  *
  * Returns: (transfer full) (nullable): The end date of the service level as a
@@ -136,7 +136,7 @@ modulemd_service_level_get_eol (ModulemdServiceLevel *self);
  * Since: 2.0
  */
 gchar *
-modulemd_service_level_get_eol_string (ModulemdServiceLevel *self);
+modulemd_service_level_get_eol_as_string (ModulemdServiceLevel *self);
 
 
 G_END_DECLS

--- a/modulemd/v2/modulemd-service-level.c
+++ b/modulemd/v2/modulemd-service-level.c
@@ -174,7 +174,7 @@ modulemd_service_level_get_eol (ModulemdServiceLevel *self)
 
 
 gchar *
-modulemd_service_level_get_eol_string (ModulemdServiceLevel *self)
+modulemd_service_level_get_eol_as_string (ModulemdServiceLevel *self)
 {
   if (self->eol && g_date_valid (self->eol))
     {
@@ -404,7 +404,7 @@ modulemd_service_level_emit_yaml (ModulemdServiceLevel *self,
           return FALSE;
         }
 
-      eol_string = modulemd_service_level_get_eol_string (self);
+      eol_string = modulemd_service_level_get_eol_as_string (self);
       ret = mmd_emitter_scalar (
         emitter, eol_string, YAML_PLAIN_SCALAR_STYLE, &nested_error);
       if (!ret)

--- a/modulemd/v2/tests/ModulemdTests/servicelevel.py
+++ b/modulemd/v2/tests/ModulemdTests/servicelevel.py
@@ -36,7 +36,7 @@ class TestServiceLevel(unittest.TestCase):
         assert sl.get_name() == 'foo'
         assert sl.props.eol is None
         assert sl.get_eol() is None
-        assert sl.get_eol_string() is None
+        assert sl.get_eol_as_string() is None
 
         # Test that standard object instatiation works with a name
         sl = Modulemd.ServiceLevel(name='foo')
@@ -45,7 +45,7 @@ class TestServiceLevel(unittest.TestCase):
         assert sl.get_name() == 'foo'
         assert sl.props.eol is None
         assert sl.get_eol() is None
-        assert sl.get_eol_string() is None
+        assert sl.get_eol_as_string() is None
 
         # Test that standard object instantiation works with a name and EOL
         sl = Modulemd.ServiceLevel(
@@ -62,8 +62,8 @@ class TestServiceLevel(unittest.TestCase):
         assert sl.get_eol().get_day() == 7
         assert sl.get_eol().get_month() == 11
         assert sl.get_eol().get_year() == 2018
-        assert sl.get_eol_string() is not None
-        assert sl.get_eol_string() == '2018-11-07'
+        assert sl.get_eol_as_string() is not None
+        assert sl.get_eol_as_string() == '2018-11-07'
 
         # Test that we fail if we call new() with a None name
         try:
@@ -88,7 +88,7 @@ class TestServiceLevel(unittest.TestCase):
         assert sl.get_name() == 'foo'
         assert sl.props.eol is None
         assert sl.get_eol() is None
-        assert sl.get_eol_string() is None
+        assert sl.get_eol_as_string() is None
 
         sl_copy = sl.copy()
         assert sl_copy
@@ -96,7 +96,7 @@ class TestServiceLevel(unittest.TestCase):
         assert sl_copy.get_name() == 'foo'
         assert sl_copy.props.eol is None
         assert sl_copy.get_eol() is None
-        assert sl_copy.get_eol_string() is None
+        assert sl_copy.get_eol_as_string() is None
 
         sl.set_eol_ymd(2018, 11, 13)
         sl_copy = sl.copy()
@@ -105,7 +105,7 @@ class TestServiceLevel(unittest.TestCase):
         assert sl_copy.get_name() == 'foo'
         assert sl_copy.props.eol is not None
         assert sl_copy.get_eol() is not None
-        assert sl_copy.get_eol_string() == '2018-11-13'
+        assert sl_copy.get_eol_as_string() == '2018-11-13'
 
     def test_get_name(self):
         sl = Modulemd.ServiceLevel.new('foo')
@@ -134,7 +134,7 @@ class TestServiceLevel(unittest.TestCase):
             assert returned_eol.get_day() == eol.get_day()
             assert returned_eol.get_month() == eol.get_month()
             assert returned_eol.get_year() == eol.get_year()
-        assert sl.get_eol_string() == '2018-11-07'
+        assert sl.get_eol_as_string() == '2018-11-07'
 
         # Test the set_eol_ymd() method
         sl.set_eol_ymd(2019, 12, 3)
@@ -144,7 +144,7 @@ class TestServiceLevel(unittest.TestCase):
             assert returned_eol.get_day() == 3
             assert returned_eol.get_month() == 12
             assert returned_eol.get_year() == 2019
-        assert sl.get_eol_string() == '2019-12-03'
+        assert sl.get_eol_as_string() == '2019-12-03'
 
         # Try setting some invalid dates
         # An initialized but unset date

--- a/modulemd/v2/tests/test-modulemd-service-level.c
+++ b/modulemd/v2/tests/test-modulemd-service-level.c
@@ -138,7 +138,7 @@ service_level_test_copy (ServiceLevelFixture *fixture, gconstpointer user_data)
   g_assert_true (MODULEMD_IS_SERVICE_LEVEL (sl_copy));
   g_assert_cmpstr (modulemd_service_level_get_name (sl_copy), ==, "foo");
   g_assert_nonnull (modulemd_service_level_get_eol (sl_copy));
-  eol_string = modulemd_service_level_get_eol_string (sl_copy);
+  eol_string = modulemd_service_level_get_eol_as_string (sl_copy);
   g_assert_cmpstr (eol_string, ==, "2018-11-13");
 }
 
@@ -201,7 +201,7 @@ service_level_test_get_set_eol (ServiceLevelFixture *fixture,
 
   /* Test that get_eol() returns NULL at first */
   g_assert_null (modulemd_service_level_get_eol (sl));
-  g_assert_null (modulemd_service_level_get_eol_string (sl));
+  g_assert_null (modulemd_service_level_get_eol_as_string (sl));
 
 
   /* Test looking up the EOL by object properties returns NULL */
@@ -232,7 +232,7 @@ service_level_test_get_set_eol (ServiceLevelFixture *fixture,
   g_assert_cmpint (g_date_compare (eol, copied_eol), ==, 0);
   g_clear_pointer (&copied_eol, g_date_free);
 
-  eol_string = modulemd_service_level_get_eol_string (sl);
+  eol_string = modulemd_service_level_get_eol_as_string (sl);
   g_assert_nonnull (eol_string);
   g_assert_cmpstr (eol_string, ==, "2018-11-07");
   g_clear_pointer (&eol_string, g_free);
@@ -256,7 +256,7 @@ service_level_test_get_set_eol (ServiceLevelFixture *fixture,
   g_assert_cmpint (g_date_compare (eol, copied_eol), ==, 0);
   g_clear_pointer (&copied_eol, g_date_free);
 
-  eol_string = modulemd_service_level_get_eol_string (sl);
+  eol_string = modulemd_service_level_get_eol_as_string (sl);
   g_assert_nonnull (eol_string);
   g_assert_cmpstr (eol_string, ==, "2018-11-07");
   g_clear_pointer (&eol_string, g_free);
@@ -285,7 +285,7 @@ service_level_test_get_set_eol (ServiceLevelFixture *fixture,
   modulemd_service_level_set_eol_ymd (sl, 2018, 11, 7);
   returned_eol = modulemd_service_level_get_eol (sl);
   g_assert_nonnull (returned_eol);
-  eol_string = modulemd_service_level_get_eol_string (sl);
+  eol_string = modulemd_service_level_get_eol_as_string (sl);
   g_assert_nonnull (eol_string);
   g_assert_cmpstr (eol_string, ==, "2018-11-07");
   g_clear_pointer (&eol_string, g_free);


### PR DESCRIPTION
The original name violated libmodulemd's API convention that functions which
allocate the return value should be suffixed with "as_<type>".

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>