### PR TITLE
Assorted fixes and rewrites needed for the ModuleStream parser

### DIFF
--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -72,7 +72,7 @@ class ModulemdUtil():
         if not isinstance(d, dict):
             raise TypeError('Only dictionaries are supported for mappings')
 
-        d_variant = dict_values(d)
+        d_variant = ModulemdUtil.dict_values(d)
         return GLib.Variant('a{sv}', d_variant)
 
     def dict_values(d):

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-profile-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-profile-private.h
@@ -30,6 +30,7 @@
  * modulemd_profile_parse_yaml:
  * @parser: (inout): A libyaml parser object positioned at the beginning of a
  * Profile entry in the YAML document.
+ * @name: (in): The name of this profile.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -40,7 +41,9 @@
  * Since: 2.0
  */
 ModulemdProfile *
-modulemd_profile_parse_yaml (yaml_parser_t *parser, GError **error);
+modulemd_profile_parse_yaml (yaml_parser_t *parser,
+                             const gchar *name,
+                             GError **error);
 
 /**
  * modulemd_profile_emitter_yaml:

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-service-level-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-service-level-private.h
@@ -30,6 +30,7 @@
  * modulemd_service_level_parse_yaml:
  * @parser: (inout): A libyaml parser object positioned at the beginning of a
  * Service Level entry in the YAML document.
+ * @name: (in): The name of this service level.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -40,7 +41,9 @@
  * Since: 2.0
  */
 ModulemdServiceLevel *
-modulemd_service_level_parse_yaml (yaml_parser_t *parser, GError **error);
+modulemd_service_level_parse_yaml (yaml_parser_t *parser,
+                                   const gchar *name,
+                                   GError **error);
 
 /**
  * modulemd_service_level_emitter_yaml:

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-yaml.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-yaml.h
@@ -115,7 +115,15 @@ mmd_yaml_get_event_name (yaml_event_type_t type);
                                "Parser error");                               \
           return _returnval;                                                  \
         }                                                                     \
-      g_debug ("Parser event: %s", mmd_yaml_get_event_name ((_event)->type)); \
+      if ((_event)->type == YAML_SCALAR_EVENT)                                \
+        g_debug ("Parser event: %s: %s",                                      \
+                 mmd_yaml_get_event_name ((_event)->type),                    \
+                 (const gchar *)event.data.scalar.value);                     \
+      else                                                                    \
+        {                                                                     \
+          g_debug ("Parser event: %s",                                        \
+                   mmd_yaml_get_event_name ((_event)->type));                 \
+        }                                                                     \
     }                                                                         \
   while (0)
 

--- a/modulemd/v2/modulemd-dependencies.c
+++ b/modulemd/v2/modulemd-dependencies.c
@@ -324,7 +324,6 @@ modulemd_dependencies_parse_yaml (yaml_parser_t *parser, GError **error)
   MODULEMD_INIT_TRACE ();
   MMD_INIT_YAML_EVENT (event);
   gboolean done = FALSE;
-  gboolean in_map = FALSE;
   g_autofree gchar *value = NULL;
   g_autoptr (ModulemdDependencies) d = NULL;
   g_autoptr (GError) nested_error = NULL;
@@ -339,17 +338,9 @@ modulemd_dependencies_parse_yaml (yaml_parser_t *parser, GError **error)
 
       switch (event.type)
         {
-        case YAML_MAPPING_START_EVENT: in_map = TRUE; break;
-
-        case YAML_MAPPING_END_EVENT:
-          in_map = FALSE;
-          done = TRUE;
-          break;
+        case YAML_MAPPING_END_EVENT: done = TRUE; break;
 
         case YAML_SCALAR_EVENT:
-          if (!in_map)
-            MMD_YAML_ERROR_EVENT_EXIT (
-              error, event, "Missing mapping in dependencies entry");
           if (g_str_equal (event.data.scalar.value, "buildrequires"))
             {
               g_hash_table_unref (d->buildtime_deps);

--- a/modulemd/v2/modulemd-profile.c
+++ b/modulemd/v2/modulemd-profile.c
@@ -233,7 +233,9 @@ modulemd_profile_init (ModulemdProfile *self)
 /* === YAML Functions === */
 
 ModulemdProfile *
