### PR TITLE
Rename Dependencies.set_empty_*_dependencies_for_module()

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-dependencies.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-dependencies.h
@@ -71,7 +71,7 @@ modulemd_dependencies_add_buildtime_stream (ModulemdDependencies *self,
 
 
 /**
- * modulemd_dependencies_set_empty_buildtime_default_dependencies_for_module:
+ * modulemd_dependencies_set_empty_buildtime_dependencies_for_module:
  * @self: This #ModuleDependencies
  * @module_name: The name of the module to add dependencies on.
  *
@@ -80,7 +80,7 @@ modulemd_dependencies_add_buildtime_stream (ModulemdDependencies *self,
  * Since: 2.0
  */
 void
-modulemd_dependencies_set_empty_buildtime_default_dependencies_for_module (
+modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
   ModulemdDependencies *self, const gchar *module_name);
 
 
@@ -128,7 +128,7 @@ modulemd_dependencies_add_runtime_stream (ModulemdDependencies *self,
 
 
 /**
- * modulemd_dependencies_set_empty_runtime_default_dependencies_for_module:
+ * modulemd_dependencies_set_empty_runtime_dependencies_for_module:
  * @self: This #ModuleDependencies
  * @module_name: The name of the module to add dependencies on.
  *
@@ -137,7 +137,7 @@ modulemd_dependencies_add_runtime_stream (ModulemdDependencies *self,
  * Since: 2.0
  */
 void
-modulemd_dependencies_set_empty_runtime_default_dependencies_for_module (
+modulemd_dependencies_set_empty_runtime_dependencies_for_module (
   ModulemdDependencies *self, const gchar *module_name);
 
 

--- a/modulemd/v2/modulemd-dependencies.c
+++ b/modulemd/v2/modulemd-dependencies.c
@@ -128,7 +128,7 @@ modulemd_dependencies_add_buildtime_stream (ModulemdDependencies *self,
 
 
 void
-modulemd_dependencies_set_empty_buildtime_default_dependencies_for_module (
+modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
   ModulemdDependencies *self, const gchar *module_name)
 {
   g_return_if_fail (MODULEMD_IS_DEPENDENCIES (self));
@@ -171,7 +171,7 @@ modulemd_dependencies_add_runtime_stream (ModulemdDependencies *self,
 
 
 void
-modulemd_dependencies_set_empty_runtime_default_dependencies_for_module (
+modulemd_dependencies_set_empty_runtime_dependencies_for_module (
   ModulemdDependencies *self, const gchar *module_name)
 {
   g_return_if_fail (MODULEMD_IS_DEPENDENCIES (self));

--- a/modulemd/v2/tests/ModulemdTests/dependencies.py
+++ b/modulemd/v2/tests/ModulemdTests/dependencies.py
@@ -62,10 +62,10 @@ class TestDependencies(TestBase):
 
         d_orig.add_buildtime_stream("buildmod1", "stream2")
         d_orig.add_buildtime_stream("buildmod1", "stream1")
-        d_orig.set_empty_buildtime_default_dependencies_for_module("builddef")
+        d_orig.set_empty_buildtime_dependencies_for_module("builddef")
         d_orig.add_runtime_stream("runmod1", "stream3")
         d_orig.add_runtime_stream("runmod1", "stream4")
-        d_orig.set_empty_runtime_default_dependencies_for_module("rundef")
+        d_orig.set_empty_runtime_dependencies_for_module("rundef")
 
         d = d_orig.copy()
         assert d

--- a/modulemd/v2/tests/test-modulemd-dependencies.c
+++ b/modulemd/v2/tests/test-modulemd-dependencies.c
@@ -83,10 +83,10 @@ dependencies_test_dependencies (DependenciesFixture *fixture,
   modulemd_dependencies_add_buildtime_stream (d, "buildmod1", "stream1");
   modulemd_dependencies_add_runtime_stream (d, "runmod1", "stream2");
   modulemd_dependencies_add_runtime_stream (d, "runmod1", "stream1");
-  modulemd_dependencies_set_empty_buildtime_default_dependencies_for_module (
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
     d, "defbuild");
-  modulemd_dependencies_set_empty_runtime_default_dependencies_for_module (
-    d, "defrun");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d,
+                                                                   "defrun");
 
   list = modulemd_dependencies_get_buildtime_modules_as_strv (d);
   g_assert_nonnull (list);
@@ -165,12 +165,12 @@ dependencies_test_copy (DependenciesFixture *fixture, gconstpointer user_data)
 
   modulemd_dependencies_add_buildtime_stream (d, "buildmod1", "stream2");
   modulemd_dependencies_add_buildtime_stream (d, "buildmod1", "stream1");
-  modulemd_dependencies_set_empty_buildtime_default_dependencies_for_module (
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
     d, "builddef");
   modulemd_dependencies_add_runtime_stream (d, "runmod1", "stream3");
   modulemd_dependencies_add_runtime_stream (d, "runmod1", "stream4");
-  modulemd_dependencies_set_empty_runtime_default_dependencies_for_module (
-    d, "rundef");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d,
+                                                                   "rundef");
 
   d_copy = modulemd_dependencies_copy (d);
   g_assert_nonnull (d_copy);
@@ -299,12 +299,12 @@ dependencies_test_emit_yaml (DependenciesFixture *fixture,
   yaml_emitter_set_output (&emitter, write_yaml_string, (void *)yaml_string);
   modulemd_dependencies_add_buildtime_stream (d, "buildmod1", "stream2");
   modulemd_dependencies_add_buildtime_stream (d, "buildmod1", "stream1");
-  modulemd_dependencies_set_empty_buildtime_default_dependencies_for_module (
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
     d, "builddef");
   modulemd_dependencies_add_runtime_stream (d, "runmod1", "stream3");
   modulemd_dependencies_add_runtime_stream (d, "runmod1", "stream4");
-  modulemd_dependencies_set_empty_runtime_default_dependencies_for_module (
-    d, "rundef");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d,
+                                                                   "rundef");
 
   g_assert_true (mmd_emitter_start_stream (&emitter, &error));
   g_assert_true (mmd_emitter_start_document (&emitter, &error));


### PR DESCRIPTION
The _default portion of the name was likely a copy-paste error in the
original design document.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>