### PR TITLE
Add support for ModuleStreamV1 and ModuleStreamV2

### DIFF
--- a/.travis/Dockerfile.deps.tmpl
+++ b/.travis/Dockerfile.deps.tmpl
@@ -22,8 +22,10 @@ RUN @PKGMGR@ -y --setopt=install_weak_deps=False install \
 	pkgconf \
 	popt-devel \
 	python3-autopep8 \
+	python3-devel \
 	python3-GitPython \
 	python3-gobject-base \
+	python3-rpm-macros \
 	redhat-rpm-config \
 	rpm-build \
 	ruby \

--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python3
+
+# This file is part of libmodulemd
+# Copyright (C) 2016 Red Hat, Inc.
+# Copyright (C) 2017-2018 Stephen Gallagher
+#
+# Fedora-License-Identifier: MIT
+# SPDX-2.0-License-Identifier: MIT
+# SPDX-3.0-License-Identifier: MIT
+#
+# This program is free software.
+# For more information on the license, see COPYING.
+# For more information on free software, see
+# <https://www.gnu.org/philosophy/free-sw.en.html>.#!/usr/bin/python3
+
+# This file is part of libmodulemd
+# Copyright (C) 2017-2018 Stephen Gallagher
+#
+# Fedora-License-Identifier: MIT
+# SPDX-2.0-License-Identifier: MIT
+# SPDX-3.0-License-Identifier: MIT
+#
+# This program is free software.
+# For more information on the license, see COPYING.
+# For more information on free software, see
+# <https://www.gnu.org/philosophy/free-sw.en.html>.
+
+
+import gi
+
+from ..module import get_introspection_module
+from ..overrides import override
+
+Modulemd = get_introspection_module('Modulemd')
+
+from six import text_type
+from gi.repository import GLib
+
+__all__ = []
+
+class ModulemdUtil():
+    def variant_str(s):
+        """ Converts a string to a GLib.Variant
+        """
+        if not isinstance(s, str):
+            raise TypeError('Only strings are supported for scalars')
+
+        return GLib.Variant('s', s)
+
+    def variant_bool(b):
+        """ Converts a boolean to a GLib.Varant
+        """
+        if not isinstance(b, bool):
+            raise TypeError('Only booleans are supported')
+
+        return GLib.Variant('b', b)
+
+    def variant_list(l):
+        """ Converts a list to a GLib.Variant
+        """
+        l_variant = list()
+        for item in l:
+            if item is None:
+                item = ''
+
+            l_variant.append(ModulemdUtil.python_to_variant(item))
+        return GLib.Variant('av', l_variant)
+
+    def variant_dict(d):
+        """ Converts a dictionary to a dictionary of GLib.Variant
+        """
+        if not isinstance(d, dict):
+            raise TypeError('Only dictionaries are supported for mappings')
+
+        d_variant = dict_values(d)
+        return GLib.Variant('a{sv}', d_variant)
+
+    def dict_values(d):
+        """ Converts each dictionary value to a GLib.Variant
+        """
+        if not isinstance(d, dict):
+            raise TypeError('Only dictionaries are supported for mappings')
+
+        d_variant = dict()
+        for k, v in d.items():
+            if v is None:
+                v = ''
+
+            d_variant[k] = ModulemdUtil.python_to_variant(v)
+        return d_variant
+
+    def python_to_variant(obj):
+        if isinstance(obj, str):
+            return ModulemdUtil.variant_str(obj)
+
+        elif isinstance(obj, text_type):
+            return ModulemdUtil.variant_str(obj.encode('utf-8'))
+
+        elif isinstance(obj, bool):
+            return ModulemdUtil.variant_bool(obj)
+
+        elif isinstance(obj, list):
+            return ModulemdUtil.variant_list(obj)
+
+        elif isinstance(obj, dict):
+            return ModulemdUtil.variant_dict(obj)
+
+        else:
+            raise TypeError('Cannot convert unknown type')
+
+
+if "ModuleStreamV2" in dir(Modulemd):
+    class ModuleStreamV2(Modulemd.ModuleStreamV2):
+
+        def __new__(cls, module_name=None, module_stream=None):
+            return Modulemd.ModuleStreamV2.new(module_name, module_stream)
+
+        def set_xmd(self, xmd):
+            super().set_xmd(ModulemdUtil.python_to_variant(xmd))
+
+        def get_xmd(self):
+            variant_xmd = super().get_xmd()
+            return variant_xmd.unpack()
+
+
+    ModuleStreamV2 = override(ModuleStreamV2)
+    __all__.append(ModuleStreamV2)
+
+
+if "ModuleStreamV1" in dir(Modulemd):
+    class ModuleStreamV1(Modulemd.ModuleStreamV1):
+
+        def __new__(cls, module_name=None, module_stream=None):
+            return Modulemd.ModuleStreamV1.new(module_name, module_stream)
+
+        def set_xmd(self, xmd):
+            super().set_xmd(ModulemdUtil.python_to_variant(xmd))
+
+        def get_xmd(self):
+            variant_xmd = super().get_xmd()
+            return variant_xmd.unpack()
+
+
+    ModuleStreamV1 = override(ModuleStreamV1)
+    __all__.append(ModuleStreamV1)
+

--- a/bindings/python/meson.build
+++ b/bindings/python/meson.build
@@ -1,0 +1,34 @@
+python3 = import('python3').find_python()
+
+get_overridedir = '''
+import os
+import sysconfig
+
+libdir = sysconfig.get_config_var('SCRIPTDIR')
+
+if not libdir:
+  libdir = '/usr/lib'
+
+try:
+  import gi
+  overridedir = gi._overridesdir
+except ImportError:
+  purelibdir = sysconfig.get_path('purelib')
+  overridedir = os.path.join(purelibdir, 'gi', 'overrides')
+
+if overridedir.startswith(libdir): # Should always be True..
+  overridedir = overridedir[len(libdir) + 1:]
+
+print(overridedir)
+'''
+
+ret = run_command([python3, '-c', get_overridedir])
+
+if ret.returncode() != 0
+  error('Failed to determine pygobject overridedir')
+else
+  pygobject_override_dir = join_paths(get_option('libdir'), ret.stdout().strip())
+endif
+
+install_data('gi/overrides/Modulemd.py', install_dir: pygobject_override_dir)
+

--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -143,8 +143,11 @@ ln -s libmodulemd.so.%{libmodulemd_v1_version} \
 
 
 %files -n python3-%{name}
+%{python3_sitearch}/gi/overrides/
+
 
 %files -n python3-compat-libmodulemd1
+
 
 %files -n compat-libmodulemd1
 %license COPYING
@@ -152,7 +155,6 @@ ln -s libmodulemd.so.%{libmodulemd_v1_version} \
 %{_libdir}/%{name}.so.1*
 %dir %{_libdir}/girepository-1.0
 %{_libdir}/girepository-1.0/Modulemd-1.0.typelib
-
 
 
 %files -n compat-libmodulemd1-devel

--- a/meson.build
+++ b/meson.build
@@ -109,3 +109,4 @@ configure_file(
 )
 
 subdir('modulemd')
