### PR TITLE
Python Overrides

### DIFF
--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -36,9 +36,14 @@ Modulemd = get_introspection_module('Modulemd')
 from six import text_type
 from gi.repository import GLib
 
+import datetime
+
+
 __all__ = []
 
+
 class ModulemdUtil():
+
     def variant_str(s):
         """ Converts a string to a GLib.Variant
         """
@@ -108,8 +113,8 @@ class ModulemdUtil():
         else:
             raise TypeError('Cannot convert unknown type')
 
+if float(Modulemd._version) >= 2:
 
-if "ModuleStreamV2" in dir(Modulemd):
     class ModuleStreamV2(Modulemd.ModuleStreamV2):
 
         def set_xmd(self, xmd):
@@ -119,12 +124,9 @@ if "ModuleStreamV2" in dir(Modulemd):
             variant_xmd = super().get_xmd()
             return variant_xmd.unpack()
 
-
     ModuleStreamV2 = override(ModuleStreamV2)
     __all__.append(ModuleStreamV2)
 
-
-if "ModuleStreamV1" in dir(Modulemd):
     class ModuleStreamV1(Modulemd.ModuleStreamV1):
 
         def set_xmd(self, xmd):
@@ -134,7 +136,28 @@ if "ModuleStreamV1" in dir(Modulemd):
             variant_xmd = super().get_xmd()
             return variant_xmd.unpack()
 
-
     ModuleStreamV1 = override(ModuleStreamV1)
     __all__.append(ModuleStreamV1)
 
+    class ServiceLevel(Modulemd.ServiceLevel):
+
+        def set_eol(self, eol):
+            if (isinstance(eol, datetime.date)):
+                return super().set_eol_ymd(eol.year, eol.month, eol.day)
+
+            raise TypeError(
+                "Expected datetime.date, but got %s." % (
+                    type(eol).__name__))
+
+        def get_eol(self):
+            eol = super().get_eol()
+            if eol is None:
+                return None
+
+            return datetime.date(
+                eol.get_year(),
+                eol.get_month(),
+                eol.get_day())
+
+    ServiceLevel = override(ServiceLevel)
+    __all__.append(ServiceLevel)

--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -112,9 +112,6 @@ class ModulemdUtil():
 if "ModuleStreamV2" in dir(Modulemd):
     class ModuleStreamV2(Modulemd.ModuleStreamV2):
 
-        def __new__(cls, module_name=None, module_stream=None):
-            return Modulemd.ModuleStreamV2.new(module_name, module_stream)
-
         def set_xmd(self, xmd):
             super().set_xmd(ModulemdUtil.python_to_variant(xmd))
 
@@ -129,9 +126,6 @@ if "ModuleStreamV2" in dir(Modulemd):
 
 if "ModuleStreamV1" in dir(Modulemd):
     class ModuleStreamV1(Modulemd.ModuleStreamV1):
-
-        def __new__(cls, module_name=None, module_stream=None):
-            return Modulemd.ModuleStreamV1.new(module_name, module_stream)
 
         def set_xmd(self, xmd):
             super().set_xmd(ModulemdUtil.python_to_variant(xmd))

--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -118,10 +118,12 @@ if float(Modulemd._version) >= 2:
     class ModuleStreamV2(Modulemd.ModuleStreamV2):
 
         def set_xmd(self, xmd):
-            super().set_xmd(ModulemdUtil.python_to_variant(xmd))
+            super(
+                ModuleStreamV2, self).set_xmd(
+                ModulemdUtil.python_to_variant(xmd))
 
         def get_xmd(self):
-            variant_xmd = super().get_xmd()
+            variant_xmd = super(ModuleStreamV2, self).get_xmd()
             return variant_xmd.unpack()
 
     ModuleStreamV2 = override(ModuleStreamV2)
@@ -130,10 +132,12 @@ if float(Modulemd._version) >= 2:
     class ModuleStreamV1(Modulemd.ModuleStreamV1):
 
         def set_xmd(self, xmd):
-            super().set_xmd(ModulemdUtil.python_to_variant(xmd))
+            super(
+                ModuleStreamV1, self).set_xmd(
+                ModulemdUtil.python_to_variant(xmd))
 
         def get_xmd(self):
-            variant_xmd = super().get_xmd()
+            variant_xmd = super(ModuleStreamV1, self).get_xmd()
             return variant_xmd.unpack()
 
     ModuleStreamV1 = override(ModuleStreamV1)
