### PR TITLE
Add locale option to summary and description getters

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v1.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v1.h
@@ -142,7 +142,7 @@ modulemd_module_stream_v1_get_community (ModulemdModuleStreamV1 *self);
 /**
  * modulemd_module_stream_v1_set_description:
  * @self: (in): This #ModulemdModuleStreamV1 object.
- * @description: (in): The untranslated description of this module.
+ * @description: (in) (nullable): The untranslated description of this module.
  *
  * Set the module description.
  *
@@ -155,14 +155,19 @@ modulemd_module_stream_v1_set_description (ModulemdModuleStreamV1 *self,
 
 /**
  * modulemd_module_stream_v1_get_description:
- * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @locale: (in) (nullable): The name of the locale to use when translating
+ * the string. If NULL, it will determine the locale with a system call to
+ * setlocale(LC_MESSAGES, NULL) and return the that. If the caller wants the
+ * untranslated string, they should pass "C" for the locale.
  *
- * Returns: (transfer none): The module description.
+ * Returns: (transfer none): The module description, translated to the
+ * requested locale if available.
  *
  * Since: 2.0
  */
 const gchar *
-modulemd_module_stream_v1_get_description (ModulemdModuleStreamV1 *self);
+modulemd_module_stream_v1_get_description (ModulemdModuleStreamV1 *self,
+                                           const gchar *locale);
 
 
 /**
@@ -194,7 +199,7 @@ modulemd_module_stream_v1_get_documentation (ModulemdModuleStreamV1 *self);
 /**
  * modulemd_module_stream_v1_set_summary:
  * @self: (in): This #ModulemdModuleStreamV1 object.
- * @summary: (in): The untranslated summary of this module.
+ * @summary: (in) (nullable): The untranslated summary of this module.
  *
  * Set the module summary.
  *
@@ -207,14 +212,19 @@ modulemd_module_stream_v1_set_summary (ModulemdModuleStreamV1 *self,
 
 /**
  * modulemd_module_stream_v1_get_summary:
- * @self: (in): This #ModulemdModuleStreamV1 object.
+ * @locale: (in) (nullable): The name of the locale to use when translating
+ * the string. If NULL, it will determine the locale with a system call to
+ * setlocale(LC_MESSAGES, NULL) and return the that. If the caller wants the
+ * untranslated string, they should pass "C" for the locale.
  *
- * Returns: (transfer none): The module summary.
+ * Returns: (transfer none): The module summary, translated to the requested
+ * locale if available.
  *
  * Since: 2.0
  */
 const gchar *
-modulemd_module_stream_v1_get_summary (ModulemdModuleStreamV1 *self);
+modulemd_module_stream_v1_get_summary (ModulemdModuleStreamV1 *self,
+                                       const gchar *locale);
 
 
 /**

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
@@ -142,7 +142,7 @@ modulemd_module_stream_v2_get_community (ModulemdModuleStreamV2 *self);
 /**
  * modulemd_module_stream_v2_set_description:
  * @self: (in): This #ModulemdModuleStreamV2 object.
- * @description: (in): The untranslated description of this module.
+ * @description: (in) (nullable): The untranslated description of this module.
  *
  * Set the module description.
  *
@@ -156,13 +156,19 @@ modulemd_module_stream_v2_set_description (ModulemdModuleStreamV2 *self,
 /**
  * modulemd_module_stream_v2_get_description:
  * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @locale: (in) (nullable): The name of the locale to use when translating
+ * the string. If NULL, it will determine the locale with a system call to
+ * setlocale(LC_MESSAGES, NULL) and return the that. If the caller wants the
+ * untranslated string, they should pass "C" for the locale.
  *
- * Returns: (transfer none): The module description.
+ * Returns: (transfer none): The module description, translated to the
+ * requested locale if available.
  *
  * Since: 2.0
  */
 const gchar *
