### PR TITLE
ModuleIndex only supports ModuleStream with name and stream

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
@@ -181,13 +181,14 @@ modulemd_module_index_get_module (ModulemdModuleIndex *self,
 /**
  * modulemd_module_index_add_module_stream:
  * @self: This #ModulemdModuleIndex
- * @stream: The #ModulemdModuleStream to add to the index.
+ * @stream: The #ModulemdModuleStream to add to the index. The stream added
+ * must have a module name and stream name set on it or it will be rejected.
  * @error: (out): A #GError containing the reason the #ModulemdModuleStream
  * object could not be added or NULL if the function succeeded.
  *
  * Returns: TRUE if the #ModulemdModule was added succesfully. If the stream
- * already existed in the index, it will be replaced by the new one. On failure,
- * returns FALSE and sets error appropriately.
+ * already existed in the index, it will be replaced by the new one. On
+ * failure, returns FALSE and sets error appropriately.
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-module-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-module-private.h
@@ -96,7 +96,10 @@ modulemd_module_get_translation (ModulemdModule *self, const gchar *stream);
 /**
  * modulemd_module_add_stream:
  * @self: This #ModulemdModule object
- * @stream: A #ModulemdModuleStream object to associate with this #ModulemdModule.
+ * @stream: A #ModulemdModuleStream object to associate with this
+ * #ModulemdModule. A stream added to a #ModulemdModule must have a module
+ * name and stream name set on it or it will be rejected.
+ *
  *
  * Since: 2.0
  */

--- a/modulemd/v2/modulemd-module-index.c
+++ b/modulemd/v2/modulemd-module-index.c
@@ -497,6 +497,17 @@ modulemd_module_index_add_module_stream (ModulemdModuleIndex *self,
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
 
+  if (!modulemd_module_stream_get_module_name (stream) ||
+      !modulemd_module_stream_get_stream_name (stream))
+    {
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
+                   "The module and stream names are required when adding to "
+                   "ModuleIndex.");
+      return FALSE;
+    }
+
   modulemd_module_add_stream (
     get_or_create_module (self,
                           modulemd_module_stream_get_module_name (stream)),

--- a/modulemd/v2/modulemd-module.c
+++ b/modulemd/v2/modulemd-module.c
@@ -218,8 +218,10 @@ modulemd_module_add_stream (ModulemdModule *self, ModulemdModuleStream *stream)
   ModulemdModuleStream *newstream = NULL;
   g_return_if_fail (MODULEMD_IS_MODULE (self));
   g_return_if_fail (stream);
-  g_return_if_fail (g_str_equal (
-    modulemd_module_stream_get_module_name (stream), self->module_name));
+  g_return_if_fail (modulemd_module_stream_get_module_name (stream));
+  g_return_if_fail (modulemd_module_stream_get_stream_name (stream));
+  g_return_if_fail (g_strcmp0 (modulemd_module_stream_get_module_name (stream),
+                               self->module_name) == 0);
 
   old = modulemd_module_get_stream_by_NSVC (
     self,
@@ -309,16 +311,16 @@ modulemd_module_get_stream_by_NSVC (ModulemdModule *self,
       under_consideration =
         (ModulemdModuleStream *)g_ptr_array_index (self->streams, i);
 
-      if (!g_str_equal (
+      if (g_strcmp0 (
             modulemd_module_stream_get_stream_name (under_consideration),
-            stream_name))
+            stream_name) != 0)
         continue;
 
       if (modulemd_module_stream_get_version (under_consideration) != version)
         continue;
 
-      if (!g_str_equal (
-            modulemd_module_stream_get_context (under_consideration), context))
+      if (g_strcmp0 (modulemd_module_stream_get_context (under_consideration),
+                     context) != 0)
         continue;
 
       return under_consideration;

--- a/modulemd/v2/tests/test-modulemd-moduleindex.c
+++ b/modulemd/v2/tests/test-modulemd-moduleindex.c
@@ -71,6 +71,8 @@ module_index_test_dump (ModuleIndexFixture *fixture, gconstpointer user_data)
   /* Third: some streams */
   stream = (ModulemdModuleStream *)modulemd_module_stream_v1_new (
     "testmodule1", "teststream1");
+  modulemd_module_stream_set_version (stream, 1);
+  modulemd_module_stream_set_context (stream, "deadbeef");
   modulemd_module_stream_v1_set_summary (MODULEMD_MODULE_STREAM_V1 (stream),
                                          "A test stream");
   modulemd_module_stream_v1_set_description (
@@ -83,6 +85,8 @@ module_index_test_dump (ModuleIndexFixture *fixture, gconstpointer user_data)
   g_clear_pointer (&stream, g_object_unref);
   stream = (ModulemdModuleStream *)modulemd_module_stream_v2_new (
     "testmodule1", "teststream2");
+  modulemd_module_stream_set_version (stream, 2);
+  modulemd_module_stream_set_context (stream, "c0ff33");
   modulemd_module_stream_v2_set_summary (MODULEMD_MODULE_STREAM_V2 (stream),
                                          "A second stream");
   modulemd_module_stream_v2_set_description (
@@ -108,10 +112,12 @@ module_index_test_dump (ModuleIndexFixture *fixture, gconstpointer user_data)
     " translations:\n  - nl_NL\n  - summary: Een test omschrijving\n  - "
     "ro_TA\n  - summary: Testsummary in ro_TA\n...\n---\ndocument: "
     "modulemd\nversion: 1\ndata:\n  name: testmodule1\n  stream: "
-    "teststream1\n  summary: A test stream\n  description: A test stream's "
+    "teststream1\n  version: 1\n  context: deadbeef\n  summary: A test "
+    "stream\n  description: A test stream's "
     "description\n  license:\n    module:\n    - "
     "Beerware\n...\n---\ndocument: modulemd\nversion: 2\ndata:\n  name: "
-    "testmodule1\n  stream: teststream2\n  summary: A second stream\n  "
+    "testmodule1\n  stream: teststream2\n  version: 2\n  context: c0ff33\n  "
+    "summary: A second stream\n  "
     "description: A second stream's description\n  license:\n    module:\n    "
     "- Beerware\n...\n");
 }


### PR DESCRIPTION
Also replaces calls to `g_str_equal()` with `g_strcmp0()` which is
NULL-safe, since the values may be unset.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>