@@ -143,14 +147,19 @@ if float(Modulemd._version) >= 2:
 
         def set_eol(self, eol):
             if (isinstance(eol, datetime.date)):
-                return super().set_eol_ymd(eol.year, eol.month, eol.day)
+                return super(
+                    ServiceLevel,
+                    self).set_eol_ymd(
+                    eol.year,
+                    eol.month,
+                    eol.day)
 
             raise TypeError(
                 "Expected datetime.date, but got %s." % (
                     type(eol).__name__))
 
         def get_eol(self):
-            eol = super().get_eol()
+            eol = super(ServiceLevel, self).get_eol()
             if eol is None:
                 return None
 

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -237,7 +237,8 @@ test('clang_format', clang_format,
 autopep8_args = [ '--in-place', '-a', '-a' ]
 autopep8_scripts = [ files('v1/tests/test-modulemd-python.py',
                            'common/tests/test-dirty.py',
-                           'common/tests/test-valgrind.py') +
+                           'common/tests/test-valgrind.py',
+                           '../bindings/python/gi/overrides/Modulemd.py') +
                      test_v2_python_scripts ]
 test('autopep8', autopep8,
      args: autopep8_args + autopep8_scripts)

--- a/modulemd/v2/modulemd-service-level.c
+++ b/modulemd/v2/modulemd-service-level.c
@@ -37,7 +37,6 @@ enum
   PROP_0,
 
   PROP_NAME,
-  PROP_EOL,
 
   N_PROPS
 };
@@ -117,7 +116,6 @@ modulemd_service_level_set_eol (ModulemdServiceLevel *self, GDate *date)
   if (!date || !g_date_valid (date))
     {
       g_date_clear (self->eol, 1);
-      g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_EOL]);
       return;
     }
 
@@ -127,7 +125,6 @@ modulemd_service_level_set_eol (ModulemdServiceLevel *self, GDate *date)
       g_date_set_year (self->eol, g_date_get_year (date));
       g_date_set_month (self->eol, g_date_get_month (date));
       g_date_set_day (self->eol, g_date_get_day (date));
-      g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_EOL]);
     }
 }
 
@@ -202,10 +199,6 @@ modulemd_service_level_get_property (GObject *object,
       g_value_set_string (value, modulemd_service_level_get_name (self));
       break;
 
-    case PROP_EOL:
-      g_value_set_boxed (value, modulemd_service_level_get_eol (self));
-      break;
-
     default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
 }
@@ -223,10 +216,6 @@ modulemd_service_level_set_property (GObject *object,
     {
     case PROP_NAME:
       modulemd_service_level_set_name (self, g_value_get_string (value));
-      break;
-
-    case PROP_EOL:
-      modulemd_service_level_set_eol (self, g_value_get_boxed (value));
       break;
 
     default: G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -249,15 +238,6 @@ modulemd_service_level_class_init (ModulemdServiceLevelClass *klass)
     "A human-readable name for this servicelevel",
     SL_DEFAULT_STRING,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT_ONLY);
-
-  properties[PROP_EOL] =
-    g_param_spec_boxed ("eol",
-                        "End of Life",
-                        "An ISO-8601 compatible YYYY-MM-DD value "
-                        "representing the end-of-life date of this service "
-                        "level.",
-                        G_TYPE_DATE,
-                        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class, N_PROPS, properties);
 }

--- a/modulemd/v2/tests/ModulemdTests/modulestream.py
+++ b/modulemd/v2/tests/ModulemdTests/modulestream.py
@@ -466,7 +466,7 @@ class TestModuleStream(TestBase):
         )[0].get_runtime_modules()
 
     def test_xmd(self):
-        if os.getenv('MMD_TEST_INSTALLED_LIB'):
+        if '_overrides_module' in dir(Modulemd):
             # The XMD python tests can only be run against the installed lib
             # because the overrides that translate between python and GVariant
             # must be installed in /usr/lib/python*/site-packages/gi/overrides

--- a/modulemd/v2/tests/ModulemdTests/servicelevel.py
+++ b/modulemd/v2/tests/ModulemdTests/servicelevel.py
@@ -25,6 +25,7 @@ except ImportError:
     sys.exit(77)
 
 from base import TestBase
+import datetime
 
 
 class TestServiceLevel(TestBase):
@@ -97,39 +98,67 @@ class TestServiceLevel(TestBase):
     def test_get_set_eol(self):
         sl = Modulemd.ServiceLevel.new('foo')
 