-modulemd_module_stream_v2_get_description (ModulemdModuleStreamV2 *self);
+modulemd_module_stream_v2_get_description (ModulemdModuleStreamV2 *self,
+                                           const gchar *locale);
 
 
 /**
@@ -194,7 +200,7 @@ modulemd_module_stream_v2_get_documentation (ModulemdModuleStreamV2 *self);
 /**
  * modulemd_module_stream_v2_set_summary:
  * @self: (in): This #ModulemdModuleStreamV2 object.
- * @summary: (in): The untranslated summary of this module.
+ * @summary: (in) (nullable): The untranslated summary of this module.
  *
  * Set the module summary.
  *
@@ -208,13 +214,19 @@ modulemd_module_stream_v2_set_summary (ModulemdModuleStreamV2 *self,
 /**
  * modulemd_module_stream_v2_get_summary:
  * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @locale: (in) (nullable): The name of the locale to use when translating
+ * the string. If NULL, it will determine the locale with a system call to
+ * setlocale(LC_MESSAGES, NULL) and return the that. If the caller wants the
+ * untranslated string, they should pass "C" for the locale.
  *
- * Returns: (transfer none): The module summary.
+ * Returns: (transfer none): The module summary, translated to the requested
+ * locale if available.
  *
  * Since: 2.0
  */
 const gchar *
-modulemd_module_stream_v2_get_summary (ModulemdModuleStreamV2 *self);
+modulemd_module_stream_v2_get_summary (ModulemdModuleStreamV2 *self,
+                                       const gchar *locale);
 
 
 /**

--- a/modulemd/v2/include/modulemd-2.0/modulemd-profile.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-profile.h
@@ -33,7 +33,8 @@ G_DECLARE_FINAL_TYPE (
  * modulemd_profile_new:
  * @name: (not nullable): The name of this profile.
  *
- * Returns: (transfer full): A newly-allocated #ModuleProfile. This object must be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModuleProfile. This object must
+ * be freed with g_object_unref().
  *
  * Since: 2.0
  */
@@ -70,7 +71,7 @@ modulemd_profile_get_name (ModulemdProfile *self);
 /**
  * modulemd_profile_set_description:
  * @self: This #ModulemdProfile
- * @description: The description of this profile in the C.UTF-8 locale.
+ * @description: (nullable): The description of this profile in the C locale.
  *
  * Since: 2.0
  */
@@ -82,19 +83,26 @@ modulemd_profile_set_description (ModulemdProfile *self,
 /**
  * modulemd_profile_get_description:
  * @self: This #ModulemdProfile
+ * @locale: (in) (nullable): The name of the locale to use when translating
+ * the string. If NULL, it will determine the locale with a system call to
+ * setlocale(LC_MESSAGES, NULL) and return the that. If the caller wants the
+ * untranslated string, they should pass "C" for the locale.
  *
- * Returns: (transfer none): The description of this profile translated into the language specified by the locale if it is available, otherwise it returns the C.UTF-8 original.
+ * Returns: (transfer none): The description of this profile translated into
+ * the language specified by the locale if it is available, otherwise it
+ * returns the C.UTF-8 original.
  *
  * Since: 2.0
  */
 const gchar *
-modulemd_profile_get_description (ModulemdProfile *self);
+modulemd_profile_get_description (ModulemdProfile *self, const gchar *locale);
 
 
 /**
  * modulemd_profile_add_rpm:
  * @self: This #ModulemdProfile
- * @rpm: The name of a binary RPM that should be installed when this profile is selected for installation.
+ * @rpm: The name of a binary RPM that should be installed when this profile is
+ * selected for installation.
  *
  * Since: 2.0
  */
@@ -117,7 +125,8 @@ modulemd_profile_remove_rpm (ModulemdProfile *self, const gchar *rpm);
  * modulemd_profile_get_rpms_as_strv: (rename-to modulemd_profile_get_rpms)
  * @self: This #ModulemdProfile
  *
- * Returns: (transfer full): An ordered list of binary RPMS that would be installed when this profile is selected for installation.
+ * Returns: (transfer full): An ordered list of binary RPMS that would be
+ * installed when this profile is selected for installation.
  *
  * Since: 2.0
  */

--- a/modulemd/v2/meson.build
+++ b/modulemd/v2/meson.build
@@ -71,6 +71,7 @@ install_headers(
 
 # Test env with release values
 test_release_env = environment()
+test_release_env.set('LC_ALL', 'C')
 test_release_env.set('G_MESSAGES_DEBUG', 'all')
 test_release_env.set ('MESON_SOURCE_ROOT', meson.source_root())
 

--- a/modulemd/v2/modulemd-module-stream-v1.c
+++ b/modulemd/v2/modulemd-module-stream-v1.c
@@ -66,9 +66,7 @@ enum
   PROP_ARCH,
   PROP_BUILDOPTS,
   PROP_COMMUNITY,
-  PROP_DESCRIPTION,
   PROP_DOCUMENTATION,
-  PROP_SUMMARY,
   PROP_TRACKER,
   N_PROPS
 };
@@ -210,15 +208,16 @@ modulemd_module_stream_v1_set_description (ModulemdModuleStreamV1 *self,
 
   g_clear_pointer (&self->description, g_free);
   self->description = g_strdup (description);
-
-  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_DESCRIPTION]);
 }
 
 
 const gchar *