-modulemd_profile_parse_yaml (yaml_parser_t *parser, GError **error)
+modulemd_profile_parse_yaml (yaml_parser_t *parser,
+                             const gchar *name,
+                             GError **error)
 {
   MODULEMD_INIT_TRACE ();
   MMD_INIT_YAML_EVENT (event);
@@ -245,14 +247,7 @@ modulemd_profile_parse_yaml (yaml_parser_t *parser, GError **error)
 
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
-  /* Read the profile name */
-  YAML_PARSER_PARSE_WITH_EXIT (parser, &event, error);
-  if (event.type != YAML_SCALAR_EVENT)
-    {
-      MMD_YAML_ERROR_EVENT_EXIT (error, event, "Missing profile name");
-    }
-  p = modulemd_profile_new ((const gchar *)event.data.scalar.value);
-  yaml_event_delete (&event);
+  p = modulemd_profile_new (name);
 
   /* Read in additional attributes */
   while (!done)

--- a/modulemd/v2/modulemd-subdocument-info.c
+++ b/modulemd/v2/modulemd-subdocument-info.c
@@ -82,7 +82,7 @@ modulemd_subdocument_info_set_yaml (ModulemdSubdocumentInfo *self,
 {
   g_return_if_fail (MODULEMD_IS_SUBDOCUMENT_INFO (self));
 
-  printf ("Setting YAML: %s\n", yaml);
+  g_debug ("Setting YAML: %s\n", yaml);
 
   g_clear_pointer (&self->contents, g_free);
   self->contents = g_strdup (yaml);

--- a/modulemd/v2/modulemd-yaml-util.c
+++ b/modulemd/v2/modulemd-yaml-util.c
@@ -360,6 +360,8 @@ modulemd_yaml_parse_date (yaml_parser_t *parser, GError **error)
       MMD_YAML_ERROR_EVENT_EXIT (error, event, "Date was not a scalar");
     }
 
+  g_debug ("Parsing scalar: %s", (const gchar *)event.data.scalar.value);
+
   strv = g_strsplit ((const gchar *)event.data.scalar.value, "-", 4);
 
   if (!strv[0] || !strv[1] || !strv[2])
@@ -383,6 +385,8 @@ modulemd_yaml_parse_string (yaml_parser_t *parser, GError **error)
     {
       MMD_YAML_ERROR_EVENT_EXIT (error, event, "String was not a scalar");
     }
+
+  g_debug ("Parsing scalar: %s", (const gchar *)event.data.scalar.value);
 
   return g_strdup ((const gchar *)event.data.scalar.value);
 }
@@ -414,6 +418,8 @@ modulemd_yaml_parse_uint64 (yaml_parser_t *parser, GError **error)
       MMD_YAML_ERROR_EVENT_EXIT_INT (error, event, "String was not a scalar");
     }
 
+  g_debug ("Parsing scalar: %s", (const gchar *)event.data.scalar.value);
+
   return g_ascii_strtoull ((const gchar *)event.data.scalar.value, NULL, 10);
 }
 
@@ -443,6 +449,7 @@ modulemd_yaml_parse_string_set (yaml_parser_t *parser, GError **error)
           break;
 
         case YAML_SCALAR_EVENT:
+          g_debug ("Parsing scalar: %s", (const gchar *)event.data.scalar.value);
           g_hash_table_add (result,
                             g_strdup ((const gchar *)event.data.scalar.value));
 

--- a/modulemd/v2/modulemd-yaml-util.c
+++ b/modulemd/v2/modulemd-yaml-util.c
@@ -449,7 +449,8 @@ modulemd_yaml_parse_string_set (yaml_parser_t *parser, GError **error)
           break;
 
         case YAML_SCALAR_EVENT:
-          g_debug ("Parsing scalar: %s", (const gchar *)event.data.scalar.value);
+          g_debug ("Parsing scalar: %s",
+                   (const gchar *)event.data.scalar.value);
           g_hash_table_add (result,
                             g_strdup ((const gchar *)event.data.scalar.value));
 

--- a/modulemd/v2/tests/test-modulemd-buildopts.c
+++ b/modulemd/v2/tests/test-modulemd-buildopts.c
@@ -216,7 +216,7 @@ buildopts_test_parse_yaml (BuildoptsFixture *fixture, gconstpointer user_data)
 
   yaml_parser_set_input_file (&parser, yaml_stream);
 