-        # Test that EOL is initialized to None
-        assert sl.get_eol() is None
+        if '_overrides_module' in dir(Modulemd):
+            # Test that EOL is initialized to None
+            assert sl.get_eol() is None
 
-        # Test the set_eol() method
-        eol = GLib.Date.new_dmy(7, 11, 2018)
-        sl.set_eol(eol)
+            # Test the set_eol() method
+            eol = datetime.date(2018, 11, 7)
+            sl.set_eol(eol)
 
-        returned_eol = sl.get_eol()
-        assert returned_eol is not None
-        assert returned_eol.get_day() == eol.get_day()
-        assert returned_eol.get_month() == eol.get_month()
-        assert returned_eol.get_year() == eol.get_year()
-        assert sl.get_eol_as_string() == '2018-11-07'
+            returned_eol = sl.get_eol()
+            assert returned_eol is not None
+            assert returned_eol == eol
+            assert sl.get_eol_as_string() == '2018-11-07'
 
-        # Test the set_eol_ymd() method
-        sl.set_eol_ymd(2019, 12, 3)
+            # Test the set_eol_ymd() method
+            sl.set_eol_ymd(2019, 12, 3)
 
-        returned_eol = sl.get_eol()
-        assert returned_eol is not None
-        assert returned_eol.get_day() == 3
-        assert returned_eol.get_month() == 12
-        assert returned_eol.get_year() == 2019
-        assert sl.get_eol_as_string() == '2019-12-03'
+            returned_eol = sl.get_eol()
+            assert returned_eol is not None
+            assert returned_eol.day == 3
+            assert returned_eol.month == 12
+            assert returned_eol.year == 2019
+            assert sl.get_eol_as_string() == '2019-12-03'
 
-        # Try setting some invalid dates
-        # An initialized but unset date
-        eol = GLib.Date.new()
-        sl.set_eol(eol)
-        assert sl.get_eol() is None
+            # There is no February 31
+            sl.set_eol_ymd(2011, 2, 31)
+            assert sl.get_eol() is None
 
-        # There is no February 31
-        sl.set_eol_ymd(2011, 2, 31)
-        assert sl.get_eol() is None
+        else:
+            # Test that EOL is initialized to None
+            assert sl.get_eol() is None
+
+            # Test the set_eol() method
+            eol = GLib.Date.new_dmy(7, 11, 2018)
+            sl.set_eol(eol)
+
+            returned_eol = sl.get_eol()
+            assert returned_eol is not None
+            assert returned_eol.get_day() == eol.get_day()
+            assert returned_eol.get_month() == eol.get_month()
+            assert returned_eol.get_year() == eol.get_year()
+            assert sl.get_eol_as_string() == '2018-11-07'
+
+            # Test the set_eol_ymd() method
+            sl.set_eol_ymd(2019, 12, 3)
+
+            returned_eol = sl.get_eol()
+            assert returned_eol is not None
+            assert returned_eol.get_day() == 3
+            assert returned_eol.get_month() == 12
+            assert returned_eol.get_year() == 2019
+            assert sl.get_eol_as_string() == '2019-12-03'
+
+            # Try setting some invalid dates
+            # An initialized but unset date
+            eol = GLib.Date.new()
+            sl.set_eol(eol)
+            assert sl.get_eol() is None
+
+            # There is no February 31
+            sl.set_eol_ymd(2011, 2, 31)
+            assert sl.get_eol() is None
 
 
 if __name__ == '__main__':

--- a/modulemd/v2/tests/ModulemdTests/servicelevel.py
+++ b/modulemd/v2/tests/ModulemdTests/servicelevel.py
@@ -35,7 +35,6 @@ class TestServiceLevel(TestBase):
         assert sl
         assert sl.props.name == 'foo'
         assert sl.get_name() == 'foo'
-        assert sl.props.eol is None
         assert sl.get_eol() is None
         assert sl.get_eol_as_string() is None
 
@@ -44,27 +43,8 @@ class TestServiceLevel(TestBase):
         assert sl
         assert sl.props.name == 'foo'
         assert sl.get_name() == 'foo'
-        assert sl.props.eol is None
         assert sl.get_eol() is None
         assert sl.get_eol_as_string() is None