-modulemd_module_stream_v1_get_description (ModulemdModuleStreamV1 *self)
+modulemd_module_stream_v1_get_description (ModulemdModuleStreamV1 *self,
+                                           const gchar *locale)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  /* TODO: retrieve translated strings */
 
   return self->description;
 }
@@ -254,15 +253,16 @@ modulemd_module_stream_v1_set_summary (ModulemdModuleStreamV1 *self,
 
   g_clear_pointer (&self->summary, g_free);
   self->summary = g_strdup (summary);
-
-  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_DESCRIPTION]);
 }
 
 
 const gchar *
-modulemd_module_stream_v1_get_summary (ModulemdModuleStreamV1 *self)
+modulemd_module_stream_v1_get_summary (ModulemdModuleStreamV1 *self,
+                                       const gchar *locale)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), NULL);
+
+  /* TODO: retrieve translated strings */
 
   return self->summary;
 }
@@ -824,18 +824,9 @@ modulemd_module_stream_v1_get_property (GObject *object,
                           modulemd_module_stream_v1_get_community (self));
       break;
 
-    case PROP_DESCRIPTION:
-      g_value_set_string (value,
-                          modulemd_module_stream_v1_get_description (self));
-      break;
-
     case PROP_DOCUMENTATION:
       g_value_set_string (value,
                           modulemd_module_stream_v1_get_documentation (self));
-      break;
-
-    case PROP_SUMMARY:
-      g_value_set_string (value, modulemd_module_stream_v1_get_summary (self));
       break;
 
     case PROP_TRACKER:
@@ -870,18 +861,9 @@ modulemd_module_stream_v1_set_property (GObject *object,
                                                g_value_get_string (value));
       break;
 
-    case PROP_DESCRIPTION:
-      modulemd_module_stream_v1_set_description (self,
-                                                 g_value_get_string (value));
-      break;
-
     case PROP_DOCUMENTATION:
       modulemd_module_stream_v1_set_documentation (self,
                                                    g_value_get_string (value));
-      break;
-
-    case PROP_SUMMARY:
-      modulemd_module_stream_v1_set_summary (self, g_value_get_string (value));
       break;
 
     case PROP_TRACKER:
@@ -926,24 +908,10 @@ modulemd_module_stream_v1_class_init (ModulemdModuleStreamV1Class *klass)
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
 
-  properties[PROP_DESCRIPTION] = g_param_spec_string (
-    "description",
-    "Module Description",
-    "The description of this module",
-    NULL,
-    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
-
   properties[PROP_DOCUMENTATION] = g_param_spec_string (
     "documentation",
     "Module Documentation Website",
     "The website address of the upstream documentation for this module",
-    NULL,
-    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
-
-  properties[PROP_SUMMARY] = g_param_spec_string (
-    "summary",
-    "Module Summary",
-    "The short description of this module",
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
 

--- a/modulemd/v2/modulemd-module-stream-v2.c
+++ b/modulemd/v2/modulemd-module-stream-v2.c
@@ -65,9 +65,7 @@ enum
   PROP_ARCH,
   PROP_BUILDOPTS,
   PROP_COMMUNITY,
-  PROP_DESCRIPTION,
   PROP_DOCUMENTATION,
-  PROP_SUMMARY,
   PROP_TRACKER,
   N_PROPS
 };
@@ -207,15 +205,16 @@ modulemd_module_stream_v2_set_description (ModulemdModuleStreamV2 *self,
 
   g_clear_pointer (&self->description, g_free);
   self->description = g_strdup (description);
-
-  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_DESCRIPTION]);
 }
 
 
 const gchar *
