### PR TITLE
Add Modulemd.Defaults objects

### DIFF
--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -117,6 +117,8 @@ test_v1_srcs = files(
 
 
 modulemd_v2_srcs = files(
+    'v2/modulemd-defaults.c',
+    'v2/modulemd-defaults-v1.c',
     'v2/modulemd-profile.c',
     'v2/modulemd-service-level.c',
     'v2/modulemd-translation-entry.c',
@@ -125,6 +127,8 @@ modulemd_v2_srcs = files(
 )
 
 modulemd_v2_hdrs = files(
+    'v2/include/modulemd-2.0/modulemd-defaults.h',
+    'v2/include/modulemd-2.0/modulemd-defaults-v1.h',
     'v2/include/modulemd-2.0/modulemd-profile.h',
     'v2/include/modulemd-2.0/modulemd-service-level.h',
     'v2/include/modulemd-2.0/modulemd-translation-entry.h',
@@ -140,6 +144,7 @@ modulemd_v2_priv_hdrs = files(
 )
 
 test_v2_srcs = files(
+    'v2/tests/test-modulemd-defaults.c',
     'v2/tests/test-modulemd-profile.c',
     'v2/tests/test-modulemd-service-level.c',
     'v2/tests/test-modulemd-translation-entry.c',
@@ -152,6 +157,7 @@ test_v2_priv_hdrs = files(
 
 test_v2_python_scripts = files(
     'v2/tests/ModulemdTests/base.py',
+    'v2/tests/ModulemdTests/defaults.py',
     'v2/tests/ModulemdTests/profile.py',
     'v2/tests/ModulemdTests/servicelevel.py',
     'v2/tests/ModulemdTests/translationentry.py',

--- a/modulemd/v2/include/modulemd-2.0/modulemd-defaults-v1.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-defaults-v1.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2017-2018 Stephen Gallagher
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#pragma once
+
+#include <glib-object.h>
+#include "modulemd-defaults.h"
+
+G_BEGIN_DECLS
+
+/**
+ * SECTION: modulemd-defaults-v1
+ * @title: Modulemd.DefaultsV1
+ * @short_description: Object representing a defaults document (version 1)
+ */
+
+#define MODULEMD_TYPE_DEFAULTS_V1 (modulemd_defaults_v1_get_type ())
+
+G_DECLARE_FINAL_TYPE (ModulemdDefaultsV1,
+                      modulemd_defaults_v1,
+                      MODULEMD,
+                      DEFAULTS_V1,
+                      ModulemdDefaults)
+
+
+/**
+ * modulemd_defaults_v1_new:
+ * @module_name: (in): The name of the module to which these defaults apply.
+ *
+ * Returns: (transfer full): A newly-allocated #ModulemdDefaultsV1 object.
+ *
+ * Since: 2.0
+ */
+ModulemdDefaultsV1 *
+modulemd_defaults_v1_new (const gchar *module_name);
+
+G_END_DECLS

--- a/modulemd/v2/include/modulemd-2.0/modulemd-defaults.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-defaults.h
@@ -1,0 +1,152 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2017-2018 Stephen Gallagher
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+
+/**
+ * SECTION: modulemd-defaults
+ * @title: Modulemd.Defaults
+ * @short_description: Parent class for Default documents.
+ * See #ModulemdDefaultsV1 for a specific type.
+ */
+
+/**
+ * ModulemdDefaultsVersionEnum:
+ * @MD_DEFAULTS_VERSION_ONE: Represents v1 of the #Modulemd.Defaults metadata
+ * format.
+ * @MD_DEFAULTS_VERSION_LATEST: Represents the highest-supported version of the
+ * #Modulemd.Defaults metadata format.
+ *
+ * Since: 2.0
+ */
+typedef enum
+{
+  MD_DEFAULTS_VERSION_UNSET = 0,
+
+  MD_DEFAULTS_VERSION_ONE = 1,
+
+  MD_DEFAULTS_VERSION_LATEST = MD_DEFAULTS_VERSION_ONE,
+} ModulemdDefaultsVersionEnum;
+
+
+#define MODULEMD_TYPE_DEFAULTS (modulemd_defaults_get_type ())
+
+G_DECLARE_DERIVABLE_TYPE (
+  ModulemdDefaults, modulemd_defaults, MODULEMD, DEFAULTS, GObject)
+
+struct _ModulemdDefaultsClass
+{
+  GObjectClass parent_class;
+
+  ModulemdDefaults *(*copy) (ModulemdDefaults *self);
+
+  gboolean (*validate) (ModulemdDefaults *self, GError **error);
+
+  guint64 (*get_mdversion) (ModulemdDefaults *self);
+
+  /* Padding to allow adding up to 10 new virtual functions without
+   * breaking ABI. */
+  gpointer padding[10];
+};
+
+
+/**
+ * modulemd_defaults_new:
+ * @version: The version of the defaults metadata to create
+ * @module_name: The name of the module to which these defaults apply
+ *
+ * Create a new #ModulemdDefaults.
+ *
+ * Returns: (transfer full): a newly created #ModulemdDefaults subtype of the
+ * requested version.
+ *
+ * Since: 2.0
+ */
+ModulemdDefaults *
+modulemd_defaults_new (guint64 version, const gchar *module_name);
+
+
+/**
+ * modulemd_defaults_copy:
+ * @self: (in): This #ModulemdDefaults object
+ *
+ * Returns: (transfer full): A newly-allocated copy of @self
+ *
+ * Since: 2.0
+ */
+ModulemdDefaults *
+modulemd_defaults_copy (ModulemdDefaults *self);
+
+
+/**
+ * modulemd_defaults_validate:
+ * @self: (in): This #ModulemdDefaults object
+ * @error: (out):  A #GError that will return the reason for a validation error.
+ *
+ * Returns: TRUE if validation passed, FALSE and sets @error appropriately if
+ * validation failed.
+ *
+ * Since: 2.0
+ */
+gboolean
+modulemd_defaults_validate (ModulemdDefaults *self, GError **error);
+
+
+/**
+ * modulemd_defaults_upgrade:
+ * @self: (in): This #ModulemdDefaults object
+ * @mdversion: (in): The version to upgrade to.
+ * @error: (out):  A #GError that will return the reason for an upgrade error.
+ *
+ * Returns: (transfer full): A newly-allocated copy of @self upgraded to the
+ * requested defaults version. NULL if the upgrade cannot be performed and sets
+ * @error appropriately. This function does not modify @self.
+ *
+ * Since: 2.0
+ */
+ModulemdDefaults *
+modulemd_defaults_upgrade (ModulemdDefaults *self,
+                           guint64 mdversion,
+                           GError **error);
+
+
+/**
+ * modulemd_defaults_get_module_name:
+ * @self: (in): This #ModulemdDefaults object
+ *
+ * Returns: (transfer none): The name of the module to which these defaults
+ * apply.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_defaults_get_module_name (ModulemdDefaults *self);
+
+
+/**
+ * modulemd_defaults_get_mdversion:
+ * @self: (in): This #ModulemdDefaults object
+ *
+ * Returns: The metadata version of this defaults object.
+ *
+ * Since: 2.0
+ */
+guint64
+modulemd_defaults_get_mdversion (ModulemdDefaults *self);
+
+G_END_DECLS

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-util.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-util.h
@@ -26,6 +26,16 @@ G_BEGIN_DECLS
  */
 
 
+#define MODULEMD_ERROR modulemd_error_quark ()
+GQuark
+modulemd_error_quark (void);
+
+enum ModulemdError
+{
+  MODULEMD_ERROR_UPGRADE,
+  MODULEMD_ERROR_VALIDATE
+};
+
 typedef struct _modulemd_tracer
 {
   gchar *function_name;

--- a/modulemd/v2/include/modulemd-2.0/private/test-utils.h
+++ b/modulemd/v2/include/modulemd-2.0/private/test-utils.h
@@ -15,8 +15,29 @@
 
 #include <glib.h>
 #include <locale.h>
+#include <yaml.h>
 
 G_BEGIN_DECLS
+
+typedef struct _CommonMmdTestFixture
+{
+} CommonMmdTestFixture;
+
+extern int modulemd_test_signal;
+
+
+/**
+ * modulemd_test_signal_handler:
+ * @sig_num: The signal received
+ *
+ * Sets the global variable modulemd_test_signal with the value of the signal
+ * that was received.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_test_signal_handler (int sig_num);
+
 
 /**
  * SECTION: test-utils

--- a/modulemd/v2/meson.build
+++ b/modulemd/v2/meson.build
@@ -21,9 +21,11 @@ else
     build_lib = declare_dependency()
 endif
 
+enums = gnome.mkenums_simple ('modulemd-enums', sources : modulemd_v2_hdrs)
+
 modulemd_v2_lib = library(
     'modulemd',
-    sources : modulemd_v2_srcs,
+    sources : modulemd_v2_srcs + enums,
     include_directories : v2_include_dirs,
     dependencies : [
         gobject,
@@ -189,6 +191,33 @@ test ('translation_entry_python_debug', python3,
 test ('translation_entry_python_release', python3,
       env : py_test_release_env,
       args : translation_entry_python_script)
+
+
+# -- Test Modulemd.Defaults (C) -- #
+test_v2_defaults = executable(
+    'defaults_v2',
+    'tests/test-modulemd-defaults.c',
+    dependencies : [
+        modulemd_v2_dep,
+    ],
+    link_with : [
+        test_utils_lib,
+    ],
+    install : false,
+)
+test('defaults_v2_debug', test_v2_defaults,
+     env : test_env)
+test('defaults_v2_release', test_v2_defaults,
+     env : test_release_env)
+
+# -- Test Modulemd.Defaults (Python) -- #
+defaults_python_script = files('tests/ModulemdTests/defaults.py')
+test ('defaults_python_debug', python3,
+      env : py_test_env,
+      args : defaults_python_script)
+test ('defaults_python_release', python3,
+      env : py_test_release_env,
+      args : defaults_python_script)
 
 
 # --- GOBject Introspection -- #

--- a/modulemd/v2/modulemd-defaults-v1.c
+++ b/modulemd/v2/modulemd-defaults-v1.c
@@ -1,0 +1,109 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2017-2018 Stephen Gallagher
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#include "modulemd-defaults-v1.h"
+
+struct _ModulemdDefaultsV1
+{
+  GObject parent_instance;
+};
+
+G_DEFINE_TYPE (ModulemdDefaultsV1,
+               modulemd_defaults_v1,
+               MODULEMD_TYPE_DEFAULTS)
+
+enum
+{
+  PROP_0,
+
+  PROP_DEFAULT_STREAM,
+  PROP_INTENT,
+
+  N_PROPS
+};
+
+static GParamSpec *properties[N_PROPS];
+
+ModulemdDefaultsV1 *
+modulemd_defaults_v1_new (const gchar *module_name)
+{
+  // clang-format off
+  return g_object_new (MODULEMD_TYPE_DEFAULTS_V1,
+                       "module-name", module_name,
+                       NULL);
+  // clang-format on
+}
+
+static void
+modulemd_defaults_v1_finalize (GObject *object)
+{
+  ModulemdDefaultsV1 *self = (ModulemdDefaultsV1 *)object;
+
+  G_OBJECT_CLASS (modulemd_defaults_v1_parent_class)->finalize (object);
+}
+
+static guint64
+modulemd_defaults_v1_get_mdversion (ModulemdDefaults *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_DEFAULTS (self), 0);
+
+  return MD_DEFAULTS_VERSION_ONE;
+}
+
+
+static void
+modulemd_defaults_v1_get_property (GObject *object,
+                                   guint prop_id,
+                                   GValue *value,
+                                   GParamSpec *pspec)
+{
+  ModulemdDefaultsV1 *self = MODULEMD_DEFAULTS_V1 (object);
+
+  switch (prop_id)
+    {
+    default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+modulemd_defaults_v1_set_property (GObject *object,
+                                   guint prop_id,
+                                   const GValue *value,
+                                   GParamSpec *pspec)
+{
+  ModulemdDefaultsV1 *self = MODULEMD_DEFAULTS_V1 (object);
+
+  switch (prop_id)
+    {
+    default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+modulemd_defaults_v1_class_init (ModulemdDefaultsV1Class *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  ModulemdDefaultsClass *defaults_class =
+    MODULEMD_DEFAULTS_CLASS (object_class);
+
+  object_class->finalize = modulemd_defaults_v1_finalize;
+  object_class->get_property = modulemd_defaults_v1_get_property;
+  object_class->set_property = modulemd_defaults_v1_set_property;
+
+  defaults_class->get_mdversion = modulemd_defaults_v1_get_mdversion;
+}
+
+static void
+modulemd_defaults_v1_init (ModulemdDefaultsV1 *self)
+{
+}

--- a/modulemd/v2/modulemd-defaults.c
+++ b/modulemd/v2/modulemd-defaults.c
@@ -1,0 +1,306 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2017-2018 Stephen Gallagher
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+
+#include <inttypes.h>
+#include "modulemd-defaults.h"
+#include "modulemd-defaults-v1.h"
+#include "private/modulemd-util.h"
+
+#define DEF_DEFAULT_NAME_STRING "__NAME_UNSET__"
+
+typedef struct
+{
+  gchar *module_name;
+} ModulemdDefaultsPrivate;
+
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ModulemdDefaults,
+                                     modulemd_defaults,
+                                     G_TYPE_OBJECT)
+
+enum
+{
+  PROP_0,
+
+  PROP_MDVERSION,
+  PROP_MODULE_NAME,
+
+  N_PROPS
+};
+
+static GParamSpec *properties[N_PROPS];
+
+
+ModulemdDefaults *
+modulemd_defaults_new (guint64 mdversion, const gchar *module_name)
+{
+  g_return_val_if_fail (mdversion && mdversion <= MD_DEFAULTS_VERSION_LATEST,
+                        NULL);
+
+  if (mdversion == MD_DEFAULTS_VERSION_ONE)
+    {
+      return MODULEMD_DEFAULTS (modulemd_defaults_v1_new (module_name));
+    }
+
+  /* This should be unreachable */
+  g_return_val_if_reached (NULL);
+}
+
+
+static void
+modulemd_defaults_finalize (GObject *object)
+{
+  ModulemdDefaults *self = (ModulemdDefaults *)object;
+  ModulemdDefaultsPrivate *priv =
+    modulemd_defaults_get_instance_private (self);
+
+  g_clear_pointer (&priv->module_name, g_free);
+
+  G_OBJECT_CLASS (modulemd_defaults_parent_class)->finalize (object);
+}
+
+
+ModulemdDefaults *
+modulemd_defaults_copy (ModulemdDefaults *self)
+{
+  ModulemdDefaultsClass *klass;
+
+  if (!self)
+    return NULL;
+
+  g_return_val_if_fail (MODULEMD_IS_DEFAULTS (self), NULL);
+
+  klass = MODULEMD_DEFAULTS_GET_CLASS (self);
+  g_return_val_if_fail (klass->copy, NULL);
+
+  return klass->copy (self);
+}
+
+
+static ModulemdDefaults *
+modulemd_defaults_default_copy (ModulemdDefaults *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_DEFAULTS (self), NULL);
+
+  return modulemd_defaults_new (modulemd_defaults_get_mdversion (self),
+                                modulemd_defaults_get_module_name (self));
+}
+
+
+gboolean
+modulemd_defaults_validate (ModulemdDefaults *self, GError **error)
+{
+  ModulemdDefaultsClass *klass;
+
+  if (!self)
+    return FALSE;
+
+  g_return_val_if_fail (MODULEMD_IS_DEFAULTS (self), FALSE);
+
+  klass = MODULEMD_DEFAULTS_GET_CLASS (self);
+  g_return_val_if_fail (klass->validate, FALSE);
+
+  return klass->validate (self, error);
+}
+
+
+static gboolean
+modulemd_defaults_default_validate (ModulemdDefaults *self, GError **error)
+{
+  ModulemdDefaultsPrivate *priv =
+    modulemd_defaults_get_instance_private (self);
+  guint64 mdversion = modulemd_defaults_get_mdversion (self);
+
+  if (!mdversion)
+    {
+      g_set_error_literal (error,
+                           MODULEMD_ERROR,
+                           MODULEMD_ERROR_VALIDATE,
+                           "Metadata version is unset.");
+      return FALSE;
+    }
+  else if (mdversion > MD_DEFAULTS_VERSION_LATEST)
+    {
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   MODULEMD_ERROR_VALIDATE,
+                   "Metadata version unknown: %" PRIu64 ".",
+                   mdversion);
+      return FALSE;
+    }
+
+  if (!priv->module_name)
+    {
+      g_set_error_literal (error,
+                           MODULEMD_ERROR,
+                           MODULEMD_ERROR_VALIDATE,
+                           "Module name is unset.");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+
+ModulemdDefaults *
+modulemd_defaults_upgrade (ModulemdDefaults *self,
+                           guint64 mdversion,
+                           GError **error)
+{
+  g_assert_true (MODULEMD_IS_DEFAULTS (self));
+
+  if (!mdversion)
+    mdversion = MD_DEFAULTS_VERSION_LATEST;
+
+  if (mdversion > MD_DEFAULTS_VERSION_LATEST)
+    {
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   MODULEMD_ERROR_UPGRADE,
+                   "Unknown metadata version for upgrade: %" PRIu64 ".",
+                   mdversion);
+      return NULL;
+    }
+
+  if (modulemd_defaults_get_mdversion (self) == mdversion)
+    {
+      /* Already at this version, just copy it and return that */
+      return modulemd_defaults_copy (self);
+    }
+
+  return NULL;
+}
+
+
+guint64
+modulemd_defaults_get_mdversion (ModulemdDefaults *self)
+{
+  ModulemdDefaultsClass *klass;
+
+  g_return_val_if_fail (self && MODULEMD_IS_DEFAULTS (self), 0);
+
+  klass = MODULEMD_DEFAULTS_GET_CLASS (self);
+  g_return_val_if_fail (klass->get_mdversion, 0);
+
+  return klass->get_mdversion (self);
+}
+
+
+static void
+modulemd_defaults_set_module_name (ModulemdDefaults *self,
+                                   const gchar *module_name)
+{
+  g_return_if_fail (MODULEMD_IS_DEFAULTS (self));
+
+  /* It is a coding error if we ever get a NULL name here */
+  g_return_if_fail (module_name);
+
+  /* It is a coding error if we ever get the default name here */
+  g_return_if_fail (g_strcmp0 (module_name, DEF_DEFAULT_NAME_STRING));
+
+  ModulemdDefaultsPrivate *priv =
+    modulemd_defaults_get_instance_private (self);
+
+  g_clear_pointer (&priv->module_name, g_free);
+  priv->module_name = g_strdup (module_name);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_MODULE_NAME]);
+}
+
+
+const gchar *
+modulemd_defaults_get_module_name (ModulemdDefaults *self)
+{
+  ModulemdDefaultsPrivate *priv =
+    modulemd_defaults_get_instance_private (self);
+
+  return priv->module_name;
+}
+
+
+static void
+modulemd_defaults_get_property (GObject *object,
+                                guint prop_id,
+                                GValue *value,
+                                GParamSpec *pspec)
+{
+  ModulemdDefaults *self = MODULEMD_DEFAULTS (object);
+
+  switch (prop_id)
+    {
+    case PROP_MODULE_NAME:
+      g_value_set_string (value, modulemd_defaults_get_module_name (self));
+      break;
+
+    case PROP_MDVERSION:
+      g_value_set_uint64 (value, modulemd_defaults_get_mdversion (self));
+      break;
+
+    default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+modulemd_defaults_set_property (GObject *object,
+                                guint prop_id,
+                                const GValue *value,
+                                GParamSpec *pspec)
+{
+  ModulemdDefaults *self = MODULEMD_DEFAULTS (object);
+
+  switch (prop_id)
+    {
+    case PROP_MODULE_NAME:
+      modulemd_defaults_set_module_name (self, g_value_get_string (value));
+      break;
+
+    case PROP_MDVERSION:
+    default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+modulemd_defaults_class_init (ModulemdDefaultsClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = modulemd_defaults_finalize;
+  object_class->get_property = modulemd_defaults_get_property;
+  object_class->set_property = modulemd_defaults_set_property;
+
+  klass->copy = modulemd_defaults_default_copy;
+  klass->validate = modulemd_defaults_default_validate;
+
+  properties[PROP_MDVERSION] = g_param_spec_uint64 (
+    "mdversion",
+    "Metadata Version",
+    "The metadata version of this Defaults object. Read-only.",
+    0,
+    MD_DEFAULTS_VERSION_LATEST,
+    0,
+    G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
+  properties[PROP_MODULE_NAME] = g_param_spec_string (
+    "module-name",
+    "Module Name",
+    "The name of the module to which these defaults apply.",
+    DEF_DEFAULT_NAME_STRING,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT_ONLY);
+
+  g_object_class_install_properties (object_class, N_PROPS, properties);
+}
+
+static void
+modulemd_defaults_init (ModulemdDefaults *self)
+{
+}

--- a/modulemd/v2/modulemd-util.c
+++ b/modulemd/v2/modulemd-util.c
@@ -14,6 +14,13 @@
 #include "private/modulemd-util.h"
 
 
+GQuark
+modulemd_error_quark (void)
+{
+  return g_quark_from_static_string ("modulemd-error-quark");
+}
+
+
 modulemd_tracer *
 modulemd_trace_init (const gchar *function_name)
 {

--- a/modulemd/v2/modulemd-v2-docs.xml
+++ b/modulemd/v2/modulemd-v2-docs.xml
@@ -35,6 +35,7 @@
     </partintro>
     <chapter>
       <title>Modulemd 2.0 Public API</title>
+        <xi:include href="xml/modulemd-defaults.xml"/>
         <xi:include href="xml/modulemd-service-level.xml"/>
         <xi:include href="xml/modulemd-translation-entry.xml"/>
     </chapter>

--- a/modulemd/v2/tests/ModulemdTests/defaults.py
+++ b/modulemd/v2/tests/ModulemdTests/defaults.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python3
+
+# This file is part of libmodulemd
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# Fedora-License-Identifier: MIT
+# SPDX-2.0-License-Identifier: MIT
+# SPDX-3.0-License-Identifier: MIT
+#
+# This program is free software.
+# For more information on the license, see COPYING.
+# For more information on free software, see
+# <https://www.gnu.org/philosophy/free-sw.en.html>.
+
+import sys
+try:
+    import unittest
+    import gi
+    gi.require_version('Modulemd', '2.0')
+    from gi.repository import Modulemd
+except ImportError:
+    # Return error 77 to skip this test on platforms without the necessary
+    # python modules
+    sys.exit(77)
+
+from base import TestBase
+
+
+class TestDefaults(TestBase):
+
+    def test_constructors(self):
+        # Test that the new() function works
+        defs = Modulemd.Defaults.new(
+            Modulemd.DefaultsVersionEnum.ONE, 'foo')
+        assert defs
+
+        assert defs.props.mdversion == Modulemd.DefaultsVersionEnum.ONE
+        assert defs.get_mdversion() == Modulemd.DefaultsVersionEnum.ONE
+
+        assert defs.props.module_name == 'foo'
+        assert defs.get_module_name() == 'foo'
+
+        # Test that we cannot instantiate directly
+        with self.assertRaisesRegex(TypeError, 'cannot create instance of abstract'):
+            Modulemd.Defaults()
+
+        # Test with a zero mdversion
+        with self.assertRaisesRegex(TypeError, 'constructor returned NULL'):
+            with self.expect_signal():
+                defs = Modulemd.Defaults.new(0, 'foo')
+
+        # Test with an unknown mdversion
+        with self.assertRaisesRegex(TypeError, 'constructor returned NULL'):
+            with self.expect_signal():
+                defs = Modulemd.Defaults.new(
+                    Modulemd.DefaultsVersionEnum.LATEST + 1, 'foo')
+
+        # Test with no name
+        with self.assertRaisesRegex(TypeError, 'does not allow None as a value'):
+            defs = Modulemd.Defaults.new(
+                Modulemd.DefaultsVersionEnum.ONE, None)
+
+    def test_copy(self):
+        defs = Modulemd.Defaults.new(
+            Modulemd.DefaultsVersionEnum.ONE, 'foo')
+        assert defs
+
+        copied_defs = defs.copy()
+        assert copied_defs
+        assert copied_defs.props.mdversion == defs.props.mdversion
+        assert copied_defs.props.module_name == defs.props.module_name
+
+    def test_mdversion(self):
+        defs = Modulemd.Defaults.new(
+            Modulemd.DefaultsVersionEnum.LATEST, 'foo')
+        assert defs
+
+        assert defs.props.mdversion == Modulemd.DefaultsVersionEnum.ONE
+        assert defs.get_mdversion() == Modulemd.DefaultsVersionEnum.ONE
+
+        # Ensure we cannot set the mdversion
+        with self.assertRaisesRegex(TypeError, 'is not writable'):
+            defs.props.mdversion = 0
+
+    def test_module_name(self):
+        defs = Modulemd.Defaults.new(
+            Modulemd.DefaultsVersionEnum.LATEST, 'foo')
+        assert defs
+
+        assert defs.props.module_name == 'foo'
+        assert defs.get_module_name() == 'foo'
+
+        # Ensure we cannot set the module_name
+        with self.expect_signal():
+            defs.props.module_name = None
+
+    def test_validate(self):
+        defs = Modulemd.Defaults.new(
+            Modulemd.DefaultsVersionEnum.LATEST, 'foo')
+        assert defs
+
+        assert defs.validate()
+
+    def test_upgrade(self):
+        defs = Modulemd.Defaults.new(
+            Modulemd.DefaultsVersionEnum.ONE, 'foo')
+        assert defs
+
+        # test upgrading to the same version
+        upgraded_defs = defs.upgrade(Modulemd.DefaultsVersionEnum.ONE)
+        assert upgraded_defs
+        assert defs.props.mdversion == Modulemd.DefaultsVersionEnum.ONE
+        assert defs.props.module_name == 'foo'
+
+        # test upgrading to the latest version
+        upgraded_defs = defs.upgrade(Modulemd.DefaultsVersionEnum.LATEST)
+        assert upgraded_defs
+        assert defs.props.mdversion == Modulemd.DefaultsVersionEnum.LATEST
+        assert defs.props.module_name == 'foo'
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/modulemd/v2/tests/test-modulemd-defaults.c
+++ b/modulemd/v2/tests/test-modulemd-defaults.c
@@ -1,0 +1,222 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2017-2018 Stephen Gallagher
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <locale.h>
+#include <signal.h>
+
+#include "modulemd-defaults.h"
+#include "modulemd-defaults-v1.h"
+#include "private/glib-extensions.h"
+#include "private/modulemd-translation-entry-private.h"
+#include "private/modulemd-yaml.h"
+#include "private/test-utils.h"
+
+static void
+defaults_test_construct (CommonMmdTestFixture *fixture,
+                         gconstpointer user_data)
+{
+  g_autoptr (ModulemdDefaults) defaults = NULL;
+
+  /* Test new() with a valid mdversion and module name */
+  defaults = modulemd_defaults_new (MD_DEFAULTS_VERSION_ONE, "foo");
+  g_assert_nonnull (defaults);
+  g_assert_true (MODULEMD_IS_DEFAULTS (defaults));
+  g_assert_true (MODULEMD_IS_DEFAULTS_V1 (defaults));
+  g_clear_object (&defaults);
+
+  /* Test new() with a zero mdversion */
+  modulemd_test_signal = 0;
+  signal (SIGTRAP, modulemd_test_signal_handler);
+  defaults = modulemd_defaults_new (0, "foo");
+  g_assert_cmpint (modulemd_test_signal, ==, SIGTRAP);
+  g_assert_null (defaults);
+
+  /* Test new() with a too-high mdversion */
+  modulemd_test_signal = 0;
+  signal (SIGTRAP, modulemd_test_signal_handler);
+  defaults = modulemd_defaults_new (MD_DEFAULTS_VERSION_LATEST + 1, "foo");
+  g_assert_cmpint (modulemd_test_signal, ==, SIGTRAP);
+  g_assert_null (defaults);
+
+  /* Test new() with a NULL module_name */
+  modulemd_test_signal = 0;
+  signal (SIGTRAP, modulemd_test_signal_handler);
+  defaults = modulemd_defaults_new (MD_DEFAULTS_VERSION_ONE, NULL);
+  g_assert_cmpint (modulemd_test_signal, ==, SIGTRAP);
+  /* If we trap the error, defaults actually returns a value here, so free
+   * it
+   */
+  g_clear_object (&defaults);
+}
+
+
+static void
+defaults_test_copy (CommonMmdTestFixture *fixture, gconstpointer user_data)
+{
+  g_autoptr (ModulemdDefaults) defaults = NULL;
+  g_autoptr (ModulemdDefaults) copied_defaults = NULL;
+
+  defaults = modulemd_defaults_new (MD_DEFAULTS_VERSION_LATEST, "foo");
+  g_assert_nonnull (defaults);
+  g_assert_true (MODULEMD_IS_DEFAULTS (defaults));
+  g_assert_true (MODULEMD_IS_DEFAULTS_V1 (defaults));
+
+  copied_defaults = modulemd_defaults_copy (defaults);
+  g_assert_nonnull (copied_defaults);
+  g_assert_true (MODULEMD_IS_DEFAULTS (copied_defaults));
+  g_assert_true (MODULEMD_IS_DEFAULTS_V1 (copied_defaults));
+  g_assert_cmpuint (modulemd_defaults_get_mdversion (defaults),
+                    ==,
+                    modulemd_defaults_get_mdversion (copied_defaults));
+
+  g_assert_cmpstr (modulemd_defaults_get_module_name (defaults),
+                   ==,
+                   modulemd_defaults_get_module_name (copied_defaults));
+}
+
+
+static void
+defaults_test_get_mdversion (CommonMmdTestFixture *fixture,
+                             gconstpointer user_data)
+{
+  g_autoptr (ModulemdDefaults) defaults = NULL;
+  guint64 mdversion;
+
+  defaults = modulemd_defaults_new (MD_DEFAULTS_VERSION_LATEST, "foo");
+  g_assert_true (MODULEMD_IS_DEFAULTS (defaults));
+
+  mdversion = modulemd_defaults_get_mdversion (defaults);
+  g_assert_cmpuint (mdversion, ==, MD_DEFAULTS_VERSION_LATEST);
+}
+
+
+static void
+defaults_test_get_module_name (CommonMmdTestFixture *fixture,
+                               gconstpointer user_data)
+{
+  g_autoptr (ModulemdDefaults) defaults = NULL;
+  const gchar *module_name;
+
+  defaults = modulemd_defaults_new (MD_DEFAULTS_VERSION_LATEST, "foo");
+  g_assert_true (MODULEMD_IS_DEFAULTS (defaults));
+
+  module_name = modulemd_defaults_get_module_name (defaults);
+  g_assert_cmpstr (module_name, ==, "foo");
+}
+
+
+static void
+defaults_test_validate (CommonMmdTestFixture *fixture, gconstpointer user_data)
+{
+  g_autoptr (ModulemdDefaults) defaults = NULL;
+
+  defaults = modulemd_defaults_new (MD_DEFAULTS_VERSION_ONE, "foo");
+  g_assert_true (MODULEMD_IS_DEFAULTS (defaults));
+
+  /* Currently there is no way for validation to fail, since all of its
+   * properties are forced to be valid at object instantiation.
+   * This will need to be updated once the subclasses have reimplimented this.
+   */
+  g_assert_true (modulemd_defaults_validate (defaults, NULL));
+}
+
+
+static void
+defaults_test_upgrade (CommonMmdTestFixture *fixture, gconstpointer user_data)
+{
+  g_autoptr (ModulemdDefaults) defaults = NULL;
+  g_autoptr (ModulemdDefaults) upgraded_defaults = NULL;
+  g_autoptr (GError) error = NULL;
+
+  defaults = modulemd_defaults_new (MD_DEFAULTS_VERSION_ONE, "foo");
+  g_assert_true (MODULEMD_IS_DEFAULTS (defaults));
+
+  /* Currently, we have only a single version, so the "upgrade" just makes a
+   * copy
+   */
+  upgraded_defaults =
+    modulemd_defaults_upgrade (defaults, MD_DEFAULTS_VERSION_ONE, &error);
+  g_assert_nonnull (upgraded_defaults);
+  g_assert_true (MODULEMD_IS_DEFAULTS (upgraded_defaults));
+  g_assert_true (MODULEMD_IS_DEFAULTS_V1 (upgraded_defaults));
+
+  g_assert_cmpint (modulemd_defaults_get_mdversion (upgraded_defaults),
+                   ==,
+                   MD_DEFAULTS_VERSION_ONE);
+  g_assert_cmpstr (
+    modulemd_defaults_get_module_name (upgraded_defaults), ==, "foo");
+  g_clear_object (&upgraded_defaults);
+
+  /* Test attempting to upgrade to an unknown mdversion */
+  upgraded_defaults = modulemd_defaults_upgrade (
+    defaults, MD_DEFAULTS_VERSION_LATEST + 1, &error);
+  g_assert_null (upgraded_defaults);
+  g_assert_nonnull (error);
+}
+
+
+int
+main (int argc, char *argv[])
+{
+  setlocale (LC_ALL, "");
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
+
+  // Define the tests.
+  g_test_add ("/modulemd/v2/defaults/construct",
+              CommonMmdTestFixture,
+              NULL,
+              NULL,
+              defaults_test_construct,
+              NULL);
+
+  g_test_add ("/modulemd/v2/defaults/copy",
+              CommonMmdTestFixture,
+              NULL,
+              NULL,
+              defaults_test_copy,
+              NULL);
+
+  g_test_add ("/modulemd/v2/defaults/mdversion",
+              CommonMmdTestFixture,
+              NULL,
+              NULL,
+              defaults_test_get_mdversion,
+              NULL);
+
+  g_test_add ("/modulemd/v2/defaults/module_name",
+              CommonMmdTestFixture,
+              NULL,
+              NULL,
+              defaults_test_get_module_name,
+              NULL);
+
+  g_test_add ("/modulemd/v2/defaults/validate",
+              CommonMmdTestFixture,
+              NULL,
+              NULL,
+              defaults_test_validate,
+              NULL);
+
+  g_test_add ("/modulemd/v2/defaults/upgrade",
+              CommonMmdTestFixture,
+              NULL,
+              NULL,
+              defaults_test_upgrade,
+              NULL);
+
+  return g_test_run ();
+}

--- a/modulemd/v2/tests/test-utils.c
+++ b/modulemd/v2/tests/test-utils.c
@@ -18,6 +18,15 @@
 #include "private/modulemd-yaml.h"
 #include "private/test-utils.h"
 
+int modulemd_test_signal;
+
+void
+modulemd_test_signal_handler (int sig_num)
+{
+  modulemd_test_signal = sig_num;
+}
+
+
 void
 parser_skip_headers (yaml_parser_t *parser)
 {


### PR DESCRIPTION
This implements only the abstract parent class (plus just enough of the `Modulemd.DefaultsV1` class to be able to run the tests).

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>