-
-        # Test that standard object instantiation works with a name and EOL
-        sl = Modulemd.ServiceLevel(
-            name='foo',
-            eol=GLib.Date.new_dmy(7, 11, 2018))
-        assert sl
-        assert sl.props.name == 'foo'
-        assert sl.get_name() == 'foo'
-        assert sl.props.eol is not None
-        assert sl.props.eol.get_day() == 7
-        assert sl.props.eol.get_month() == 11
-        assert sl.props.eol.get_year() == 2018
-        assert sl.get_eol() is not None
-        assert sl.get_eol().get_day() == 7
-        assert sl.get_eol().get_month() == 11
-        assert sl.get_eol().get_year() == 2018
-        assert sl.get_eol_as_string() is not None
-        assert sl.get_eol_as_string() == '2018-11-07'
 
         # Test that we fail if we call new() with a None name
         try:
@@ -86,7 +66,6 @@ class TestServiceLevel(TestBase):
         assert sl
         assert sl.props.name == 'foo'
         assert sl.get_name() == 'foo'
-        assert sl.props.eol is None
         assert sl.get_eol() is None
         assert sl.get_eol_as_string() is None
 
@@ -94,7 +73,6 @@ class TestServiceLevel(TestBase):
         assert sl_copy
         assert sl_copy.props.name == 'foo'
         assert sl_copy.get_name() == 'foo'
-        assert sl_copy.props.eol is None
         assert sl_copy.get_eol() is None
         assert sl_copy.get_eol_as_string() is None
 
@@ -103,7 +81,6 @@ class TestServiceLevel(TestBase):
         assert sl_copy
         assert sl_copy.props.name == 'foo'
         assert sl_copy.get_name() == 'foo'
-        assert sl_copy.props.eol is not None
         assert sl_copy.get_eol() is not None
         assert sl_copy.get_eol_as_string() == '2018-11-13'
 
@@ -122,27 +99,26 @@ class TestServiceLevel(TestBase):
 
         # Test that EOL is initialized to None
         assert sl.get_eol() is None
-        assert sl.props.eol is None
 
         # Test the set_eol() method
         eol = GLib.Date.new_dmy(7, 11, 2018)
         sl.set_eol(eol)
 
-        for returned_eol in [sl.get_eol(), sl.props.eol]:
-            assert returned_eol is not None
-            assert returned_eol.get_day() == eol.get_day()
-            assert returned_eol.get_month() == eol.get_month()
-            assert returned_eol.get_year() == eol.get_year()
+        returned_eol = sl.get_eol()
+        assert returned_eol is not None
+        assert returned_eol.get_day() == eol.get_day()
+        assert returned_eol.get_month() == eol.get_month()
+        assert returned_eol.get_year() == eol.get_year()
         assert sl.get_eol_as_string() == '2018-11-07'
 
         # Test the set_eol_ymd() method
         sl.set_eol_ymd(2019, 12, 3)
 
-        for returned_eol in [sl.get_eol(), sl.props.eol]:
-            assert returned_eol is not None
-            assert returned_eol.get_day() == 3
-            assert returned_eol.get_month() == 12
-            assert returned_eol.get_year() == 2019
+        returned_eol = sl.get_eol()
+        assert returned_eol is not None
+        assert returned_eol.get_day() == 3
+        assert returned_eol.get_month() == 12
+        assert returned_eol.get_year() == 2019
         assert sl.get_eol_as_string() == '2019-12-03'
 
         # Try setting some invalid dates
@@ -150,12 +126,10 @@ class TestServiceLevel(TestBase):
         eol = GLib.Date.new()
         sl.set_eol(eol)
         assert sl.get_eol() is None
-        assert sl.props.eol is None
 
         # There is no February 31
         sl.set_eol_ymd(2011, 2, 31)
         assert sl.get_eol() is None
-        assert sl.props.eol is None
 
 
 if __name__ == '__main__':

