### PR TITLE
Change YAML parsing/emitting slightly

### DIFF
--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -172,6 +172,25 @@ modulemd_module_stream_read_yaml (yaml_parser_t *parser,
     }
   yaml_event_delete (&event);
 
+  /* The second event must be the document start */
+  if (!yaml_parser_parse (parser, &event))
+    {
+      g_set_error_literal (error,
+                           MODULEMD_YAML_ERROR,
+                           MODULEMD_YAML_ERROR_UNPARSEABLE,
+                           "Parser error");
+      return NULL;
+    }
+  if (event.type != YAML_DOCUMENT_START_EVENT)
+    {
+      g_set_error_literal (error,
+                           MODULEMD_YAML_ERROR,
+                           MODULEMD_YAML_ERROR_PARSE,
+                           "YAML didn't begin with STREAM_START.");
+      return NULL;
+    }
+  yaml_event_delete (&event);
+
   subdoc = modulemd_yaml_parse_document_type (parser);
   if (subdoc == NULL)
     {

--- a/modulemd/v2/modulemd-yaml-util.c
+++ b/modulemd/v2/modulemd-yaml-util.c
@@ -506,16 +506,12 @@ modulemd_yaml_parse_document_type_internal (
       return FALSE;
     }
 
-  /* The first event must be the document start */
-  YAML_PARSER_PARSE_WITH_EXIT_BOOL (parser, &event, error);
-  if (event.type != YAML_DOCUMENT_START_EVENT)
-    {
-      MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-        error, event, "Parser is not at the start of a document");
-    }
-  MMD_EMIT_WITH_EXIT_FULL (
-    emitter, FALSE, &event, error, "Error starting document");
-  yaml_event_delete (&event);
+  /*
+   * We should assume the initial document start is consumed by the Index.
+   * But we still emit it.
+   */
+  if (!mmd_emitter_start_document (emitter, error))
+    return FALSE;
 
   /* The second event must be the mapping start */
   YAML_PARSER_PARSE_WITH_EXIT_BOOL (parser, &event, error);

--- a/modulemd/v2/tests/test-modulemd-defaults-v1.c
+++ b/modulemd/v2/tests/test-modulemd-defaults-v1.c
@@ -301,6 +301,12 @@ defaults_test_parse_yaml (CommonMmdTestFixture *fixture,
   g_assert_cmpint (event.type, ==, YAML_STREAM_START_EVENT);
   yaml_event_delete (&event);
 
+  /* The second event must be the document start */
+  yaml_ret = yaml_parser_parse (&parser, &event);
+  g_assert_true (yaml_ret);
+  g_assert_cmpint (event.type, ==, YAML_DOCUMENT_START_EVENT);
+  yaml_event_delete (&event);
+
   subdoc = modulemd_yaml_parse_document_type (&parser);
   g_assert_nonnull (subdoc);
   g_assert_null (modulemd_subdocument_info_get_gerror (subdoc));
@@ -315,7 +321,7 @@ defaults_test_parse_yaml (CommonMmdTestFixture *fixture,
   g_assert_cmpstr (
     modulemd_subdocument_info_get_yaml (subdoc),
     ==,
-    "document: modulemd-defaults\nversion: 1\ndata:\n  module: "
+    "---\ndocument: modulemd-defaults\nversion: 1\ndata:\n  module: "
     "foo\n  "
     "stream: x.y\n  profiles:\n    'x.y': []\n    bar: [baz, snafu]\n  "
     "intents:\n    desktop:\n      stream: y.z\n      profiles:\n        "

--- a/modulemd/v2/tests/test-modulemd-translation.c
+++ b/modulemd/v2/tests/test-modulemd-translation.c
@@ -257,6 +257,12 @@ translation_test_parse_yaml (TranslationFixture *fixture,
   g_assert_cmpint (event.type, ==, YAML_STREAM_START_EVENT);
   yaml_event_delete (&event);
 
+  /* The second event must be the document start */
+  yaml_ret = yaml_parser_parse (&parser, &event);
+  g_assert_true (yaml_ret);
+  g_assert_cmpint (event.type, ==, YAML_DOCUMENT_START_EVENT);
+  yaml_event_delete (&event);
+
   subdoc = modulemd_yaml_parse_document_type (&parser);
   g_assert_nonnull (subdoc);
   g_assert_null (modulemd_subdocument_info_get_gerror (subdoc));


### PR DESCRIPTION
This moves the parsing of the document start out of the sub-elements,
since the Index needs to parse those to see whether more documents
follow.

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>