+subdir('bindings/python')

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -144,6 +144,7 @@ modulemd_v2_hdrs = files(
     'v2/include/modulemd-2.0/modulemd-defaults.h',
     'v2/include/modulemd-2.0/modulemd-defaults-v1.h',
     'v2/include/modulemd-2.0/modulemd-dependencies.h',
+    'v2/include/modulemd-2.0/modulemd-deprecated.h',
     'v2/include/modulemd-2.0/modulemd-module-stream.h',
     'v2/include/modulemd-2.0/modulemd-module-stream-v1.h',
     'v2/include/modulemd-2.0/modulemd-module-stream-v2.h',

--- a/modulemd/v2/include/modulemd-2.0/modulemd-deprecated.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-deprecated.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2017-2018 Stephen Gallagher
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#pragma once
+
+#ifdef MMD_DISABLE_DEPRECATION_WARNINGS
+#define MMD_DEPRECATED extern
+#define MMD_DEPRECATED_FOR(f) extern
+#define MMD_UNAVAILABLE(maj, min) extern
+#define MMD_DEPRECATED_TYPE_FOR(f)
+#else
+#define MMD_DEPRECATED G_DEPRECATED extern
+#define MMD_DEPRECATED_FOR(f) G_DEPRECATED_FOR (f) extern
+#define MMD_DEPRECATED_TYPE_FOR(f) G_DEPRECATED_FOR (f)
+#define MMD_UNAVAILABLE(maj, min) G_UNAVAILABLE (maj, min) extern
+#endif

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v1.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v1.h
@@ -14,9 +14,24 @@
 #pragma once
 
 #include <glib-object.h>
-#include <modulemd-module-stream.h>
+#include "modulemd-buildopts.h"
+#include "modulemd-component.h"
+#include "modulemd-component-module.h"
+#include "modulemd-component-rpm.h"
+#include "modulemd-deprecated.h"
+#include "modulemd-module-stream.h"
+#include "modulemd-profile.h"
+#include "modulemd-service-level.h"
 
 G_BEGIN_DECLS
+
+/**
+ * SECTION: modulemd-module-stream-v1
+ * @title: Modulemd.ModuleStreamV1
+ * @stability: stable
+ * @short_description: The data to represent a stream of a module as described
+ * by a modulemd YAML document of version 1.
+ */
 
 #define MODULEMD_TYPE_MODULE_STREAM_V1 (modulemd_module_stream_v1_get_type ())
 
@@ -26,8 +41,796 @@ G_DECLARE_FINAL_TYPE (ModulemdModuleStreamV1,
                       MODULE_STREAM_V1,
                       ModulemdModuleStream)
 
+
+/**
+ * modulemd_module_stream_v1_new:
+ * @module_name: (in) (nullable): The name of this module.
+ * @module_stream: (in) (nullable): The name of this module stream.
+ *
+ * Returns: (transfer full): A newly-allocated #ModulemdModuleStreamV1 object,
+ * with the specified module and stream names, if provided.
+ *
+ * Since: 2.0
+ */
 ModulemdModuleStreamV1 *
 modulemd_module_stream_v1_new (const gchar *module_name,
                                const gchar *module_stream);
+
+
+/* ===== Properties ====== */
+
+
+/**
+ * modulemd_module_stream_v1_set_arch:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @arch: (in): The module artifact architecture.
+ *
+ * Set the module artifact architecture.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_set_arch (ModulemdModuleStreamV1 *self,
+                                    const gchar *arch);
+
+
+/**
+ * modulemd_module_stream_v1_get_arch:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer none): The module artifact architecture.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v1_get_arch (ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_set_buildopts:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @buildopts: (in) (transfer none): A #ModulemdBuildOpts object describing
+ * build options that apply globally to components in this module.
+ *
+ * Set build options for this module's components.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_set_buildopts (ModulemdModuleStreamV1 *self,
+                                         ModulemdBuildopts *buildopts);
+
+
+/**
+ * modulemd_module_stream_v1_get_buildopts:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer none): The build options for this module's components.
+ *
+ * Since: 2.0
+ */
+ModulemdBuildopts *
+modulemd_module_stream_v1_get_buildopts (ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_set_community:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @community: (in): The upstream community website for this module.
+ *
+ * Set the module community website address.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_set_community (ModulemdModuleStreamV1 *self,
+                                         const gchar *community);
+
+
+/**
+ * modulemd_module_stream_v1_get_community:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer none): The module community website address.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v1_get_community (ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_set_description:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @description: (in): The untranslated description of this module.
+ *
+ * Set the module description.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_set_description (ModulemdModuleStreamV1 *self,
+                                           const gchar *description);
+
+
+/**
+ * modulemd_module_stream_v1_get_description:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer none): The module description.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v1_get_description (ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_set_documentation:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @documentation: (in): The upstream documentation website for this module.
+ *
+ * Set the module documentation website address.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_set_documentation (ModulemdModuleStreamV1 *self,
+                                             const gchar *documentation);
+
+
+/**
+ * modulemd_module_stream_v1_get_documentation:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer none): The module documentation website address.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v1_get_documentation (ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_set_summary:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @summary: (in): The untranslated summary of this module.
+ *
+ * Set the module summary.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_set_summary (ModulemdModuleStreamV1 *self,
+                                       const gchar *summary);
+
+
+/**
+ * modulemd_module_stream_v1_get_summary:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer none): The module summary.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v1_get_summary (ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_set_tracker:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @tracker: (in): The upstream bug tracker website for this module.
+ *
+ * Set the module bug tracker website address.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_set_tracker (ModulemdModuleStreamV1 *self,
+                                       const gchar *tracker);
+
+
+/**
+ * modulemd_module_stream_v1_get_tracker:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer none): The module bug tracker website address.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v1_get_tracker (ModulemdModuleStreamV1 *self);
+
+
+/* ===== Non-property Methods ===== */
+
+
+/**
+ * modulemd_module_stream_v1_add_component:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @component: (in) (transfer none): A #ModulemdComponent to be added to this
+ * module stream.
+ *
+ * Add a component definition to the module.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_add_component (ModulemdModuleStreamV1 *self,
+                                         ModulemdComponent *component);
+
+
+/**
+ * modulemd_module_stream_v1_remove_module_component:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @component_name: (in): The name of the component to remove from the module
+ * stream.
+ *
+ * Remove a component from this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_remove_module_component (
+  ModulemdModuleStreamV1 *self, const gchar *component_name);
+
+
+/**
+ * modulemd_module_stream_v1_remove_rpm_component:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @component_name: (in): The name of the component to remove from the module
+ * stream.
+ *
+ * Remove a component from this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_remove_rpm_component (ModulemdModuleStreamV1 *self,
+                                                const gchar *component_name);
+
+
+/**
+ * modulemd_module_stream_v1_get_module_component_names_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of module component names included
+ * in this stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_module_component_names_as_strv (
+  ModulemdModuleStreamV1 *self);
+
+/**
+ * modulemd_module_stream_v1_get_rpm_component_names_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of RPM component names included
+ * in this stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_rpm_component_names_as_strv (
+  ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_get_module_component:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @component_name: (in): The name of the component to retrieve.
+ *
+ * Returns: (transfer none): The module component matching @component name if
+ * it exists, else NULL.
+ *
+ * Since: 2.0
+ */
+ModulemdComponentModule *
+modulemd_module_stream_v1_get_module_component (ModulemdModuleStreamV1 *self,
+                                                const gchar *component_name);
+
+
+/**
+ * modulemd_module_stream_v1_get_rpm_component:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @component_name: (in): The name of the component to retrieve.
+ *
+ * Returns: (transfer none): The RPM component matching @component name if it
+ * exists, else NULL.
+ *
+ * Since: 2.0
+ */
+ModulemdComponentRpm *
+modulemd_module_stream_v1_get_rpm_component (ModulemdModuleStreamV1 *self,
+                                             const gchar *component_name);
+
+
+/**
+ * modulemd_module_stream_v1_add_content_license:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @license: (in): A license under which one or more of the components of this
+ * module stream are distributed.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_add_content_license (ModulemdModuleStreamV1 *self,
+                                               const gchar *license);
+
+
+/**
+ * modulemd_module_stream_v1_add_module_license:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @license: (in): A license under which this module stream is distributed.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_add_module_license (ModulemdModuleStreamV1 *self,
+                                              const gchar *license);
+
+
+/**
+ * modulemd_module_stream_v1_remove_content_license:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @license: (in): A license to remove from the list. Has no effect if the
+ * license is not present.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_remove_content_license (ModulemdModuleStreamV1 *self,
+                                                  const gchar *license);
+
+
+/**
+ * modulemd_module_stream_v1_remove_module_license:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @license: (in): A license to remove from the list. Has no effect if the
+ * license is not present.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_remove_module_license (ModulemdModuleStreamV1 *self,
+                                                 const gchar *license);
+
+
+/**
+ * modulemd_module_stream_v1_get_content_licenses_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of licenses under which one or
+ * more components of this module stream are released.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_content_licenses_as_strv (
+  ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_get_module_licenses_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of licenses under which this
+ * module stream is released.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_module_licenses_as_strv (
+  ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_add_profile:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @profile: (in) (transfer none): A #ModulemdProfile for this module stream.
+ *
+ * Adds a profile definition to this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_add_profile (ModulemdModuleStreamV1 *self,
+                                       ModulemdProfile *profile);
+
+
+/**
+ * modulemd_module_stream_v1_clear_profiles:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Removes all profiles from this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_clear_profiles (ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_get_profile_names_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of profile names associated with
+ * this module stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_profile_names_as_strv (
+  ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_get_profile:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @profile_name: (in): The name of a profile to retrieve.
+ *
+ * Returns: (transfer none): The requested profile definition if present in the
+ * module stream. NULL otherwise.
+ *
+ * Since: 2.0
+ */
+ModulemdProfile *
+modulemd_module_stream_v1_get_profile (ModulemdModuleStreamV1 *self,
+                                       const gchar *profile_name);
+
+
+/**
+ * modulemd_module_stream_v1_add_rpm_api:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @rpm: (in): The name of a binary RPM present in this module that is
+ * considered stable public API.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_add_rpm_api (ModulemdModuleStreamV1 *self,
+                                       const gchar *rpm);
+
+
+/**
+ * modulemd_module_stream_v1_remove_rpm_api:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @rpm: (in): A binary RPM name to remove from the list of stable public API.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_remove_rpm_api (ModulemdModuleStreamV1 *self,
+                                          const gchar *rpm);
+
+
+/**
+ * modulemd_module_stream_v1_get_rpm_api_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of binary RPM names that forms
+ * the public API of this module stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_rpm_api_as_strv (ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_add_rpm_artifact:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @nevr: (in): The NEVR of a binary RPM present in this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_add_rpm_artifact (ModulemdModuleStreamV1 *self,
+                                            const gchar *nevr);
+
+
+/**
+ * modulemd_module_stream_v1_remove_rpm_artifact:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @nevr: (in): An RPM NEVR to remove from the list of artifacts.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_remove_rpm_artifact (ModulemdModuleStreamV1 *self,
+                                               const gchar *nevr);
+
+
+/**
+ * modulemd_module_stream_v1_get_rpm_artifacts_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of RPM NEVRs are included in this
+ * module stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_rpm_artifacts_as_strv (
+  ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_add_rpm_filter:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @rpm: (in): The name of a binary RPM to filter out of this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_add_rpm_filter (ModulemdModuleStreamV1 *self,
+                                          const gchar *rpm);
+
+
+/**
+ * modulemd_module_stream_v1_remove_rpm_filter:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @rpm: (in): A binary RPM name to remove from the filter list.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_remove_rpm_filter (ModulemdModuleStreamV1 *self,
+                                             const gchar *rpm);
+
+
+/**
+ * modulemd_module_stream_v1_get_rpm_filters_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of binary RPM names that are
+ * filtered out of this module stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_rpm_filters_as_strv (
+  ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_add_servicelevel:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @servicelevel: (in) (transfer none): A #ModulemdServiceLevel for this module stream.
+ *
+ * Adds a servicelevel definition to this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_add_servicelevel (
+  ModulemdModuleStreamV1 *self, ModulemdServiceLevel *servicelevel);
+
+
+/**
+ * modulemd_module_stream_v1_clear_servicelevels:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Removes all servicelevels from this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_clear_servicelevels (ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_get_servicelevel_names_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of servicelevel names associated with
+ * this module stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_servicelevel_names_as_strv (
+  ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_get_servicelevel:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @servicelevel_name: (in): The name of a servicelevel to retrieve.
+ *
+ * Returns: (transfer none): The requested servicelevel definition if present in the
+ * module stream. NULL otherwise.
+ *
+ * Since: 2.0
+ */
+ModulemdServiceLevel *
+modulemd_module_stream_v1_get_servicelevel (ModulemdModuleStreamV1 *self,
+                                            const gchar *servicelevel_name);
+
+
+/**
+ * modulemd_module_stream_v1_set_eol:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @eol: (in): The end-of-life date for the "rawhide" service level.
+ *
+ * Comptibility function with early iterations of modulemd v1. This function is
+ * a wrapper for Modulemd.ModuleStreamV1.add_servicelevel("rawhide", eol).
+ *
+ * Since: 2.0
+ * Deprecated: 2.0
+ */
+MMD_DEPRECATED_FOR (modulemd_module_stream_v1_add_servicelevel)
+void
+modulemd_module_stream_v1_set_eol (ModulemdModuleStreamV1 *self, GDate *eol);
+
+
+/**
+ * modulemd_module_stream_v1_get_eol:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Compatibility function with early iterations of modulemd v1. This function
+ * is a wrapper for Modulemd.ModuleStreamV1.get_servicelevel("rawhide").
+ *
+ * Returns: (transfer none): The end-of-life date for the "rawhide" service
+ * level.
+ *
+ * Since: 2.0
+ * Deprecated: 2.0
+ */
+MMD_DEPRECATED_FOR (modulemd_module_stream_v1_get_servicelevel)
+GDate *
+modulemd_module_stream_v1_get_eol (ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_add_buildtime_requirement:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @module_name: (in): The name of the module to depend on.
+ * @module_stream: (in): The name of the module stream to depend on.
+ *
+ * Add a build-time dependency for this module.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_add_buildtime_requirement (
+  ModulemdModuleStreamV1 *self,
+  const gchar *module_name,
+  const gchar *module_stream);
+
+/**
+ * modulemd_module_stream_v1_add_runtime_requirement:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @module_name: (in): The name of the module to depend on.
+ * @module_stream: (in): The name of the module stream to depend on.
+ *
+ * Add a runtime dependency for this module.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_add_runtime_requirement (
+  ModulemdModuleStreamV1 *self,
+  const gchar *module_name,
+  const gchar *module_stream);
+
+
+/**
+ * modulemd_module_stream_v1_remove_buildtime_requirement:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @module_name: (in): The name of the module to be removed.
+ *
+ * Remove a build-time dependency for this module.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_remove_buildtime_requirement (
+  ModulemdModuleStreamV1 *self, const gchar *module_name);
+
+
+/**
+ * modulemd_module_stream_v1_remove_runtime_requirement:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @module_name: (in): The name of the module to be removed.
+ *
+ * Remove a runtime dependency for this module.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_remove_runtime_requirement (
+  ModulemdModuleStreamV1 *self, const gchar *module_name);
+
+
+/**
+ * modulemd_module_stream_v1_get_buildtime_modules_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of module names that this module
+ * depends on at build-time.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_buildtime_modules_as_strv (
+  ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_get_runtime_modules_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer full): An ordered list of module names that this module
+ * depends on at runtime.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v1_get_runtime_modules_as_strv (
+  ModulemdModuleStreamV1 *self);
+
+
+/**
+ * modulemd_module_stream_v1_get_buildtime_requirement_stream:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @module_name: (in): The name of the module this module depends on.
+ *
+ * Returns: (transfer none): The name of the stream matching this module name
+ * in the build-time dependencies.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v1_get_buildtime_requirement_stream (
+  ModulemdModuleStreamV1 *self, const gchar *module_name);
+
+
+/**
+ * modulemd_module_stream_get_runtime_requirement_stream:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @module_name: (in): The name of the module this module depends on.
+ *
+ * Returns: (transfer none): The name of the stream matching this module name
+ * in the runtime dependencies.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v1_get_runtime_requirement_stream (
+  ModulemdModuleStreamV1 *self, const gchar *module_name);
+
+
+/**
+ * modulemd_module_stream_v1_set_xmd:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @xmd: (in) (transfer full): A #GVariant representing arbitrary YAML.
+ *
+ * Sets the eXtensible MetaData (XMD) for this module. XMD is arbitrary YAML
+ * data that will be set and returned as-is (with the exception that the
+ * ordering of mapping keys is not defined). Useful for carrying private data.
+ *
+ * This function assumes ownership of the XMD #GVariant and thus should not be
+ * freed by the caller.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v1_set_xmd (ModulemdModuleStreamV1 *self,
+                                   GVariant *xmd);
+
+
+/**
+ * modulemd_module_stream_v1_get_xmd:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Returns: (transfer none): The extensible metadata block as a GVariant.
+ */
+GVariant *
+modulemd_module_stream_v1_get_xmd (ModulemdModuleStreamV1 *self);
+
 
 G_END_DECLS

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
@@ -14,9 +14,24 @@
 #pragma once
 
 #include <glib-object.h>
-#include <modulemd-module-stream.h>
+#include "modulemd-buildopts.h"
+#include "modulemd-component.h"
+#include "modulemd-component-module.h"
+#include "modulemd-component-rpm.h"
+#include "modulemd-dependencies.h"
+#include "modulemd-module-stream.h"
+#include "modulemd-profile.h"
+#include "modulemd-service-level.h"
 
 G_BEGIN_DECLS
+
+/**
+ * SECTION: modulemd-module-stream-v2
+ * @title: Modulemd.ModuleStreamV2
+ * @stability: stable
+ * @short_description: The data to represent a stream of a module as described
+ * by a modulemd YAML document of version 2.
+ */
 
 #define MODULEMD_TYPE_MODULE_STREAM_V2 (modulemd_module_stream_v2_get_type ())
 
@@ -26,8 +41,672 @@ G_DECLARE_FINAL_TYPE (ModulemdModuleStreamV2,
                       MODULE_STREAM_V2,
                       ModulemdModuleStream)
 
+
+/**
+ * modulemd_module_stream_v2_new:
+ * @module_name: (in) (nullable): The name of this module.
+ * @module_stream: (in) (nullable): The name of this module stream.
+ *
+ * Returns: (transfer full): A newly-allocated #ModulemdModuleStreamV2 object,
+ * with the specified module and stream names, if provided.
+ *
+ * Since: 2.0
+ */
 ModulemdModuleStreamV2 *
 modulemd_module_stream_v2_new (const gchar *module_name,
                                const gchar *module_stream);
+
+
+/* ===== Properties ====== */
+
+
+/**
+ * modulemd_module_stream_v2_set_arch:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @arch: (in): The module artifact architecture.
+ *
+ * Set the module artifact architecture.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_set_arch (ModulemdModuleStreamV2 *self,
+                                    const gchar *arch);
+
+
+/**
+ * modulemd_module_stream_v2_get_arch:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer none): The module artifact architecture.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v2_get_arch (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_set_buildopts:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @buildopts: (in) (transfer none): A #ModulemdBuildOpts object describing
+ * build options that apply globally to components in this module.
+ *
+ * Set build options for this module's components.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_set_buildopts (ModulemdModuleStreamV2 *self,
+                                         ModulemdBuildopts *buildopts);
+
+
+/**
+ * modulemd_module_stream_v2_get_buildopts:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer none): The build options for this module's components.
+ *
+ * Since: 2.0
+ */
+ModulemdBuildopts *
+modulemd_module_stream_v2_get_buildopts (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_set_community:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @community: (in): The upstream community website for this module.
+ *
+ * Set the module community website address.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_set_community (ModulemdModuleStreamV2 *self,
+                                         const gchar *community);
+
+
+/**
+ * modulemd_module_stream_v2_get_community:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer none): The module community website address.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v2_get_community (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_set_description:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @description: (in): The untranslated description of this module.
+ *
+ * Set the module description.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_set_description (ModulemdModuleStreamV2 *self,
+                                           const gchar *description);
+
+
+/**
+ * modulemd_module_stream_v2_get_description:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer none): The module description.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v2_get_description (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_set_documentation:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @documentation: (in): The upstream documentation website for this module.
+ *
+ * Set the module documentation website address.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_set_documentation (ModulemdModuleStreamV2 *self,
+                                             const gchar *documentation);
+
+
+/**
+ * modulemd_module_stream_v2_get_documentation:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer none): The module documentation website address.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v2_get_documentation (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_set_summary:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @summary: (in): The untranslated summary of this module.
+ *
+ * Set the module summary.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_set_summary (ModulemdModuleStreamV2 *self,
+                                       const gchar *summary);
+
+
+/**
+ * modulemd_module_stream_v2_get_summary:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer none): The module summary.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v2_get_summary (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_set_tracker:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @tracker: (in): The upstream bug tracker website for this module.
+ *
+ * Set the module bug tracker website address.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_set_tracker (ModulemdModuleStreamV2 *self,
+                                       const gchar *tracker);
+
+
+/**
+ * modulemd_module_stream_v2_get_tracker:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer none): The module bug tracker website address.
+ *
+ * Since: 2.0
+ */
+const gchar *
+modulemd_module_stream_v2_get_tracker (ModulemdModuleStreamV2 *self);
+
+
+/* ===== Non-property Methods ===== */
+
+
+/**
+ * modulemd_module_stream_v2_add_component:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @component: (in) (transfer none): A #ModulemdComponent to be added to this
+ * module stream.
+ *
+ * Add a component definition to the module.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_add_component (ModulemdModuleStreamV2 *self,
+                                         ModulemdComponent *component);
+
+
+/**
+ * modulemd_module_stream_v2_remove_module_component:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @component_name: (in): The name of the component to remove from the module
+ * stream.
+ *
+ * Remove a component from this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_remove_module_component (
+  ModulemdModuleStreamV2 *self, const gchar *component_name);
+
+
+/**
+ * modulemd_module_stream_v2_remove_rpm_component:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @component_name: (in): The name of the component to remove from the module
+ * stream.
+ *
+ * Remove a component from this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_remove_rpm_component (ModulemdModuleStreamV2 *self,
+                                                const gchar *component_name);
+
+
+/**
+ * modulemd_module_stream_v2_get_module_component_names_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer full): An ordered list of module component names included
+ * in this stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v2_get_module_component_names_as_strv (
+  ModulemdModuleStreamV2 *self);
+
+/**
+ * modulemd_module_stream_v2_get_rpm_component_names_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer full): An ordered list of RPM component names included
+ * in this stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v2_get_rpm_component_names_as_strv (
+  ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_get_module_component:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @component_name: (in): The name of the component to retrieve.
+ *
+ * Returns: (transfer none): The module component matching @component name if
+ * it exists, else NULL.
+ *
+ * Since: 2.0
+ */
+ModulemdComponentModule *
+modulemd_module_stream_v2_get_module_component (ModulemdModuleStreamV2 *self,
+                                                const gchar *component_name);
+
+
+/**
+ * modulemd_module_stream_v2_get_rpm_component:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @component_name: (in): The name of the component to retrieve.
+ *
+ * Returns: (transfer none): The RPM component matching @component name if it
+ * exists, else NULL.
+ *
+ * Since: 2.0
+ */
+ModulemdComponentRpm *
+modulemd_module_stream_v2_get_rpm_component (ModulemdModuleStreamV2 *self,
+                                             const gchar *component_name);
+
+
+/**
+ * modulemd_module_stream_v2_add_content_license:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @license: (in): A license under which one or more of the components of this
+ * module stream are distributed.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_add_content_license (ModulemdModuleStreamV2 *self,
+                                               const gchar *license);
+
+
+/**
+ * modulemd_module_stream_v2_add_module_license:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @license: (in): A license under which this module stream is distributed.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_add_module_license (ModulemdModuleStreamV2 *self,
+                                              const gchar *license);
+
+
+/**
+ * modulemd_module_stream_v2_remove_content_license:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @license: (in): A license to remove from the list. Has no effect if the
+ * license is not present.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_remove_content_license (ModulemdModuleStreamV2 *self,
+                                                  const gchar *license);
+
+
+/**
+ * modulemd_module_stream_v2_remove_module_license:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @license: (in): A license to remove from the list. Has no effect if the
+ * license is not present.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_remove_module_license (ModulemdModuleStreamV2 *self,
+                                                 const gchar *license);
+
+
+/**
+ * modulemd_module_stream_v2_get_content_licenses_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer full): An ordered list of licenses under which one or
+ * more components of this module stream are released.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v2_get_content_licenses_as_strv (
+  ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_get_module_licenses_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer full): An ordered list of licenses under which this
+ * module stream is released.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v2_get_module_licenses_as_strv (
+  ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_add_profile:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @profile: (in) (transfer none): A #ModulemdProfile for this module stream.
+ *
+ * Adds a profile definition to this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_add_profile (ModulemdModuleStreamV2 *self,
+                                       ModulemdProfile *profile);
+
+
+/**
+ * modulemd_module_stream_v2_clear_profiles:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
+ *
+ * Removes all profiles from this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_clear_profiles (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_get_profile_names_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer full): An ordered list of profile names associated with
+ * this module stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v2_get_profile_names_as_strv (
+  ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_get_profile:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @profile_name: (in): The name of a profile to retrieve.
+ *
+ * Returns: (transfer none): The requested profile definition if present in the
+ * module stream. NULL otherwise.
+ *
+ * Since: 2.0
+ */
+ModulemdProfile *
+modulemd_module_stream_v2_get_profile (ModulemdModuleStreamV2 *self,
+                                       const gchar *profile_name);
+
+
+/**
+ * modulemd_module_stream_v2_add_rpm_api:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @rpm: (in): The name of a binary RPM present in this module that is
+ * considered stable public API.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_add_rpm_api (ModulemdModuleStreamV2 *self,
+                                       const gchar *rpm);
+
+
+/**
+ * modulemd_module_stream_v2_remove_rpm_api:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @rpm: (in): A binary RPM name to remove from the list of stable public API.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_remove_rpm_api (ModulemdModuleStreamV2 *self,
+                                          const gchar *rpm);
+
+
+/**
+ * modulemd_module_stream_v2_get_rpm_api_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer full): An ordered list of binary RPM names that forms
+ * the public API of this module stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v2_get_rpm_api_as_strv (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_add_rpm_artifact:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @nevr: (in): The NEVR of a binary RPM present in this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_add_rpm_artifact (ModulemdModuleStreamV2 *self,
+                                            const gchar *nevr);
+
+
+/**
+ * modulemd_module_stream_v2_remove_rpm_artifact:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @nevr: (in): An RPM NEVR to remove from the list of artifacts.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_remove_rpm_artifact (ModulemdModuleStreamV2 *self,
+                                               const gchar *nevr);
+
+
+/**
+ * modulemd_module_stream_v2_get_rpm_artifacts_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer full): An ordered list of RPM NEVRs are included in this
+ * module stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v2_get_rpm_artifacts_as_strv (
+  ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_add_rpm_filter:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @rpm: (in): The name of a binary RPM to filter out of this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_add_rpm_filter (ModulemdModuleStreamV2 *self,
+                                          const gchar *rpm);
+
+
+/**
+ * modulemd_module_stream_v2_remove_rpm_filter:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @rpm: (in): A binary RPM name to remove from the filter list.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_remove_rpm_filter (ModulemdModuleStreamV2 *self,
+                                             const gchar *rpm);
+
+
+/**
+ * modulemd_module_stream_v2_get_rpm_filters_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer full): An ordered list of binary RPM names that are
+ * filtered out of this module stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v2_get_rpm_filters_as_strv (
+  ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_add_servicelevel:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @servicelevel: (in) (transfer none): A #ModulemdServiceLevel for this module stream.
+ *
+ * Adds a servicelevel definition to this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_add_servicelevel (
+  ModulemdModuleStreamV2 *self, ModulemdServiceLevel *servicelevel);
+
+
+/**
+ * modulemd_module_stream_v2_clear_servicelevels:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Removes all servicelevels from this module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_clear_servicelevels (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_get_servicelevel_names_as_strv:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer full): An ordered list of servicelevel names associated with
+ * this module stream.
+ *
+ * Since: 2.0
+ */
+GStrv
+modulemd_module_stream_v2_get_servicelevel_names_as_strv (
+  ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_get_servicelevel:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @servicelevel_name: (in): The name of a servicelevel to retrieve.
+ *
+ * Returns: (transfer none): The requested servicelevel definition if present in the
+ * module stream. NULL otherwise.
+ *
+ * Since: 2.0
+ */
+ModulemdServiceLevel *
+modulemd_module_stream_v2_get_servicelevel (ModulemdModuleStreamV2 *self,
+                                            const gchar *servicelevel_name);
+
+
+/**
+ * modulemd_module_stream_v2_add_dependencies:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @deps: (in): A #ModulemdDependencies object to add to the list for this
+ * module stream.
+ *
+ * Add a #ModulemdDependencies object to the list of dependencies for this
+ * module stream.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_add_dependencies (ModulemdModuleStreamV2 *self,
+                                            ModulemdDependencies *deps);
+
+
+/**
+ * modulemd_module_stream_v2_get_dependencies:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Return the list of #ModulemdDependencies objects as a GPtrArray
+ *
+ * Returns: (transfer none) (element-type ModulemdDependencies): A list of
+ * all #ModulemdDependencies objects associated with this module stream.
+ */
+GPtrArray *
+modulemd_module_stream_v2_get_dependencies (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_set_xmd:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @xmd: (in) (transfer full): A #GVariant representing arbitrary YAML.
+ *
+ * Sets the eXtensible MetaData (XMD) for this module. XMD is arbitrary YAML
+ * data that will be set and returned as-is (with the exception that the
+ * ordering of mapping keys is not defined). Useful for carrying private data.
+ *
+ * This function assumes ownership of the XMD #GVariant and thus should not be
+ * freed by the caller.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_set_xmd (ModulemdModuleStreamV2 *self,
+                                   GVariant *xmd);
+
+
+/**
+ * modulemd_module_stream_v2_get_xmd:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer none): The extensible metadata block as a GVariant.
+ */
+GVariant *
+modulemd_module_stream_v2_get_xmd (ModulemdModuleStreamV2 *self);
+
 
 G_END_DECLS

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-util.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-util.h
@@ -80,5 +80,8 @@ modulemd_ordered_str_keys (GHashTable *htable, GCompareFunc compare_func);
 gchar **
 modulemd_ordered_str_keys_as_strv (GHashTable *htable);
 
+GVariant *
+modulemd_variant_deep_copy (GVariant *variant);
+
 void
 modulemd_hash_table_unref (void *table);

--- a/modulemd/v2/meson.build
+++ b/modulemd/v2/meson.build
@@ -90,6 +90,10 @@ if not test_installed_lib
     # This test is just to catch whether we are accidentally not testing
     # the built version.
     py_test_env.set ('MODULEMD_VERSION', libmodulemd_v2_version)
+else
+    # Add an env var to exercise the Python overrides, which can only be done
+    # against installed libs.
+    py_test_env.set ('MMD_TEST_INSTALLED_LIBS', 'TRUE')
 endif
 
 # Python test env with release values

--- a/modulemd/v2/modulemd-module-stream-v1.c
+++ b/modulemd/v2/modulemd-module-stream-v1.c
@@ -11,12 +11,49 @@
  * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
  */
 
+#include "modulemd-buildopts.h"
+#include "modulemd-component.h"
+#include "modulemd-component-module.h"
+#include "modulemd-component-rpm.h"
 #include "modulemd-module-stream.h"
 #include "modulemd-module-stream-v1.h"
+#include "modulemd-profile.h"
+#include "private/modulemd-util.h"
 
 struct _ModulemdModuleStreamV1
 {
   GObject parent_instance;
+
+  /* Properties */
+  gchar *arch;
+  ModulemdBuildopts *buildopts;
+  gchar *community;
+  gchar *description;
+  gchar *documentation;
+  gchar *summary;
+  gchar *tracker;
+
+  /* Internal Data Structures */
+  GHashTable *rpm_components; /* <string, Modulemd.ComponentRpm> */
+  GHashTable *module_components; /* <string, Modulemd.ComponentModule */
+
+  GHashTable *content_licenses; /* string set */
+  GHashTable *module_licenses; /* string set */
+
+  GHashTable *profiles; /* <string, Modulemd.Profile> */
+
+  GHashTable *rpm_api; /* string set */
+
+  GHashTable *rpm_artifacts; /* string set */
+
+  GHashTable *rpm_filters; /* string set */
+
+  GHashTable *servicelevels; /* <string, Modulemd.ServiceLevel */
+
+  GHashTable *buildtime_deps; /* <string, string> */
+  GHashTable *runtime_deps; /* <string, string> */
+
+  GVariant *xmd;
 };
 
 G_DEFINE_TYPE (ModulemdModuleStreamV1,
@@ -26,8 +63,17 @@ G_DEFINE_TYPE (ModulemdModuleStreamV1,
 enum
 {
   PROP_0,
+  PROP_ARCH,
+  PROP_BUILDOPTS,
+  PROP_COMMUNITY,
+  PROP_DESCRIPTION,
+  PROP_DOCUMENTATION,
+  PROP_SUMMARY,
+  PROP_TRACKER,
   N_PROPS
 };
+
+static GParamSpec *properties[N_PROPS];
 
 ModulemdModuleStreamV1 *
 modulemd_module_stream_v1_new (const gchar *module_name,
@@ -42,18 +88,717 @@ modulemd_module_stream_v1_new (const gchar *module_name,
 }
 
 
+static void
+modulemd_module_stream_v1_finalize (GObject *object)
+{
+  ModulemdModuleStreamV1 *self = MODULEMD_MODULE_STREAM_V1 (object);
+
+  /* Properties */
+  g_clear_pointer (&self->arch, g_free);
+  g_clear_object (&self->buildopts);
+  g_clear_pointer (&self->community, g_free);
+  g_clear_pointer (&self->description, g_free);
+  g_clear_pointer (&self->documentation, g_free);
+  g_clear_pointer (&self->summary, g_free);
+
+  /* Internal Data Structures */
+  g_clear_pointer (&self->module_components, g_hash_table_unref);
+  g_clear_pointer (&self->rpm_components, g_hash_table_unref);
+
+  g_clear_pointer (&self->content_licenses, g_hash_table_unref);
+  g_clear_pointer (&self->module_licenses, g_hash_table_unref);
+
+  g_clear_pointer (&self->profiles, g_hash_table_unref);
+
+  g_clear_pointer (&self->rpm_api, g_hash_table_unref);
+
+  g_clear_pointer (&self->rpm_artifacts, g_hash_table_unref);
+
+  g_clear_pointer (&self->rpm_filters, g_hash_table_unref);
+
+  g_clear_pointer (&self->servicelevels, g_hash_table_unref);
+
+  g_clear_pointer (&self->buildtime_deps, g_hash_table_unref);
+  g_clear_pointer (&self->runtime_deps, g_hash_table_unref);
+
+  g_clear_pointer (&self->xmd, g_variant_unref);
+
+  G_OBJECT_CLASS (modulemd_module_stream_v1_parent_class)->finalize (object);
+}
+
+
+/* ===== Properties ====== */
+
+
 static guint64
 modulemd_module_stream_v1_get_mdversion (ModulemdModuleStream *self)
 {
   return MD_MODULESTREAM_VERSION_ONE;
 }
 
-
-static void
-modulemd_module_stream_v1_finalize (GObject *object)
+void
+modulemd_module_stream_v1_set_arch (ModulemdModuleStreamV1 *self,
+                                    const gchar *arch)
 {
-  G_OBJECT_CLASS (modulemd_module_stream_v1_parent_class)->finalize (object);
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_clear_pointer (&self->arch, g_free);
+  self->arch = g_strdup (arch);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_ARCH]);
 }
+
+
+const gchar *
+modulemd_module_stream_v1_get_arch (ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return self->arch;
+}
+
+
+void
+modulemd_module_stream_v1_set_buildopts (ModulemdModuleStreamV1 *self,
+                                         ModulemdBuildopts *buildopts)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_clear_object (&self->buildopts);
+  self->buildopts = modulemd_buildopts_copy (buildopts);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_BUILDOPTS]);
+}
+
+
+ModulemdBuildopts *
+modulemd_module_stream_v1_get_buildopts (ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return self->buildopts;
+}
+
+
+void
+modulemd_module_stream_v1_set_community (ModulemdModuleStreamV1 *self,
+                                         const gchar *community)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_clear_pointer (&self->community, g_free);
+  self->community = g_strdup (community);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_COMMUNITY]);
+}
+
+
+const gchar *
+modulemd_module_stream_v1_get_community (ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return self->community;
+}
+
+
+void
+modulemd_module_stream_v1_set_description (ModulemdModuleStreamV1 *self,
+                                           const gchar *description)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_clear_pointer (&self->description, g_free);
+  self->description = g_strdup (description);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_DESCRIPTION]);
+}
+
+
+const gchar *
+modulemd_module_stream_v1_get_description (ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return self->description;
+}
+
+
+void
+modulemd_module_stream_v1_set_documentation (ModulemdModuleStreamV1 *self,
+                                             const gchar *documentation)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_clear_pointer (&self->documentation, g_free);
+  self->documentation = g_strdup (documentation);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_COMMUNITY]);
+}
+
+
+const gchar *
+modulemd_module_stream_v1_get_documentation (ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return self->documentation;
+}
+
+
+void
+modulemd_module_stream_v1_set_summary (ModulemdModuleStreamV1 *self,
+                                       const gchar *summary)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_clear_pointer (&self->summary, g_free);
+  self->summary = g_strdup (summary);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_DESCRIPTION]);
+}
+
+
+const gchar *
+modulemd_module_stream_v1_get_summary (ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return self->summary;
+}
+
+
+void
+modulemd_module_stream_v1_set_tracker (ModulemdModuleStreamV1 *self,
+                                       const gchar *tracker)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_clear_pointer (&self->tracker, g_free);
+  self->tracker = g_strdup (tracker);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_TRACKER]);
+}
+
+
+const gchar *
+modulemd_module_stream_v1_get_tracker (ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return self->tracker;
+}
+
+
+/* ===== Non-property Methods ===== */
+
+
+void
+modulemd_module_stream_v1_add_component (ModulemdModuleStreamV1 *self,
+                                         ModulemdComponent *component)
+{
+  GHashTable *table = NULL;
+
+  /* Do nothing if we were passed a NULL component */
+  if (!component)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+  g_return_if_fail (MODULEMD_IS_COMPONENT (component));
+
+  if (MODULEMD_IS_COMPONENT_RPM (component))
+    {
+      table = self->rpm_components;
+    }
+  else if (MODULEMD_IS_COMPONENT_MODULE (component))
+    {
+      table = self->module_components;
+    }
+  else
+    {
+      /* Unknown component. Raise a warning and return */
+      g_return_if_reached ();
+    }
+
+  /* Add the component to the table. This will replace an existing component
+   * with the same name
+   */
+  g_hash_table_replace (table,
+                        g_strdup (modulemd_component_get_name (component)),
+                        modulemd_component_copy (component, NULL));
+}
+
+
+void
+modulemd_module_stream_v1_remove_module_component (
+  ModulemdModuleStreamV1 *self, const gchar *component_name)
+{
+  /* Do nothing if we were passed a NULL component_name */
+  if (!component_name)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_remove (self->module_components, component_name);
+}
+
+
+void
+modulemd_module_stream_v1_remove_rpm_component (ModulemdModuleStreamV1 *self,
+                                                const gchar *component_name)
+{
+  /* Do nothing if we were passed a NULL component_name */
+  if (!component_name)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_remove (self->rpm_components, component_name);
+}
+
+
+GStrv
+modulemd_module_stream_v1_get_module_component_names_as_strv (
+  ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->module_components);
+}
+
+
+GStrv
+modulemd_module_stream_v1_get_rpm_component_names_as_strv (
+  ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->rpm_components);
+}
+
+
+ModulemdComponentModule *
+modulemd_module_stream_v1_get_module_component (ModulemdModuleStreamV1 *self,
+                                                const gchar *component_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return g_hash_table_lookup (self->module_components, component_name);
+}
+
+
+ModulemdComponentRpm *
+modulemd_module_stream_v1_get_rpm_component (ModulemdModuleStreamV1 *self,
+                                             const gchar *component_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return g_hash_table_lookup (self->rpm_components, component_name);
+}
+
+
+void
+modulemd_module_stream_v1_add_content_license (ModulemdModuleStreamV1 *self,
+                                               const gchar *license)
+{
+  if (!license)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_add (self->content_licenses, g_strdup (license));
+}
+
+
+void
+modulemd_module_stream_v1_add_module_license (ModulemdModuleStreamV1 *self,
+                                              const gchar *license)
+{
+  if (!license)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_add (self->module_licenses, g_strdup (license));
+}
+
+
+void
+modulemd_module_stream_v1_remove_content_license (ModulemdModuleStreamV1 *self,
+                                                  const gchar *license)
+{
+  if (!license)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_remove (self->content_licenses, license);
+}
+
+
+void
+modulemd_module_stream_v1_remove_module_license (ModulemdModuleStreamV1 *self,
+                                                 const gchar *license)
+{
+  if (!license)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_remove (self->module_licenses, license);
+}
+
+
+GStrv
+modulemd_module_stream_v1_get_content_licenses_as_strv (
+  ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->content_licenses);
+}
+
+
+GStrv
+modulemd_module_stream_v1_get_module_licenses_as_strv (
+  ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->module_licenses);
+}
+
+
+void
+modulemd_module_stream_v1_add_profile (ModulemdModuleStreamV1 *self,
+                                       ModulemdProfile *profile)
+{
+  if (!profile)
+    return;
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+  g_return_if_fail (MODULEMD_IS_PROFILE (profile));
+
+  g_hash_table_replace (self->profiles,
+                        g_strdup (modulemd_profile_get_name (profile)),
+                        modulemd_profile_copy (profile));
+}
+
+
+void
+modulemd_module_stream_v1_clear_profiles (ModulemdModuleStreamV1 *self)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_remove_all (self->profiles);
+}
+
+
+GStrv
+modulemd_module_stream_v1_get_profile_names_as_strv (
+  ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->profiles);
+}
+
+
+ModulemdProfile *
+modulemd_module_stream_v1_get_profile (ModulemdModuleStreamV1 *self,
+                                       const gchar *profile_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return g_hash_table_lookup (self->profiles, profile_name);
+}
+
+
+void
+modulemd_module_stream_v1_add_rpm_api (ModulemdModuleStreamV1 *self,
+                                       const gchar *rpm)
+{
+  if (!rpm)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_add (self->rpm_api, g_strdup (rpm));
+}
+
+
+void
+modulemd_module_stream_v1_remove_rpm_api (ModulemdModuleStreamV1 *self,
+                                          const gchar *rpm)
+{
+  if (!rpm)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_remove (self->rpm_api, rpm);
+}
+
+GStrv
+modulemd_module_stream_v1_get_rpm_api_as_strv (ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->rpm_api);
+}
+
+
+void
+modulemd_module_stream_v1_add_rpm_artifact (ModulemdModuleStreamV1 *self,
+                                            const gchar *nevr)
+{
+  if (!nevr)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_add (self->rpm_artifacts, g_strdup (nevr));
+}
+
+
+void
+modulemd_module_stream_v1_remove_rpm_artifact (ModulemdModuleStreamV1 *self,
+                                               const gchar *nevr)
+{
+  if (!nevr)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_remove (self->rpm_artifacts, nevr);
+}
+
+
+GStrv
+modulemd_module_stream_v1_get_rpm_artifacts_as_strv (
+  ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->rpm_artifacts);
+}
+
+
+void
+modulemd_module_stream_v1_add_rpm_filter (ModulemdModuleStreamV1 *self,
+                                          const gchar *rpm)
+{
+  if (!rpm)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_add (self->rpm_filters, g_strdup (rpm));
+}
+
+
+void
+modulemd_module_stream_v1_remove_rpm_filter (ModulemdModuleStreamV1 *self,
+                                             const gchar *rpm)
+{
+  if (!rpm)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_remove (self->rpm_filters, rpm);
+}
+
+
+GStrv
+modulemd_module_stream_v1_get_rpm_filters_as_strv (
+  ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->rpm_filters);
+}
+
+
+void
+modulemd_module_stream_v1_add_servicelevel (ModulemdModuleStreamV1 *self,
+                                            ModulemdServiceLevel *servicelevel)
+{
+  if (!servicelevel)
+    return;
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+  g_return_if_fail (MODULEMD_IS_SERVICE_LEVEL (servicelevel));
+
+  g_hash_table_replace (
+    self->servicelevels,
+    g_strdup (modulemd_service_level_get_name (servicelevel)),
+    modulemd_service_level_copy (servicelevel));
+}
+
+
+void
+modulemd_module_stream_v1_clear_servicelevels (ModulemdModuleStreamV1 *self)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_hash_table_remove_all (self->servicelevels);
+}
+
+
+GStrv
+modulemd_module_stream_v1_get_servicelevel_names_as_strv (
+  ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->servicelevels);
+}
+
+
+ModulemdServiceLevel *
+modulemd_module_stream_v1_get_servicelevel (ModulemdModuleStreamV1 *self,
+                                            const gchar *servicelevel_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return g_hash_table_lookup (self->servicelevels, servicelevel_name);
+}
+
+
+void
+modulemd_module_stream_v1_set_eol (ModulemdModuleStreamV1 *self, GDate *eol)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  /* The "eol" field in the YAML is a relic of an early iteration and has been
+   * entirely replaced by the ServiceLevel concept. If we encounter it, we just
+   * treat it as if it was the EOL value for a service level named "rawhide".
+   */
+  g_autoptr (ModulemdServiceLevel) sl = modulemd_service_level_new ("rawhide");
+  modulemd_service_level_set_eol (sl, eol);
+
+  return modulemd_module_stream_v1_add_servicelevel (self, sl);
+}
+
+
+GDate *
+modulemd_module_stream_v1_get_eol (ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  ModulemdServiceLevel *sl =
+    modulemd_module_stream_v1_get_servicelevel (self, "rawhide");
+
+  return modulemd_service_level_get_eol (sl);
+}
+
+
+void
+modulemd_module_stream_v1_add_buildtime_requirement (
+  ModulemdModuleStreamV1 *self,
+  const gchar *module_name,
+  const gchar *module_stream)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+  g_return_if_fail (module_name && module_stream);
+
+  g_hash_table_replace (
+    self->buildtime_deps, g_strdup (module_name), g_strdup (module_stream));
+}
+
+
+void
+modulemd_module_stream_v1_add_runtime_requirement (
+  ModulemdModuleStreamV1 *self,
+  const gchar *module_name,
+  const gchar *module_stream)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+  g_return_if_fail (module_name && module_stream);
+
+  g_hash_table_replace (
+    self->runtime_deps, g_strdup (module_name), g_strdup (module_stream));
+}
+
+
+void
+modulemd_module_stream_v1_remove_buildtime_requirement (
+  ModulemdModuleStreamV1 *self, const gchar *module_name)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+  g_return_if_fail (module_name);
+
+  g_hash_table_remove (self->buildtime_deps, module_name);
+}
+
+
+void
+modulemd_module_stream_v1_remove_runtime_requirement (
+  ModulemdModuleStreamV1 *self, const gchar *module_name)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+  g_return_if_fail (module_name);
+
+  g_hash_table_remove (self->runtime_deps, module_name);
+}
+
+
+GStrv
+modulemd_module_stream_v1_get_buildtime_modules_as_strv (
+  ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->buildtime_deps);
+}
+
+
+GStrv
+modulemd_module_stream_v1_get_runtime_modules_as_strv (
+  ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->runtime_deps);
+}
+
+
+const gchar *
+modulemd_module_stream_v1_get_buildtime_requirement_stream (
+  ModulemdModuleStreamV1 *self, const gchar *module_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return g_hash_table_lookup (self->buildtime_deps, module_name);
+}
+
+
+const gchar *
+modulemd_module_stream_v1_get_runtime_requirement_stream (
+  ModulemdModuleStreamV1 *self, const gchar *module_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return g_hash_table_lookup (self->runtime_deps, module_name);
+}
+
+
+void
+modulemd_module_stream_v1_set_xmd (ModulemdModuleStreamV1 *self, GVariant *xmd)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
+
+  g_clear_pointer (&self->xmd, g_variant_unref);
+  self->xmd = xmd;
+}
+
+GVariant *
+modulemd_module_stream_v1_get_xmd (ModulemdModuleStreamV1 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  return self->xmd;
+}
+
 
 static void
 modulemd_module_stream_v1_get_property (GObject *object,
@@ -61,8 +806,42 @@ modulemd_module_stream_v1_get_property (GObject *object,
                                         GValue *value,
                                         GParamSpec *pspec)
 {
+  ModulemdModuleStreamV1 *self = MODULEMD_MODULE_STREAM_V1 (object);
+
   switch (prop_id)
     {
+    case PROP_ARCH:
+      g_value_set_string (value, modulemd_module_stream_v1_get_arch (self));
+      break;
+
+    case PROP_BUILDOPTS:
+      g_value_set_object (value,
+                          modulemd_module_stream_v1_get_buildopts (self));
+      break;
+
+    case PROP_COMMUNITY:
+      g_value_set_string (value,
+                          modulemd_module_stream_v1_get_community (self));
+      break;
+
+    case PROP_DESCRIPTION:
+      g_value_set_string (value,
+                          modulemd_module_stream_v1_get_description (self));
+      break;
+
+    case PROP_DOCUMENTATION:
+      g_value_set_string (value,
+                          modulemd_module_stream_v1_get_documentation (self));
+      break;
+
+    case PROP_SUMMARY:
+      g_value_set_string (value, modulemd_module_stream_v1_get_summary (self));
+      break;
+
+    case PROP_TRACKER:
+      g_value_set_string (value, modulemd_module_stream_v1_get_tracker (self));
+      break;
+
     default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
 }
@@ -73,8 +852,42 @@ modulemd_module_stream_v1_set_property (GObject *object,
                                         const GValue *value,
                                         GParamSpec *pspec)
 {
+  ModulemdModuleStreamV1 *self = MODULEMD_MODULE_STREAM_V1 (object);
+
   switch (prop_id)
     {
+    case PROP_ARCH:
+      modulemd_module_stream_v1_set_arch (self, g_value_get_string (value));
+      break;
+
+    case PROP_BUILDOPTS:
+      modulemd_module_stream_v1_set_buildopts (self,
+                                               g_value_get_object (value));
+      break;
+
+    case PROP_COMMUNITY:
+      modulemd_module_stream_v1_set_community (self,
+                                               g_value_get_string (value));
+      break;
+
+    case PROP_DESCRIPTION:
+      modulemd_module_stream_v1_set_description (self,
+                                                 g_value_get_string (value));
+      break;
+
+    case PROP_DOCUMENTATION:
+      modulemd_module_stream_v1_set_documentation (self,
+                                                   g_value_get_string (value));
+      break;
+
+    case PROP_SUMMARY:
+      modulemd_module_stream_v1_set_summary (self, g_value_get_string (value));
+      break;
+
+    case PROP_TRACKER:
+      modulemd_module_stream_v1_set_tracker (self, g_value_get_string (value));
+      break;
+
     default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
 }
@@ -91,9 +904,92 @@ modulemd_module_stream_v1_class_init (ModulemdModuleStreamV1Class *klass)
   object_class->set_property = modulemd_module_stream_v1_set_property;
 
   stream_class->get_mdversion = modulemd_module_stream_v1_get_mdversion;
+
+  properties[PROP_ARCH] = g_param_spec_string (
+    "arch",
+    "Module Artifact Architecture",
+    "The architecture of the produced artifacts",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  properties[PROP_BUILDOPTS] =
+    g_param_spec_object ("buildopts",
+                         "Module Build Options",
+                         "Build options for module components",
+                         MODULEMD_TYPE_BUILDOPTS,
+                         G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+  properties[PROP_COMMUNITY] = g_param_spec_string (
+    "community",
+    "Module Community Website",
+    "The website address of the upstream community for this module",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  properties[PROP_DESCRIPTION] = g_param_spec_string (
+    "description",
+    "Module Description",
+    "The description of this module",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  properties[PROP_DOCUMENTATION] = g_param_spec_string (
+    "documentation",
+    "Module Documentation Website",
+    "The website address of the upstream documentation for this module",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  properties[PROP_SUMMARY] = g_param_spec_string (
+    "summary",
+    "Module Summary",
+    "The short description of this module",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  properties[PROP_TRACKER] = g_param_spec_string (
+    "tracker",
+    "Module Bug Tracker Website",
+    "The website address of the upstream bug tracker for this module",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  g_object_class_install_properties (object_class, N_PROPS, properties);
 }
 
 static void
 modulemd_module_stream_v1_init (ModulemdModuleStreamV1 *self)
 {
+  /* Properties */
+
+  /* Internal Data Structures */
+  self->module_components =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  self->rpm_components =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+
+  self->content_licenses =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  self->module_licenses =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  self->profiles =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+
+  self->rpm_api =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  self->rpm_artifacts =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  self->rpm_filters =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  self->servicelevels =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+
+  self->buildtime_deps =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  self->runtime_deps =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 }

--- a/modulemd/v2/modulemd-module-stream-v2.c
+++ b/modulemd/v2/modulemd-module-stream-v2.c
@@ -11,12 +11,48 @@
  * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
  */
 
+#include "modulemd-buildopts.h"
+#include "modulemd-component.h"
+#include "modulemd-component-module.h"
+#include "modulemd-component-rpm.h"
 #include "modulemd-module-stream.h"
 #include "modulemd-module-stream-v2.h"
+#include "modulemd-profile.h"
+#include "private/modulemd-util.h"
 
 struct _ModulemdModuleStreamV2
 {
   GObject parent_instance;
+
+  /* Properties */
+  gchar *arch;
+  ModulemdBuildopts *buildopts;
+  gchar *community;
+  gchar *description;
+  gchar *documentation;
+  gchar *summary;
+  gchar *tracker;
+
+  /* Internal Data Structures */
+  GHashTable *module_components; /* <string, Modulemd.ComponentModule */
+  GHashTable *rpm_components; /* <string, Modulemd.ComponentRpm> */
+
+  GHashTable *content_licenses; /* string set */
+  GHashTable *module_licenses; /* string set */
+
+  GHashTable *profiles; /* <string, Modulemd.Profile> */
+
+  GHashTable *rpm_api; /* string set */
+
+  GHashTable *rpm_artifacts; /* string set */
+
+  GHashTable *rpm_filters; /* string set */
+
+  GHashTable *servicelevels; /* <string, Modulemd.ServiceLevel */
+
+  GPtrArray *dependencies; /* <Modulemd.Dependencies> */
+
+  GVariant *xmd;
 };
 
 G_DEFINE_TYPE (ModulemdModuleStreamV2,
@@ -26,8 +62,17 @@ G_DEFINE_TYPE (ModulemdModuleStreamV2,
 enum
 {
   PROP_0,
+  PROP_ARCH,
+  PROP_BUILDOPTS,
+  PROP_COMMUNITY,
+  PROP_DESCRIPTION,
+  PROP_DOCUMENTATION,
+  PROP_SUMMARY,
+  PROP_TRACKER,
   N_PROPS
 };
+
+static GParamSpec *properties[N_PROPS];
 
 ModulemdModuleStreamV2 *
 modulemd_module_stream_v2_new (const gchar *module_name,
@@ -42,6 +87,45 @@ modulemd_module_stream_v2_new (const gchar *module_name,
 }
 
 
+static void
+modulemd_module_stream_v2_finalize (GObject *object)
+{
+  ModulemdModuleStreamV2 *self = MODULEMD_MODULE_STREAM_V2 (object);
+
+  /* Properties */
+  g_clear_pointer (&self->arch, g_free);
+  g_clear_object (&self->buildopts);
+  g_clear_pointer (&self->community, g_free);
+  g_clear_pointer (&self->description, g_free);
+  g_clear_pointer (&self->documentation, g_free);
+  g_clear_pointer (&self->summary, g_free);
+  g_clear_pointer (&self->tracker, g_free);
+
+  /* Internal Data Structures */
+  g_clear_pointer (&self->module_components, g_hash_table_unref);
+  g_clear_pointer (&self->rpm_components, g_hash_table_unref);
+
+  g_clear_pointer (&self->content_licenses, g_hash_table_unref);
+  g_clear_pointer (&self->module_licenses, g_hash_table_unref);
+
+  g_clear_pointer (&self->profiles, g_hash_table_unref);
+
+  g_clear_pointer (&self->rpm_api, g_hash_table_unref);
+
+  g_clear_pointer (&self->rpm_artifacts, g_hash_table_unref);
+
+  g_clear_pointer (&self->rpm_filters, g_hash_table_unref);
+
+  g_clear_pointer (&self->servicelevels, g_hash_table_unref);
+
+  g_clear_pointer (&self->dependencies, g_ptr_array_unref);
+
+  g_clear_pointer (&self->xmd, g_variant_unref);
+
+  G_OBJECT_CLASS (modulemd_module_stream_v2_parent_class)->finalize (object);
+}
+
+
 static guint64
 modulemd_module_stream_v2_get_mdversion (ModulemdModuleStream *self)
 {
@@ -49,10 +133,566 @@ modulemd_module_stream_v2_get_mdversion (ModulemdModuleStream *self)
 }
 
 
-static void
-modulemd_module_stream_v2_finalize (GObject *object)
+void
+modulemd_module_stream_v2_set_arch (ModulemdModuleStreamV2 *self,
+                                    const gchar *arch)
 {
-  G_OBJECT_CLASS (modulemd_module_stream_v2_parent_class)->finalize (object);
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_clear_pointer (&self->arch, g_free);
+  self->arch = g_strdup (arch);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_ARCH]);
+}
+
+
+const gchar *
+modulemd_module_stream_v2_get_arch (ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return self->arch;
+}
+
+
+void
+modulemd_module_stream_v2_set_buildopts (ModulemdModuleStreamV2 *self,
+                                         ModulemdBuildopts *buildopts)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_clear_object (&self->buildopts);
+  self->buildopts = modulemd_buildopts_copy (buildopts);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_BUILDOPTS]);
+}
+
+
+ModulemdBuildopts *
+modulemd_module_stream_v2_get_buildopts (ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return self->buildopts;
+}
+
+
+void
+modulemd_module_stream_v2_set_community (ModulemdModuleStreamV2 *self,
+                                         const gchar *community)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_clear_pointer (&self->community, g_free);
+  self->community = g_strdup (community);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_COMMUNITY]);
+}
+
+
+const gchar *
+modulemd_module_stream_v2_get_community (ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return self->community;
+}
+
+
+void
+modulemd_module_stream_v2_set_description (ModulemdModuleStreamV2 *self,
+                                           const gchar *description)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_clear_pointer (&self->description, g_free);
+  self->description = g_strdup (description);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_DESCRIPTION]);
+}
+
+
+const gchar *
+modulemd_module_stream_v2_get_description (ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return self->description;
+}
+
+
+void
+modulemd_module_stream_v2_set_documentation (ModulemdModuleStreamV2 *self,
+                                             const gchar *documentation)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_clear_pointer (&self->documentation, g_free);
+  self->documentation = g_strdup (documentation);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_COMMUNITY]);
+}
+
+
+const gchar *
+modulemd_module_stream_v2_get_documentation (ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return self->documentation;
+}
+
+
+void
+modulemd_module_stream_v2_set_summary (ModulemdModuleStreamV2 *self,
+                                       const gchar *summary)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_clear_pointer (&self->summary, g_free);
+  self->summary = g_strdup (summary);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_DESCRIPTION]);
+}
+
+
+const gchar *
+modulemd_module_stream_v2_get_summary (ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return self->summary;
+}
+
+
+void
+modulemd_module_stream_v2_set_tracker (ModulemdModuleStreamV2 *self,
+                                       const gchar *tracker)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_clear_pointer (&self->tracker, g_free);
+  self->tracker = g_strdup (tracker);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_TRACKER]);
+}
+
+
+const gchar *
+modulemd_module_stream_v2_get_tracker (ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return self->tracker;
+}
+
+
+/* ===== Non-property Methods ===== */
+
+void
+modulemd_module_stream_v2_add_component (ModulemdModuleStreamV2 *self,
+                                         ModulemdComponent *component)
+{
+  GHashTable *table = NULL;
+
+  /* Do nothing if we were passed a NULL component */
+  if (!component)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+  g_return_if_fail (MODULEMD_IS_COMPONENT (component));
+
+  if (MODULEMD_IS_COMPONENT_RPM (component))
+    {
+      table = self->rpm_components;
+    }
+  else if (MODULEMD_IS_COMPONENT_MODULE (component))
+    {
+      table = self->module_components;
+    }
+  else
+    {
+      /* Unknown component. Raise a warning and return */
+      g_return_if_reached ();
+    }
+
+  /* Add the component to the table. This will replace an existing component
+   * with the same name
+   */
+  g_hash_table_replace (table,
+                        g_strdup (modulemd_component_get_name (component)),
+                        modulemd_component_copy (component, NULL));
+}
+
+
+void
+modulemd_module_stream_v2_remove_module_component (
+  ModulemdModuleStreamV2 *self, const gchar *component_name)
+{
+  /* Do nothing if we were passed a NULL component_name */
+  if (!component_name)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_remove (self->module_components, component_name);
+}
+
+
+void
+modulemd_module_stream_v2_remove_rpm_component (ModulemdModuleStreamV2 *self,
+                                                const gchar *component_name)
+{
+  /* Do nothing if we were passed a NULL component_name */
+  if (!component_name)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_remove (self->rpm_components, component_name);
+}
+
+
+GStrv
+modulemd_module_stream_v2_get_module_component_names_as_strv (
+  ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->module_components);
+}
+
+
+GStrv
+modulemd_module_stream_v2_get_rpm_component_names_as_strv (
+  ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->rpm_components);
+}
+
+
+ModulemdComponentModule *
+modulemd_module_stream_v2_get_module_component (ModulemdModuleStreamV2 *self,
+                                                const gchar *component_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return g_hash_table_lookup (self->module_components, component_name);
+}
+
+
+ModulemdComponentRpm *
+modulemd_module_stream_v2_get_rpm_component (ModulemdModuleStreamV2 *self,
+                                             const gchar *component_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return g_hash_table_lookup (self->rpm_components, component_name);
+}
+
+
+void
+modulemd_module_stream_v2_add_content_license (ModulemdModuleStreamV2 *self,
+                                               const gchar *license)
+{
+  if (!license)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_add (self->content_licenses, g_strdup (license));
+}
+
+
+void
+modulemd_module_stream_v2_add_module_license (ModulemdModuleStreamV2 *self,
+                                              const gchar *license)
+{
+  if (!license)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_add (self->module_licenses, g_strdup (license));
+}
+
+
+void
+modulemd_module_stream_v2_remove_content_license (ModulemdModuleStreamV2 *self,
+                                                  const gchar *license)
+{
+  if (!license)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_remove (self->content_licenses, license);
+}
+
+
+void
+modulemd_module_stream_v2_remove_module_license (ModulemdModuleStreamV2 *self,
+                                                 const gchar *license)
+{
+  if (!license)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_remove (self->module_licenses, license);
+}
+
+
+GStrv
+modulemd_module_stream_v2_get_content_licenses_as_strv (
+  ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->content_licenses);
+}
+
+
+GStrv
+modulemd_module_stream_v2_get_module_licenses_as_strv (
+  ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->module_licenses);
+}
+
+
+void
+modulemd_module_stream_v2_add_profile (ModulemdModuleStreamV2 *self,
+                                       ModulemdProfile *profile)
+{
+  if (!profile)
+    return;
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+  g_return_if_fail (MODULEMD_IS_PROFILE (profile));
+
+  g_hash_table_replace (self->profiles,
+                        g_strdup (modulemd_profile_get_name (profile)),
+                        modulemd_profile_copy (profile));
+}
+
+
+void
+modulemd_module_stream_v2_clear_profiles (ModulemdModuleStreamV2 *self)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_remove_all (self->profiles);
+}
+
+
+GStrv
+modulemd_module_stream_v2_get_profile_names_as_strv (
+  ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->profiles);
+}
+
+
+ModulemdProfile *
+modulemd_module_stream_v2_get_profile (ModulemdModuleStreamV2 *self,
+                                       const gchar *profile_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return g_hash_table_lookup (self->profiles, profile_name);
+}
+
+
+void
+modulemd_module_stream_v2_add_rpm_api (ModulemdModuleStreamV2 *self,
+                                       const gchar *rpm)
+{
+  if (!rpm)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_add (self->rpm_api, g_strdup (rpm));
+}
+
+
+void
+modulemd_module_stream_v2_remove_rpm_api (ModulemdModuleStreamV2 *self,
+                                          const gchar *rpm)
+{
+  if (!rpm)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_remove (self->rpm_api, rpm);
+}
+
+GStrv
+modulemd_module_stream_v2_get_rpm_api_as_strv (ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->rpm_api);
+}
+
+
+void
+modulemd_module_stream_v2_add_rpm_artifact (ModulemdModuleStreamV2 *self,
+                                            const gchar *nevr)
+{
+  if (!nevr)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_add (self->rpm_artifacts, g_strdup (nevr));
+}
+
+
+void
+modulemd_module_stream_v2_remove_rpm_artifact (ModulemdModuleStreamV2 *self,
+                                               const gchar *nevr)
+{
+  if (!nevr)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_remove (self->rpm_artifacts, nevr);
+}
+
+
+GStrv
+modulemd_module_stream_v2_get_rpm_artifacts_as_strv (
+  ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->rpm_artifacts);
+}
+
+
+void
+modulemd_module_stream_v2_add_rpm_filter (ModulemdModuleStreamV2 *self,
+                                          const gchar *rpm)
+{
+  if (!rpm)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_add (self->rpm_filters, g_strdup (rpm));
+}
+
+
+void
+modulemd_module_stream_v2_remove_rpm_filter (ModulemdModuleStreamV2 *self,
+                                             const gchar *rpm)
+{
+  if (!rpm)
+    return;
+
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_remove (self->rpm_filters, rpm);
+}
+
+
+GStrv
+modulemd_module_stream_v2_get_rpm_filters_as_strv (
+  ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->rpm_filters);
+}
+
+
+void
+modulemd_module_stream_v2_add_servicelevel (ModulemdModuleStreamV2 *self,
+                                            ModulemdServiceLevel *servicelevel)
+{
+  if (!servicelevel)
+    return;
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+  g_return_if_fail (MODULEMD_IS_SERVICE_LEVEL (servicelevel));
+
+  g_hash_table_replace (
+    self->servicelevels,
+    g_strdup (modulemd_service_level_get_name (servicelevel)),
+    modulemd_service_level_copy (servicelevel));
+}
+
+
+void
+modulemd_module_stream_v2_clear_servicelevels (ModulemdModuleStreamV2 *self)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_hash_table_remove_all (self->servicelevels);
+}
+
+
+GStrv
+modulemd_module_stream_v2_get_servicelevel_names_as_strv (
+  ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->servicelevels);
+}
+
+
+ModulemdServiceLevel *
+modulemd_module_stream_v2_get_servicelevel (ModulemdModuleStreamV2 *self,
+                                            const gchar *servicelevel_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return g_hash_table_lookup (self->servicelevels, servicelevel_name);
+}
+
+
+void
+modulemd_module_stream_v2_add_dependencies (ModulemdModuleStreamV2 *self,
+                                            ModulemdDependencies *deps)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_ptr_array_add (self->dependencies, modulemd_dependencies_copy (deps));
+}
+
+
+GPtrArray *
+modulemd_module_stream_v2_get_dependencies (ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  return self->dependencies;
+}
+
+
+void
+modulemd_module_stream_v2_set_xmd (ModulemdModuleStreamV2 *self, GVariant *xmd)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_clear_pointer (&self->xmd, g_variant_unref);
+  self->xmd = xmd;
+}
+
+GVariant *
+modulemd_module_stream_v2_get_xmd (ModulemdModuleStreamV2 *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+  return self->xmd;
 }
 
 static void