--- a/modulemd/v2/tests/test-modulemd-service-level.c
+++ b/modulemd/v2/tests/test-modulemd-service-level.c
@@ -39,7 +39,6 @@ service_level_test_construct (ServiceLevelFixture *fixture,
                               gconstpointer user_data)
 {
   g_autoptr (ModulemdServiceLevel) sl = NULL;
-  g_autoptr (GDate) eol = NULL;
 
 
   /* Test that the new() function works */
@@ -60,23 +59,6 @@ service_level_test_construct (ServiceLevelFixture *fixture,
   g_assert_true (MODULEMD_IS_SERVICE_LEVEL (sl));
   g_assert_cmpstr (modulemd_service_level_get_name (sl), ==, "bar");
   g_assert_null (modulemd_service_level_get_eol (sl));
-  g_clear_object (&sl);
-
-
-  /* Test that standard object instantiation works with a name and EOL */
-  eol = g_date_new_dmy (7, 11, 2018);
-
-  // clang-format off
-  sl = g_object_new (MODULEMD_TYPE_SERVICE_LEVEL,
-                     "name", "bar",
-                     "eol", eol,
-                     NULL);
-  // clang-format on
-  g_assert_true (MODULEMD_IS_SERVICE_LEVEL (sl));
-  g_assert_cmpstr (modulemd_service_level_get_name (sl), ==, "bar");
-  g_assert_nonnull (modulemd_service_level_get_eol (sl));
-  g_assert_cmpint (
-    g_date_compare (eol, modulemd_service_level_get_eol (sl)), ==, 0);
   g_clear_object (&sl);
 
 
@@ -204,15 +186,6 @@ service_level_test_get_set_eol (ServiceLevelFixture *fixture,
   g_assert_null (modulemd_service_level_get_eol_as_string (sl));
 
 
-  /* Test looking up the EOL by object properties returns NULL */
-  // clang-format off
-  g_object_get (sl,
-                "eol", &eol,
-                NULL);
-  // clang-format on
-  g_assert_null (eol);
-
-
   /* Set the EOL with the set_eol() method */
   eol = g_date_new_dmy (7, 11, 2018);
   modulemd_service_level_set_eol (sl, eol);
@@ -221,16 +194,6 @@ service_level_test_get_set_eol (ServiceLevelFixture *fixture,
   g_assert_nonnull (returned_eol);
   g_assert_true (g_date_valid (returned_eol));
   g_assert_cmpint (g_date_compare (eol, returned_eol), ==, 0);
-
-  // clang-format off
-  g_object_get(sl,
-               "eol", &copied_eol,
-               NULL);
-  // clang-format on
-  g_assert_nonnull (copied_eol);
-  g_assert_true (g_date_valid (copied_eol));
-  g_assert_cmpint (g_date_compare (eol, copied_eol), ==, 0);
-  g_clear_pointer (&copied_eol, g_date_free);
 
   eol_string = modulemd_service_level_get_eol_as_string (sl);
   g_assert_nonnull (eol_string);
@@ -246,16 +209,6 @@ service_level_test_get_set_eol (ServiceLevelFixture *fixture,
   g_assert_true (g_date_valid (returned_eol));
   g_assert_cmpint (g_date_compare (eol, returned_eol), ==, 0);
 
-  // clang-format off
-  g_object_get(sl,
-               "eol", &copied_eol,
-               NULL);
-  // clang-format on
-  g_assert_nonnull (copied_eol);
-  g_assert_true (g_date_valid (copied_eol));
-  g_assert_cmpint (g_date_compare (eol, copied_eol), ==, 0);
-  g_clear_pointer (&copied_eol, g_date_free);
-
   eol_string = modulemd_service_level_get_eol_as_string (sl);
   g_assert_nonnull (eol_string);
   g_assert_cmpstr (eol_string, ==, "2018-11-07");
@@ -266,13 +219,6 @@ service_level_test_get_set_eol (ServiceLevelFixture *fixture,
   g_clear_pointer (&eol, g_date_free);
   eol = g_date_new ();
   modulemd_service_level_set_eol (sl, eol);
-  g_assert_null (modulemd_service_level_get_eol (sl));
-
-  // clang-format off
-  g_object_set (sl,
-                "eol", eol,
-                NULL);
-  // clang-format on
   g_assert_null (modulemd_service_level_get_eol (sl));
 
   modulemd_service_level_set_eol_ymd (sl, 2018, 2, 31);


### PR DESCRIPTION
First patch adds overrides for the `ServiceLevel.set_eol()` and `ServiceLevel.get_eol()` functions. It also reworks slightly the method used to determine when to apply the overrides to base it on the API version of the Modulemd namespace, rather than on presence of the symbol in the namespace, since ServiceLevel existed in 1.0 and we don't want to break compatibility there if both APIs are available on the system.

The first patch also adds the overrides to the autopep8 formatter, which results in a few minor formatting changes as well.


The second patch drops an unneeded override function from ModuleStreamV1 and V2 that were leftovers from trial-and-error to get the overrides properly applied. They are entirely superfluous.