### PR TITLE
Handle streams with version: 0 gracefully

### DIFF
--- a/modulemd/v1/modulemd-modulestream.c
+++ b/modulemd/v1/modulemd-modulestream.c
@@ -1789,7 +1789,7 @@ modulemd_modulestream_get_nsvc (ModulemdModuleStream *self)
   guint64 version = modulemd_modulestream_get_version (self);
   const gchar *context = modulemd_modulestream_peek_context (self);
 
-  if (!name || !stream || !version)
+  if (!name || !stream)
     {
       /* Mandatory field is missing */
       return NULL;

--- a/modulemd/v1/modulemd-yaml-parser-modulemd.c
+++ b/modulemd/v1/modulemd-yaml-parser-modulemd.c
@@ -262,6 +262,7 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
   gboolean done = FALSE;
   guint64 version;
   GDate *eol = NULL;
+  char *endptr = NULL;
 
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
   g_debug ("TRACE: entering _parse_modulemd_data");
@@ -329,9 +330,11 @@ _parse_modulemd_data (ModulemdModuleStream *modulestream,
                 }
 
               version = g_ascii_strtoull (
-                (const gchar *)value_event.data.scalar.value, NULL, 10);
-              if (!version)
+                (const gchar *)value_event.data.scalar.value, &endptr, 10);
+              if (!version &&
+                  endptr == (const gchar *)value_event.data.scalar.value)
                 {
+                  /* Could not convert to an integer */
                   MMD_YAML_ERROR_EVENT_RETURN (
                     error, value_event, "Unknown module version");
                 }

--- a/modulemd/v1/tests/test-modulemd-python.py
+++ b/modulemd/v1/tests/test-modulemd-python.py
@@ -298,6 +298,54 @@ data:
         assert len(objects_from_repo_a) == len(objects_from_repo_b)
         assert len(objects_from_repo_a) == len(supposedly_merged_objects)
 
+    def test_issue94(self):
+        # Verify that we can read in a module stream with a zero module
+        # version.
+        stream = Modulemd.ModuleStream.new()
+        stream.import_from_string("""
+document: modulemd
+version: 1
+data:
+    name: foo
+    stream: bar
+    version: 0
+    summary: A test module in all its beautiful beauty.
+    description: This module demonstrates how to write simple modulemd files And can be used for testing the build and release pipeline.
+    license:
+        module: [ MIT ]
+    dependencies:
+        buildrequires:
+            platform: el8
+        requires:
+            platform: el8
+    references:
+        community: https://fedoraproject.org/wiki/Modularity
+        documentation: https://fedoraproject.org/wiki/Fedora_Packaging_Guidelines_for_Modules
+        tracker: https://taiga.fedorainfracloud.org/project/modularity
+    profiles:
+        default:
+            rpms:
+                - acl
+    api:
+        rpms:
+            - acl
+    components:
+        rpms:
+            acl:
+                rationale: needed
+                ref: rhel-8.0
+        modules:
+            testmodule:
+                ref: private-x
+                rationale: Testing module inclusion.
+                buildorder: 10
+""")
+        assert stream is not None
+        assert stream.props.version == 0
+
+        # Verify that get_nsvc() works with a zeroed module version
+        assert stream.get_nsvc() == 'foo:bar:0'
+
 
 class TestPrioritizer(unittest.TestCase):
 


### PR DESCRIPTION
Also permit get_nsvc() to emit zero for the version.

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/94

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>