### PR TITLE
Fix translation-entry compiler warnings

### DIFF
--- a/modulemd/v2/modulemd-translation-entry.c
+++ b/modulemd/v2/modulemd-translation-entry.c
@@ -481,7 +481,7 @@ modulemd_translation_entry_parse_yaml (yaml_parser_t *parser, GError **error)
   return g_steal_pointer (&te);
 }
 
-gboolean
+static gboolean
 modulemd_translation_entry_emit_yaml_profiles (ModulemdTranslationEntry *self,
                                                yaml_emitter_t *emitter,
                                                GError **error)

--- a/modulemd/v2/tests/test-modulemd-translation-entry.c
+++ b/modulemd/v2/tests/test-modulemd-translation-entry.c
@@ -441,8 +441,8 @@ translation_entry_test_profile_descriptions (TranslationEntryFixture *fixture,
   /* Assert we start with 0 profiles */
   profile_names = modulemd_translation_entry_get_profiles_as_strv (te);
   g_assert_cmpint (g_strv_length (profile_names), ==, 0);
-  g_assert_false (g_strv_contains (profile_names, "test1"));
-  g_assert_false (g_strv_contains (profile_names, "test2"));
+  g_assert_false (g_strv_contains ((const gchar **)profile_names, "test1"));
+  g_assert_false (g_strv_contains ((const gchar **)profile_names, "test2"));
   g_assert_null (
     modulemd_translation_entry_get_profile_description (te, "test1"));
   g_assert_null (
@@ -453,8 +453,8 @@ translation_entry_test_profile_descriptions (TranslationEntryFixture *fixture,
   modulemd_translation_entry_set_profile_description (te, "test1", "foobar");
   profile_names = modulemd_translation_entry_get_profiles_as_strv (te);
   g_assert_cmpint (g_strv_length (profile_names), ==, 1);
-  g_assert_true (g_strv_contains (profile_names, "test1"));
-  g_assert_false (g_strv_contains (profile_names, "test2"));
+  g_assert_true (g_strv_contains ((const gchar **)profile_names, "test1"));
+  g_assert_false (g_strv_contains ((const gchar **)profile_names, "test2"));
   g_assert_cmpstr (
     modulemd_translation_entry_get_profile_description (te, "test1"),
     ==,
@@ -467,8 +467,8 @@ translation_entry_test_profile_descriptions (TranslationEntryFixture *fixture,
   modulemd_translation_entry_set_profile_description (te, "test2", "barfoo");
   profile_names = modulemd_translation_entry_get_profiles_as_strv (te);
   g_assert_cmpint (g_strv_length (profile_names), ==, 2);
-  g_assert_true (g_strv_contains (profile_names, "test1"));
-  g_assert_true (g_strv_contains (profile_names, "test2"));
+  g_assert_true (g_strv_contains ((const gchar **)profile_names, "test1"));
+  g_assert_true (g_strv_contains ((const gchar **)profile_names, "test2"));
   g_assert_cmpstr (
     modulemd_translation_entry_get_profile_description (te, "test1"),
     ==,


### PR DESCRIPTION
Seems g_strv_contains wants a "const gchar **" while g_strv_length wants a "gchar **". Let's typecast.
In addition, actually mark modulemd_translation_entry_emit_yaml_profiles as static.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>