-  parser_skip_headers (&parser);
+  parser_skip_document_start (&parser);
 
   b = modulemd_buildopts_parse_yaml (&parser, &error);
   g_assert_nonnull (b);

--- a/modulemd/v2/tests/test-modulemd-dependencies.c
+++ b/modulemd/v2/tests/test-modulemd-dependencies.c
@@ -241,7 +241,7 @@ dependencies_test_parse_yaml (DependenciesFixture *fixture,
 
   yaml_parser_set_input_file (&parser, yaml_stream);
 
-  parser_skip_document_start (&parser);
+  parser_skip_headers (&parser);
 
   d = modulemd_dependencies_parse_yaml (&parser, &error);
   g_assert_nonnull (d);

--- a/modulemd/v2/tests/test-modulemd-profile.c
+++ b/modulemd/v2/tests/test-modulemd-profile.c
@@ -274,6 +274,7 @@ profile_test_parse_yaml (ProfileFixture *fixture, gconstpointer user_data)
   g_autofree gchar *yaml_path = NULL;
   g_auto (GStrv) rpms = NULL;
   g_autoptr (FILE) yaml_stream = NULL;
+  g_autofree gchar *name = NULL;
   yaml_path = g_strdup_printf ("%s/modulemd/v2/tests/test_data/p.yaml",
                                g_getenv ("MESON_SOURCE_ROOT"));
   g_assert_nonnull (yaml_path);
@@ -285,7 +286,12 @@ profile_test_parse_yaml (ProfileFixture *fixture, gconstpointer user_data)
 
   parser_skip_headers (&parser);
 
-  p = modulemd_profile_parse_yaml (&parser, &error);
+  /* Parse the name */
+  name = modulemd_yaml_parse_string (&parser, &error);
+  g_assert_nonnull (name);
+  g_assert_cmpstr (name, ==, "default");
+
+  p = modulemd_profile_parse_yaml (&parser, name, &error);
   g_assert_nonnull (p);
   g_assert_true (MODULEMD_IS_PROFILE (p));
   g_assert_cmpstr (modulemd_profile_get_name (p), ==, "default");

--- a/modulemd/v2/tests/test-modulemd-service-level.c
+++ b/modulemd/v2/tests/test-modulemd-service-level.c
@@ -304,6 +304,7 @@ service_level_test_parse_yaml (ServiceLevelFixture *fixture,
   MMD_INIT_YAML_PARSER (parser);
   g_autofree gchar *yaml_path = NULL;
   g_autoptr (FILE) yaml_stream = NULL;
+  g_autofree gchar *name = NULL;
   GDate *eol = NULL;
   yaml_path =
     g_strdup_printf ("%s/modulemd/v2/tests/test_data/sl_with_eol.yaml",
@@ -318,7 +319,12 @@ service_level_test_parse_yaml (ServiceLevelFixture *fixture,
   /* Advance the parser past STREAM_START, DOCUMENT_START and MAPPING_START */
   parser_skip_headers (&parser);
 
-  sl = modulemd_service_level_parse_yaml (&parser, &error);
+  /* Read the name */
+  name = modulemd_yaml_parse_string (&parser, &error);
+  g_assert_nonnull (name);
+  g_assert_cmpstr (name, ==, "sl_name");
+
+  sl = modulemd_service_level_parse_yaml (&parser, name, &error);
   g_assert_nonnull (sl);
   g_assert_true (MODULEMD_IS_SERVICE_LEVEL (sl));
   g_assert_cmpstr (modulemd_service_level_get_name (sl), ==, "sl_name");


### PR DESCRIPTION
Most of these are fairly simple: as I was implementing the ModuleStreamV2 YAML parser, I realized that we needed the object-specific parsers to start at a slightly different place. The biggest change is the Buildopts parser which I rewrote most of (partly to move the starting location and partly to ensure that if we add keys other than "rpms" to the modulemd spec in the future, they'll be simpler to add).

There are also several very minor bugfixes mixed in.

These are prerequisites for my upcoming patches for ModuleStream YAML parsing and emitting. (See https://github.com/sgallagher/libmodulemd/tree/api2-modulestream-yaml for work-in-progress on that).