### PR TITLE
Minor improvements

### DIFF
--- a/modulemd/v2/modulemd-util.c
+++ b/modulemd/v2/modulemd-util.c
@@ -73,8 +73,7 @@ modulemd_hash_table_deep_set_copy (GHashTable *orig)
 
   g_return_val_if_fail (orig, NULL);
 
-  new = g_hash_table_new_full (
-    g_str_hash, g_str_equal, g_free, modulemd_hash_table_unref);
+  new = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
   g_hash_table_iter_init (&iter, orig);
   while (g_hash_table_iter_next (&iter, &key, &value))

--- a/modulemd/v2/modulemd-yaml-util.c
+++ b/modulemd/v2/modulemd-yaml-util.c
@@ -445,6 +445,14 @@ modulemd_yaml_parse_string_set (yaml_parser_t *parser, GError **error)
         case YAML_SCALAR_EVENT:
           g_hash_table_add (result,
                             g_strdup ((const gchar *)event.data.scalar.value));
+
+          if (!in_list)
+            {
+              /* We got a scalar instead of a sequence. Treat it as a list with
+               * a single entry
+               */
+              done = TRUE;
+            }
           break;
 
         default:


### PR DESCRIPTION
The first patch relaxes the YAML parser for string sets so that it will interpret a single scalar as a list of one entry. This will treat the following two constructs as identical
```yaml
license: MIT

license:
  - MIT
``` 

The second patch fixes a potential memory error caused by a copy-paste. When using `g_hash_table_add()`, the value is just a pointer to the key  and must not be freed separately. And the free function there would have been incorrect as well, since the keys are strings, not hash tables.