-modulemd_module_stream_v2_get_description (ModulemdModuleStreamV2 *self)
+modulemd_module_stream_v2_get_description (ModulemdModuleStreamV2 *self,
+                                           const gchar *locale)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  /* TODO: retrieve translated strings */
 
   return self->description;
 }
@@ -251,15 +250,16 @@ modulemd_module_stream_v2_set_summary (ModulemdModuleStreamV2 *self,
 
   g_clear_pointer (&self->summary, g_free);
   self->summary = g_strdup (summary);
-
-  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_DESCRIPTION]);
 }
 
 
 const gchar *
-modulemd_module_stream_v2_get_summary (ModulemdModuleStreamV2 *self)
+modulemd_module_stream_v2_get_summary (ModulemdModuleStreamV2 *self,
+                                       const gchar *locale)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), NULL);
+
+  /* TODO: retrieve translated strings */
 
   return self->summary;
 }
@@ -719,18 +719,9 @@ modulemd_module_stream_v2_get_property (GObject *object,
                           modulemd_module_stream_v2_get_community (self));
       break;
 
-    case PROP_DESCRIPTION:
-      g_value_set_string (value,
-                          modulemd_module_stream_v2_get_description (self));
-      break;
-
     case PROP_DOCUMENTATION:
       g_value_set_string (value,
                           modulemd_module_stream_v2_get_documentation (self));
-      break;
-
-    case PROP_SUMMARY:
-      g_value_set_string (value, modulemd_module_stream_v2_get_summary (self));
       break;
 
     case PROP_TRACKER:
@@ -764,18 +755,9 @@ modulemd_module_stream_v2_set_property (GObject *object,
                                                g_value_get_string (value));
       break;
 
-    case PROP_DESCRIPTION:
-      modulemd_module_stream_v2_set_description (self,
-                                                 g_value_get_string (value));
-      break;
-
     case PROP_DOCUMENTATION:
       modulemd_module_stream_v2_set_documentation (self,
                                                    g_value_get_string (value));
-      break;
-
-    case PROP_SUMMARY:
-      modulemd_module_stream_v2_set_summary (self, g_value_get_string (value));
       break;
 
     case PROP_TRACKER:
@@ -820,24 +802,10 @@ modulemd_module_stream_v2_class_init (ModulemdModuleStreamV2Class *klass)
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
 