@@ -61,8 +701,42 @@ modulemd_module_stream_v2_get_property (GObject *object,
                                         GValue *value,
                                         GParamSpec *pspec)
 {
+  ModulemdModuleStreamV2 *self = MODULEMD_MODULE_STREAM_V2 (object);
+
   switch (prop_id)
     {
+    case PROP_ARCH:
+      g_value_set_string (value, modulemd_module_stream_v2_get_arch (self));
+      break;
+
+    case PROP_BUILDOPTS:
+      g_value_set_object (value,
+                          modulemd_module_stream_v2_get_buildopts (self));
+      break;
+
+    case PROP_COMMUNITY:
+      g_value_set_string (value,
+                          modulemd_module_stream_v2_get_community (self));
+      break;
+
+    case PROP_DESCRIPTION:
+      g_value_set_string (value,
+                          modulemd_module_stream_v2_get_description (self));
+      break;
+
+    case PROP_DOCUMENTATION:
+      g_value_set_string (value,
+                          modulemd_module_stream_v2_get_documentation (self));
+      break;
+
+    case PROP_SUMMARY:
+      g_value_set_string (value, modulemd_module_stream_v2_get_summary (self));
+      break;
+
+    case PROP_TRACKER:
+      g_value_set_string (value, modulemd_module_stream_v2_get_tracker (self));
+      break;
+
     default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
 }
@@ -73,8 +747,41 @@ modulemd_module_stream_v2_set_property (GObject *object,
                                         const GValue *value,
                                         GParamSpec *pspec)
 {
+  ModulemdModuleStreamV2 *self = MODULEMD_MODULE_STREAM_V2 (object);
   switch (prop_id)
     {
+    case PROP_ARCH:
+      modulemd_module_stream_v2_set_arch (self, g_value_get_string (value));
+      break;
+
+    case PROP_BUILDOPTS:
+      modulemd_module_stream_v2_set_buildopts (self,
+                                               g_value_get_object (value));
+      break;
+
+    case PROP_COMMUNITY:
+      modulemd_module_stream_v2_set_community (self,
+                                               g_value_get_string (value));
+      break;
+
+    case PROP_DESCRIPTION:
+      modulemd_module_stream_v2_set_description (self,
+                                                 g_value_get_string (value));
+      break;
+
+    case PROP_DOCUMENTATION:
+      modulemd_module_stream_v2_set_documentation (self,
+                                                   g_value_get_string (value));
+      break;
+
+    case PROP_SUMMARY:
+      modulemd_module_stream_v2_set_summary (self, g_value_get_string (value));
+      break;
+
+    case PROP_TRACKER:
+      modulemd_module_stream_v2_set_tracker (self, g_value_get_string (value));
+      break;
+
     default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
 }
@@ -91,9 +798,93 @@ modulemd_module_stream_v2_class_init (ModulemdModuleStreamV2Class *klass)
   object_class->set_property = modulemd_module_stream_v2_set_property;
 
   stream_class->get_mdversion = modulemd_module_stream_v2_get_mdversion;
+
+  properties[PROP_ARCH] = g_param_spec_string (
+    "arch",
+    "Module Artifact Architecture",
+    "The architecture of the produced artifacts",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  properties[PROP_BUILDOPTS] =
+    g_param_spec_object ("buildopts",
+                         "Module Build Options",
+                         "Build options for module components",
+                         MODULEMD_TYPE_BUILDOPTS,
+                         G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+  properties[PROP_COMMUNITY] = g_param_spec_string (
+    "community",
+    "Module Community Website",
+    "The website address of the upstream community for this module",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  properties[PROP_DESCRIPTION] = g_param_spec_string (
+    "description",
+    "Module Description",
+    "The description of this module",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  properties[PROP_DOCUMENTATION] = g_param_spec_string (
+    "documentation",
+    "Module Documentation Website",
+    "The website address of the upstream documentation for this module",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  properties[PROP_SUMMARY] = g_param_spec_string (
+    "summary",
+    "Module Summary",
+    "The short description of this module",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  properties[PROP_TRACKER] = g_param_spec_string (
+    "tracker",
+    "Module Bug Tracker Website",
+    "The website address of the upstream bug tracker for this module",
+    NULL,
+    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
+
+  g_object_class_install_properties (object_class, N_PROPS, properties);
 }
 
 static void
 modulemd_module_stream_v2_init (ModulemdModuleStreamV2 *self)
 {
+  /* Properties */
+
+  /* Internal Data Structures */
+  self->module_components =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+  self->rpm_components =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+
+
+  self->content_licenses =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  self->module_licenses =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  self->profiles =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+
+  self->rpm_api =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  self->rpm_artifacts =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  self->rpm_filters =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+  self->servicelevels =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+
+  /* The common case is for a single entry, so we'll optimize for that when
+   * preallocating
+   */
+  self->dependencies = g_ptr_array_new_full (1, g_object_unref);
 }

--- a/modulemd/v2/modulemd-util.c
+++ b/modulemd/v2/modulemd-util.c
@@ -156,3 +156,14 @@ modulemd_hash_table_unref (void *table)
 
   g_hash_table_unref ((GHashTable *)table);
 }
+
+GVariant *
+modulemd_variant_deep_copy (GVariant *variant)
+{
+  const GVariantType *data_type = g_variant_get_type (variant);
+  gsize data_size = g_variant_get_size (variant);
+  gconstpointer data = g_variant_get_data (variant);
+
+  return g_variant_ref_sink (
+    g_variant_new_from_data (data_type, data, data_size, TRUE, NULL, NULL));
+}

--- a/modulemd/v2/tests/ModulemdTests/modulestream.py
+++ b/modulemd/v2/tests/ModulemdTests/modulestream.py
@@ -1,8 +1,11 @@
+import os
 import sys
 try:
     import unittest
     import gi
+
     gi.require_version('Modulemd', '2.0')
+    from gi.repository import GLib
     from gi.repository import Modulemd
 except ImportError:
     # Return error 77 to skip this test on platforms without the necessary
@@ -174,6 +177,327 @@ class TestModuleStream(TestBase):
             # Add a context
             stream.props.context = 'deadbeef'
             assert stream.get_nsvc_as_string() == 'modulename:streamname:42:deadbeef'
+
+    def test_arch(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            # Check the defaults
+            assert stream.props.arch is None
+            assert stream.get_arch() is None
+
+            # Test property setting
+            stream.props.arch = 'x86_64'
+            assert stream.props.arch == 'x86_64'
+            assert stream.get_arch() == 'x86_64'
+
+            # Test set_arch()
+            stream.set_arch('ppc64le')
+            assert stream.props.arch == 'ppc64le'
+            assert stream.get_arch() == 'ppc64le'
+
+            # Test setting it to None
+            stream.props.arch = None
+            assert stream.props.arch is None
+            assert stream.get_arch() is None
+
+    def test_buildopts(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            # Check the defaults
+            assert stream.props.buildopts is None
+            assert stream.get_buildopts() is None
+
+            buildopts = Modulemd.Buildopts()
+            buildopts.props.rpm_macros = '%demomacro 1'
+            stream.set_buildopts(buildopts)
+
+            assert stream.props.buildopts is not None
+            assert stream.props.buildopts is not None
+            assert stream.props.buildopts.props.rpm_macros == '%demomacro 1'
+
+    def test_community(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            # Check the defaults
+            assert stream.props.community is None
+            assert stream.get_community() is None
+
+            # Test property setting
+            stream.props.community = 'http://example.com'
+            assert stream.props.community == 'http://example.com'
+            assert stream.get_community() == 'http://example.com'
+
+            # Test set_community()
+            stream.set_community('http://redhat.com')
+            assert stream.props.community == 'http://redhat.com'
+            assert stream.get_community() == 'http://redhat.com'
+
+            # Test setting it to None
+            stream.props.community = None
+            assert stream.props.community is None
+            assert stream.get_community() is None
+
+    def test_description(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            # Check the defaults
+            assert stream.props.description is None
+            assert stream.get_description() is None
+
+            # Test property setting
+            stream.props.description = 'A description'
+            assert stream.props.description == 'A description'
+            assert stream.get_description() == 'A description'
+
+            # Test set_description()
+            stream.set_description('A different description')
+            assert stream.props.description == 'A different description'
+            assert stream.get_description() == 'A different description'
+
+            # Test setting it to None
+            stream.props.description = None
+            assert stream.props.description is None
+            assert stream.get_description() is None
+
+    def test_documentation(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            # Check the defaults
+            assert stream.props.documentation is None
+            assert stream.get_documentation() is None
+
+            # Test property setting
+            stream.props.documentation = 'http://example.com'
+            assert stream.props.documentation == 'http://example.com'
+            assert stream.get_documentation() == 'http://example.com'
+
+            # Test set_documentation()
+            stream.set_documentation('http://redhat.com')
+            assert stream.props.documentation == 'http://redhat.com'
+            assert stream.get_documentation() == 'http://redhat.com'
+
+            # Test setting it to None
+            stream.props.documentation = None
+            assert stream.props.documentation is None
+            assert stream.get_documentation() is None
+
+    def test_summary(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            # Check the defaults
+            assert stream.props.summary is None
+            assert stream.get_summary() is None
+
+            # Test property setting
+            stream.props.summary = 'A summary'
+            assert stream.props.summary == 'A summary'
+            assert stream.get_summary() == 'A summary'
+
+            # Test set_summary()
+            stream.set_summary('A different summary')
+            assert stream.props.summary == 'A different summary'
+            assert stream.get_summary() == 'A different summary'
+
+            # Test setting it to None
+            stream.props.summary = None
+            assert stream.props.summary is None
+            assert stream.get_summary() is None
+
+    def test_tracker(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            # Check the defaults
+            assert stream.props.tracker is None
+            assert stream.get_tracker() is None
+
+            # Test property setting
+            stream.props.tracker = 'http://example.com'
+            assert stream.props.tracker == 'http://example.com'
+            assert stream.get_tracker() == 'http://example.com'
+
+            # Test set_tracker()
+            stream.set_tracker('http://redhat.com')
+            assert stream.props.tracker == 'http://redhat.com'
+            assert stream.get_tracker() == 'http://redhat.com'
+
+            # Test setting it to None
+            stream.props.tracker = None
+            assert stream.props.tracker is None
+            assert stream.get_tracker() is None
+
+    def test_components(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            # Add an RPM component to a stream
+            rpm_comp = Modulemd.ComponentRpm(name='rpmcomponent')
+            stream.add_component(rpm_comp)
+            assert 'rpmcomponent' in stream.get_rpm_component_names_as_strv()
+            retrieved_comp = stream.get_rpm_component('rpmcomponent')
+            assert retrieved_comp
+            assert retrieved_comp.props.name == 'rpmcomponent'
+
+            # Add a Module component to a stream
+            mod_comp = Modulemd.ComponentModule(name='modulecomponent')
+            stream.add_component(mod_comp)
+            assert 'modulecomponent' in stream.get_module_component_names_as_strv()
+            retrieved_comp = stream.get_module_component('modulecomponent')
+            assert retrieved_comp
+            assert retrieved_comp.props.name == 'modulecomponent'
+
+            # Remove an RPM component from a stream
+            stream.remove_rpm_component('rpmcomponent')
+
+            # Remove a Module component from a stream
+            stream.remove_module_component('modulecomponent')
+
+    def test_licenses(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            stream.add_content_license('GPLv2+')
+            assert 'GPLv2+' in stream.get_content_licenses_as_strv()
+
+            stream.add_module_license('MIT')
+            assert 'MIT' in stream.get_module_licenses_as_strv()
+
+            stream.remove_content_license('GPLv2+')
+            stream.remove_module_license('MIT')
+
+    def test_profiles(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version, 'sssd')
+
+            profile = Modulemd.Profile(name='client')
+            profile.add_rpm('sssd-client')
+
+            stream.add_profile(profile)
+            assert len(stream.get_profile_names_as_strv()) == 1
+            assert 'client' in stream.get_profile_names_as_strv()
+            assert 'sssd-client' in stream.get_profile(
+                'client').get_rpms_as_strv()
+
+            stream.clear_profiles()
+            assert len(stream.get_profile_names_as_strv()) == 0
+
+    def test_rpm_api(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version, 'sssd')
+
+            stream.add_rpm_api('sssd-common')
+            assert 'sssd-common' in stream.get_rpm_api_as_strv()
+
+            stream.remove_rpm_api('sssd-common')
+            assert len(stream.get_rpm_api_as_strv()) == 0
+
+    def test_rpm_artifacts(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            stream.add_rpm_artifact('bar-0:1.23-1.module_deadbeef.x86_64')
+            assert 'bar-0:1.23-1.module_deadbeef.x86_64' in stream.get_rpm_artifacts_as_strv()
+
+            stream.remove_rpm_artifact('bar-0:1.23-1.module_deadbeef.x86_64')
+            assert len(stream.get_rpm_artifacts_as_strv()) == 0
+
+    def test_rpm_filters(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+
+            stream.add_rpm_filter('bar')
+            assert 'bar' in stream.get_rpm_filters_as_strv()
+
+            stream.remove_rpm_filter('bar')
+            assert len(stream.get_rpm_filters_as_strv()) == 0
+
+    def test_servicelevels(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+            sl = Modulemd.ServiceLevel.new('rawhide')
+            sl.set_eol_ymd(1980, 3, 2)
+
+            stream.add_servicelevel(sl)
+
+            assert 'rawhide' in stream.get_servicelevel_names_as_strv()
+
+            retrieved_sl = stream.get_servicelevel('rawhide')
+            assert retrieved_sl.props.name == 'rawhide'
+            assert retrieved_sl.get_eol_as_string() == '1980-03-02'
+
+    def test_v1_eol(self):
+        stream = Modulemd.ModuleStreamV1.new()
+        eol = GLib.Date.new_dmy(3, 2, 1998)
+
+        stream.set_eol(eol)
+        retrieved_eol = stream.get_eol()
+
+        assert retrieved_eol.get_day() == 3
+        assert retrieved_eol.get_month() == 2
+        assert retrieved_eol.get_year() == 1998
+
+        sl = stream.get_servicelevel('rawhide')
+        assert sl.get_eol_as_string() == '1998-02-03'
+
+    def test_v1_dependencies(self):
+        stream = Modulemd.ModuleStreamV1.new()
+        stream.add_buildtime_requirement('testmodule', 'stable')
+
+        assert len(stream.get_buildtime_modules_as_strv()) == 1
+        assert 'testmodule' in stream.get_buildtime_modules_as_strv()
+
+        assert stream.get_buildtime_requirement_stream('testmodule') == \
+            'stable'
+
+        stream.add_runtime_requirement('testmodule', 'latest')
+        assert len(stream.get_runtime_modules_as_strv()) == 1
+        assert 'testmodule' in stream.get_runtime_modules_as_strv()
+        assert stream.get_runtime_requirement_stream('testmodule') == 'latest'
+
+    def test_v2_dependencies(self):
+        stream = Modulemd.ModuleStreamV2.new()
+        deps = Modulemd.Dependencies()
+
+        deps.add_buildtime_stream('foo', 'stable')
+        deps.set_empty_runtime_dependencies_for_module('bar')
+        stream.add_dependencies(deps)
+
+        assert len(stream.get_dependencies()) == 1
+        assert len(stream.get_dependencies()) == 1
+
+        assert 'foo' in stream.get_dependencies(
+        )[0].get_buildtime_modules_as_strv()
+
+        assert 'stable' in stream.get_dependencies(
+        )[0].get_buildtime_streams_as_strv('foo')
+
+        assert 'bar' in stream.get_dependencies(
+        )[0].get_runtime_modules_as_strv()
+
+    def test_xmd(self):
+        if os.getenv('MMD_TEST_INSTALLED_LIB'):
+            # The XMD python tests can only be run against the installed lib
+            # because the overrides that translate between python and GVariant
+            # must be installed in /usr/lib/python*/site-packages/gi/overrides
+            # or they are not included when importing Modulemd
+            stream = Modulemd.ModuleStreamV2.new()
+
+            xmd = {'outer_key': ['scalar', {'inner_key': 'another_scalar'}]}
+
+            stream.set_xmd(xmd)
+
+            xmd_copy = stream.get_xmd()
+            assert xmd_copy
+            assert 'outer_key' in xmd
+            assert 'scalar' in xmd['outer_key']
+            assert 'inner_key' in xmd['outer_key'][1]
+            assert xmd['outer_key'][1]['inner_key'] == 'another_scalar'
 
     def test_yaml(self):
         for version in modulestream_versions:


### PR DESCRIPTION
At the moment, this is mostly just the implementation of these two classes. The YAML parser and emitter will follow shortly, but I wanted to get this up for review sooner.

I've left the individual patches I created as I built this up in the PR for now. I will squash them together before merging this, but it's a lot easier to review in small pieces, considering that it's over 3500 lines of new code (and that's without the YAML...)

Also new in this patch: Python overrides. In order to simplify the use of the XMD field, the ModuleStreamV2 class now provides a Python override that will convert native python objects to and from GLib.Variant (as long as they are comprised only of strings, booleans, lists or dictionaries). This will make it much easier to use from the consumer side.