-  properties[PROP_DESCRIPTION] = g_param_spec_string (
-    "description",
-    "Module Description",
-    "The description of this module",
-    NULL,
-    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
-
   properties[PROP_DOCUMENTATION] = g_param_spec_string (
     "documentation",
     "Module Documentation Website",
     "The website address of the upstream documentation for this module",
-    NULL,
-    G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
-
-  properties[PROP_SUMMARY] = g_param_spec_string (
-    "summary",
-    "Module Summary",
-    "The short description of this module",
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
 

--- a/modulemd/v2/tests/ModulemdTests/modulestream.py
+++ b/modulemd/v2/tests/ModulemdTests/modulestream.py
@@ -245,23 +245,16 @@ class TestModuleStream(TestBase):
             stream = Modulemd.ModuleStream.new(version)
 
             # Check the defaults
-            assert stream.props.description is None
-            assert stream.get_description() is None
-
-            # Test property setting
-            stream.props.description = 'A description'
-            assert stream.props.description == 'A description'
-            assert stream.get_description() == 'A description'
+            assert stream.get_description(locale="C") is None
 
             # Test set_description()
             stream.set_description('A different description')
-            assert stream.props.description == 'A different description'
-            assert stream.get_description() == 'A different description'
+            assert stream.get_description(
+                locale="C") == 'A different description'
 
             # Test setting it to None
-            stream.props.description = None
-            assert stream.props.description is None
-            assert stream.get_description() is None
+            stream.set_description(None)
+            assert stream.get_description(locale="C") is None
 
     def test_documentation(self):
         for version in modulestream_versions:
@@ -291,23 +284,15 @@ class TestModuleStream(TestBase):
             stream = Modulemd.ModuleStream.new(version)
 
             # Check the defaults
-            assert stream.props.summary is None
-            assert stream.get_summary() is None
-
-            # Test property setting
-            stream.props.summary = 'A summary'
-            assert stream.props.summary == 'A summary'
-            assert stream.get_summary() == 'A summary'
+            assert stream.get_summary(locale="C") is None
 
             # Test set_summary()
             stream.set_summary('A different summary')
-            assert stream.props.summary == 'A different summary'
-            assert stream.get_summary() == 'A different summary'
+            assert stream.get_summary(locale="C") == 'A different summary'
 
             # Test setting it to None
-            stream.props.summary = None
-            assert stream.props.summary is None
-            assert stream.get_summary() is None
+            stream.set_summary(None)
+            assert stream.get_summary(locale="C") is None
 
     def test_tracker(self):
         for version in modulestream_versions:

--- a/modulemd/v2/tests/ModulemdTests/profile.py
+++ b/modulemd/v2/tests/ModulemdTests/profile.py
@@ -34,7 +34,6 @@ class TestProfile(TestBase):
         assert p
         assert p.props.name == 'testprofile'
         assert p.get_name() == 'testprofile'
-        assert p.props.description is None
         assert p.get_description() is None
         assert p.get_rpms() == []
 
@@ -43,17 +42,7 @@ class TestProfile(TestBase):
         assert p
         assert p.props.name == 'testprofile'
         assert p.get_name() == 'testprofile'
-        assert p.props.description is None
         assert p.get_description() is None
-        assert p.get_rpms() == []
-
-        # Test that init works with name and description
-        p = Modulemd.Profile(name='testprofile', description='A test profile')
-        assert p
-        assert p.props.name == 'testprofile'
-        assert p.get_name() == 'testprofile'
-        assert p.props.description == 'A test profile'
-        assert p.get_description() == 'A test profile'
         assert p.get_rpms() == []
 
         # Test that we fail without name
@@ -73,7 +62,6 @@ class TestProfile(TestBase):
         assert p
         assert p.props.name == 'testprofile'
         assert p.get_name() == 'testprofile'
-        assert p.props.description is None
         assert p.get_description() is None
         assert p.get_rpms() == []
 
@@ -86,7 +74,6 @@ class TestProfile(TestBase):
         assert p
         assert p.props.name == 'testprofile'
         assert p.get_name() == 'testprofile'
-        assert p.props.description == 'Test profile'
         assert p.get_description() == 'Test profile'
         assert p.get_rpms() == ['test1', 'test2', 'test3']
 
@@ -102,19 +89,12 @@ class TestProfile(TestBase):
     def test_get_set_description(self):
         p = Modulemd.Profile(name='testprofile')
 
-        assert p.props.description is None
         assert p.get_description() is None
 
         p.set_description('foobar')
-        assert p.props.description == 'foobar'
         assert p.get_description() == 'foobar'
 
-        p.props.description = 'barfoo'
-        assert p.props.description == 'barfoo'
-        assert p.get_description() == 'barfoo'
-
-        p.props.description = None
-        assert p.props.description is None
+        p.set_description(None)
         assert p.get_description() is None
 
     def test_rpms(self):

--- a/modulemd/v2/tests/test-modulemd-profile.c
+++ b/modulemd/v2/tests/test-modulemd-profile.c
@@ -45,28 +45,16 @@ profile_test_construct (ProfileFixture *fixture, gconstpointer user_data)
   g_assert_nonnull (p);
   g_assert_true (MODULEMD_IS_PROFILE (p));
   g_assert_cmpstr (modulemd_profile_get_name (p), ==, "testprofile");
-  g_assert_null (modulemd_profile_get_description (p));
+  g_assert_null (modulemd_profile_get_description (p, "C"));
   rpms = modulemd_profile_get_rpms_as_strv (p);
   g_assert_nonnull (rpms);
   g_assert_cmpint (g_strv_length (rpms), ==, 0);
   g_clear_object (&p);
 
-  /* Test that object instantiation works wiht a name */
+  /* Test that object instantiation works with a name */
   p = g_object_new (MODULEMD_TYPE_PROFILE, "name", "testprofile", NULL);
   g_assert_true (MODULEMD_IS_PROFILE (p));
   g_assert_cmpstr (modulemd_profile_get_name (p), ==, "testprofile");
-  g_clear_object (&p);
-
-  /* Test instantiation works with name and description */
-  p = g_object_new (MODULEMD_TYPE_PROFILE,
-                    "name",
-                    "testprofile",
-                    "description",
-                    "A test",
-                    NULL);
-  g_assert_true (MODULEMD_IS_PROFILE (p));
-  g_assert_cmpstr (modulemd_profile_get_name (p), ==, "testprofile");
-  g_assert_cmpstr (modulemd_profile_get_description (p), ==, "A test");
   g_clear_object (&p);
 
   /* Test that we abort with a NULL name to new() */
@@ -103,7 +91,7 @@ profile_test_copy (ProfileFixture *fixture, gconstpointer user_data)
   g_assert_nonnull (p);
   g_assert_true (MODULEMD_IS_PROFILE (p));
   g_assert_cmpstr (modulemd_profile_get_name (p), ==, "testprofile");
-  g_assert_null (modulemd_profile_get_description (p));
+  g_assert_null (modulemd_profile_get_description (p, "C"));
   rpms = modulemd_profile_get_rpms_as_strv (p);
   g_assert_nonnull (rpms);
   g_assert_cmpint (g_strv_length (rpms), ==, 0);
@@ -113,7 +101,7 @@ profile_test_copy (ProfileFixture *fixture, gconstpointer user_data)
   g_assert_nonnull (p_copy);
   g_assert_true (MODULEMD_IS_PROFILE (p_copy));
   g_assert_cmpstr (modulemd_profile_get_name (p_copy), ==, "testprofile");
-  g_assert_null (modulemd_profile_get_description (p_copy));
+  g_assert_null (modulemd_profile_get_description (p_copy, "C"));
   rpms = modulemd_profile_get_rpms_as_strv (p_copy);
   g_assert_nonnull (rpms);
   g_assert_cmpint (g_strv_length (rpms), ==, 0);
@@ -127,7 +115,7 @@ profile_test_copy (ProfileFixture *fixture, gconstpointer user_data)
   g_assert_nonnull (p);
   g_assert_true (MODULEMD_IS_PROFILE (p));
   g_assert_cmpstr (modulemd_profile_get_name (p), ==, "testprofile");
-  g_assert_cmpstr (modulemd_profile_get_description (p), ==, "a test");
+  g_assert_cmpstr (modulemd_profile_get_description (p, "C"), ==, "a test");
   rpms = modulemd_profile_get_rpms_as_strv (p);
   g_assert_nonnull (rpms);
   g_assert_cmpint (g_strv_length (rpms), ==, 0);
@@ -137,7 +125,8 @@ profile_test_copy (ProfileFixture *fixture, gconstpointer user_data)
   g_assert_nonnull (p_copy);
   g_assert_true (MODULEMD_IS_PROFILE (p_copy));
   g_assert_cmpstr (modulemd_profile_get_name (p_copy), ==, "testprofile");
-  g_assert_cmpstr (modulemd_profile_get_description (p_copy), ==, "a test");
+  g_assert_cmpstr (
+    modulemd_profile_get_description (p_copy, "C"), ==, "a test");
   rpms = modulemd_profile_get_rpms_as_strv (p_copy);
   g_assert_nonnull (rpms);
   g_assert_cmpint (g_strv_length (rpms), ==, 0);
@@ -151,7 +140,7 @@ profile_test_copy (ProfileFixture *fixture, gconstpointer user_data)
   g_assert_nonnull (p);
   g_assert_true (MODULEMD_IS_PROFILE (p));
   g_assert_cmpstr (modulemd_profile_get_name (p), ==, "testprofile");
-  g_assert_null (modulemd_profile_get_description (p));
+  g_assert_null (modulemd_profile_get_description (p, "C"));
   rpms = modulemd_profile_get_rpms_as_strv (p);
   g_assert_nonnull (rpms);
   g_assert_cmpint (g_strv_length (rpms), ==, 1);
@@ -162,7 +151,7 @@ profile_test_copy (ProfileFixture *fixture, gconstpointer user_data)
   g_assert_nonnull (p_copy);
   g_assert_true (MODULEMD_IS_PROFILE (p_copy));
   g_assert_cmpstr (modulemd_profile_get_name (p_copy), ==, "testprofile");
-  g_assert_null (modulemd_profile_get_description (p_copy));
+  g_assert_null (modulemd_profile_get_description (p_copy, "C"));
   rpms = modulemd_profile_get_rpms_as_strv (p_copy);
   g_assert_nonnull (rpms);
   g_assert_cmpint (g_strv_length (rpms), ==, 1);
@@ -201,30 +190,21 @@ profile_test_get_set_description (ProfileFixture *fixture,
                                   gconstpointer user_data)
 {
   g_autoptr (ModulemdProfile) p = NULL;
-  g_autofree gchar *description;
 
   p = modulemd_profile_new ("testprofile");
   g_assert_nonnull (p);
   g_assert_true (MODULEMD_IS_PROFILE (p));
 
-  g_assert_null (modulemd_profile_get_description (p));
-  g_object_get (p, "description", &description, NULL);
-  g_assert_null (description);
-  g_clear_pointer (&description, g_free);
+  g_assert_null (modulemd_profile_get_description (p, "C"));
 
   /* Set a description */
   modulemd_profile_set_description (p, "Some description");
   g_assert_cmpstr (
-    modulemd_profile_get_description (p), ==, "Some description");
-  g_object_get (p, "description", &description, NULL);
-  g_assert_cmpstr (description, ==, "Some description");
-  g_clear_pointer (&description, g_free);
+    modulemd_profile_get_description (p, "C"), ==, "Some description");
 
   /* Clear the description */
   modulemd_profile_set_description (p, NULL);
-  g_object_get (p, "description", &description, NULL);
-  g_assert_null (description);
-  g_clear_pointer (&description, g_free);
+  g_assert_null (modulemd_profile_get_description (p, "C"));
 }
 
 static void
@@ -295,8 +275,9 @@ profile_test_parse_yaml (ProfileFixture *fixture, gconstpointer user_data)
   g_assert_nonnull (p);
   g_assert_true (MODULEMD_IS_PROFILE (p));
   g_assert_cmpstr (modulemd_profile_get_name (p), ==, "default");
-  g_assert_cmpstr (
-    modulemd_profile_get_description (p), ==, "An example profile for tests");
+  g_assert_cmpstr (modulemd_profile_get_description (p, NULL),
+                   ==,
+                   "An example profile for tests");
   rpms = modulemd_profile_get_rpms_as_strv (p);
   g_assert_cmpint (g_strv_length (rpms), ==, 3);
   g_assert_cmpstr (rpms[0], ==, "bar");


### PR DESCRIPTION
Add locale option to summary and description getters

The ModuleStream.get_summary(), ModuleStream.get_description() and
Profile.get_description() fields need to take an optional locale in
order to return translated strings.

It also drops the properties associated with summary and description
as it is the safest course of action, rather than having users guess
which string they will get back, they must use the getter which will
handle the locale appropriately.

This patch updates the API but does not yet implement the
translation, which will be done later while implementing ModuleIndex
that handles associating the Translation documents with the streams.

Also reflows the gtkdoc comments in modulemd-profile.h.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>
