### PR TITLE
Properly manage memory reading XMD and other bugfixes

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-yaml.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-yaml.h
@@ -444,7 +444,7 @@ modulemd_yaml_emit_variant (yaml_emitter_t *emitter,
  * mmd_variant_from_scalar:
  * @scalar: (in): A string or boolean value to read into a #GVariant
  *
- * Returns: (transfer full): A newly-allocated #GVariant representing a string
+ * Returns: (transfer full): A new, floating #GVariant representing a string
  * or boolean value matching the scalar passed in.
  *
  * Since: 2.0
@@ -458,7 +458,7 @@ mmd_variant_from_scalar (const gchar *scalar);
  * @parser: (inout): A YAML parser positioned just after a MAPPING_START
  * @error: (out): A #GError that will return the reason for failing to parse.
  *
- * Returns: (transfer full): A newly-allocated #GVariant representing a hash
+ * Returns: (transfer full): A new, floating #GVariant representing a hash
  * table with string keys and #GVariant values.
  *
  * Since: 2.0
@@ -472,7 +472,7 @@ mmd_variant_from_mapping (yaml_parser_t *parser, GError **error);
  * @parser: (inout): A YAML parser positioned just after a SEQUENCE_START
  * @error: (out): A #GError that will return the reason for failing to parse.
  *
- * Returns: (transfer full): A newly-allocated #GVariant representing a list of
+ * Returns: (transfer full): A new, floating #GVariant representing a list of
  * #GVariant values.
  *
  * Since: 2.0

--- a/modulemd/v2/modulemd-module-stream-v2.c
+++ b/modulemd/v2/modulemd-module-stream-v2.c
@@ -1148,8 +1148,8 @@ modulemd_module_stream_v2_parse_yaml (ModulemdSubdocumentInfo *subdoc,
                   g_propagate_error (error, g_steal_pointer (&nested_error));
                   return NULL;
                 }
-              modulemd_module_stream_v2_set_xmd (modulestream, xmd);
-              xmd = NULL;
+              modulemd_module_stream_v2_set_xmd (modulestream,
+                                                 g_steal_pointer (&xmd));
             }
 
           /* Dependencies */
@@ -1935,6 +1935,8 @@ modulemd_module_stream_v2_parse_raw (yaml_parser_t *parser,
                                  mmd_yaml_get_event_name (event.type));
       break;
     }
+
+  g_variant_ref_sink (variant);
 
   return g_steal_pointer (&variant);
 }

--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -497,25 +497,28 @@ modulemd_module_stream_upgrade_to_v2 (ModulemdModuleStream *from,
 
 
   /* Upgrade the Dependencies */
-  deps = modulemd_dependencies_new ();
-
-  /* Add the build-time deps */
-  g_hash_table_iter_init (&iter, v1_stream->buildtime_deps);
-  while (g_hash_table_iter_next (&iter, &key, &value))
+  if (g_hash_table_size (v1_stream->buildtime_deps) > 0 ||
+      g_hash_table_size (v1_stream->runtime_deps) > 0)
     {
-      modulemd_dependencies_add_buildtime_stream (deps, key, value);
+      deps = modulemd_dependencies_new ();
+
+      /* Add the build-time deps */
+      g_hash_table_iter_init (&iter, v1_stream->buildtime_deps);
+      while (g_hash_table_iter_next (&iter, &key, &value))
+        {
+          modulemd_dependencies_add_buildtime_stream (deps, key, value);
+        }
+
+      /* Add the run-time deps */
+      g_hash_table_iter_init (&iter, v1_stream->runtime_deps);
+      while (g_hash_table_iter_next (&iter, &key, &value))
+        {
+          modulemd_dependencies_add_runtime_stream (deps, key, value);
+        }
+
+      /* Add the Dependencies to this ModuleStreamV2 */
+      modulemd_module_stream_v2_add_dependencies (copy, deps);
     }
-
-  /* Add the run-time deps */
-  g_hash_table_iter_init (&iter, v1_stream->runtime_deps);
-  while (g_hash_table_iter_next (&iter, &key, &value))
-    {
-      modulemd_dependencies_add_runtime_stream (deps, key, value);
-    }
-
-  /* Add the Dependencies to this ModuleStreamV2 */
-  modulemd_module_stream_v2_add_dependencies (copy, deps);
-
 
   return MODULEMD_MODULE_STREAM (g_steal_pointer (&copy));
 }

--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -418,7 +418,7 @@ modulemd_module_stream_upgrade (ModulemdModuleStream *self,
           g_assert_not_reached ();
         }
 
-      g_object_unref (&current_stream);
+      g_object_unref (current_stream);
       current_stream = g_steal_pointer (&updated_stream);
       current_mdversion =
         modulemd_module_stream_get_mdversion (current_stream);

--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -371,8 +371,6 @@ modulemd_module_stream_upgrade (ModulemdModuleStream *self,
   guint64 current_mdversion = modulemd_module_stream_get_mdversion (self);
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self), NULL);
-  g_return_val_if_fail (
-    mdversion && mdversion <= MD_MODULESTREAM_VERSION_LATEST, NULL);
 
   if (!mdversion)
     {
@@ -415,7 +413,13 @@ modulemd_module_stream_upgrade (ModulemdModuleStream *self,
 
         default:
           /* If we get here, it means we failed to address an upgrade. */
-          g_assert_not_reached ();
+          g_set_error (
+            error,
+            MODULEMD_ERROR,
+            MODULEMD_ERROR_UPGRADE,
+            "Cannot upgrade beyond metadata version %" G_GUINT64_FORMAT,
+            current_mdversion);
+          return NULL;
         }
 
       g_object_unref (current_stream);

--- a/modulemd/v2/modulemd-yaml-util.c
+++ b/modulemd/v2/modulemd-yaml-util.c
@@ -957,7 +957,7 @@ mmd_variant_from_scalar (const gchar *scalar)
       variant = g_variant_new_string (scalar);
     }
 
-  return g_variant_ref_sink (variant);
+  return variant;
 }
 
 
@@ -1010,6 +1010,7 @@ mmd_variant_from_mapping (yaml_parser_t *parser, GError **error)
               if (!value)
                 {
                   g_propagate_error (error, g_steal_pointer (&nested_error));
+                  return NULL;
                 }
               break;
 
@@ -1018,6 +1019,7 @@ mmd_variant_from_mapping (yaml_parser_t *parser, GError **error)
               if (!value)
                 {
                   g_propagate_error (error, g_steal_pointer (&nested_error));
+                  return NULL;
                 }
               break;
 
@@ -1032,7 +1034,7 @@ mmd_variant_from_mapping (yaml_parser_t *parser, GError **error)
             }
 
           yaml_event_delete (&value_event);
-          g_variant_dict_insert_value (dict, key, value);
+          g_variant_dict_insert_value (dict, key, g_steal_pointer (&value));
           g_clear_pointer (&key, g_free);
           break;
 
@@ -1049,7 +1051,7 @@ mmd_variant_from_mapping (yaml_parser_t *parser, GError **error)
       yaml_event_delete (&event);
     }
 
-  return g_variant_ref_sink (g_variant_dict_end (dict));
+  return g_variant_dict_end (dict);
 }
 
 
@@ -1118,7 +1120,7 @@ mmd_variant_from_sequence (yaml_parser_t *parser, GError **error)
 
       if (value)
         {
-          g_variant_builder_add_value (&builder, g_variant_ref (value));
+          g_variant_builder_add_value (&builder, g_steal_pointer (&value));
           empty_array = FALSE;
         }
 
@@ -1138,5 +1140,5 @@ mmd_variant_from_sequence (yaml_parser_t *parser, GError **error)
       result = g_variant_builder_end (&builder);
     }
 
-  return g_variant_ref_sink (result);
+  return result;
 }

--- a/modulemd/v2/tests/test-modulemd-moduleindex.c
+++ b/modulemd/v2/tests/test-modulemd-moduleindex.c
@@ -189,6 +189,29 @@ module_index_test_read (ModuleIndexFixture *fixture, gconstpointer user_data)
 }
 
 
+static void
+module_index_test_read_mixed (ModuleIndexFixture *fixture,
+                              gconstpointer user_data)
+{
+  g_autoptr (ModulemdModuleIndex) index = NULL;
+  g_autofree gchar *yaml_path = NULL;
+  g_autoptr (GPtrArray) failures = NULL;
+  g_autoptr (GError) error = NULL;
+
+  index = modulemd_module_index_new ();
+
+  yaml_path =
+    g_strdup_printf ("%s/modulemd/v2/tests/test_data/long-valid.yaml",
+                     g_getenv ("MESON_SOURCE_ROOT"));
+  g_assert_nonnull (yaml_path);
+
+  g_assert_true (modulemd_module_index_update_from_file (
+    index, yaml_path, &failures, &error));
+  g_assert_cmpint (failures->len, ==, 0);
+  g_clear_pointer (&failures, g_ptr_array_unref);
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -211,6 +234,13 @@ main (int argc, char *argv[])
               NULL,
               NULL,
               module_index_test_read,
+              NULL);
+
+  g_test_add ("/modulemd/v2/module/index/read/mixed",
+              ModuleIndexFixture,
+              NULL,
+              NULL,
+              module_index_test_read_mixed,
               NULL);
 
   return g_test_run ();

--- a/modulemd/v2/tests/test_data/long-valid.yaml
+++ b/modulemd/v2/tests/test_data/long-valid.yaml
@@ -1,0 +1,470 @@
+---
+document: modulemd-translations
+version: 1
+data:
+  module: nodejs
+  stream: 8
+  modified: 1
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: nodejs
+  profiles:
+    6: [default]
+    8: [default]
+    9: [default]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: reviewboard
+  stream: 2.5
+  profiles:
+    2.5: [default]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: django
+  profiles:
+    1.6: [default]
+...
+---
+document: modulemd
+version: 2
+data:
+  name: django
+  stream: 1.6
+  version: 20180307130104
+  context: c2c572ec
+  summary: A high-level Python Web framework
+  description: >-
+    Django is a high-level Python Web framework that encourages rapid development
+    and a clean, pragmatic design. It focuses on automating as much as possible and
+    adhering to the DRY (Don't Repeat Yourself) principle.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/django.git?#90c50f8ad1cb5ca41d62632699c375dce6353adf
+      commit: 90c50f8ad1cb5ca41d62632699c375dce6353adf
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+      rpms:
+        python-django:
+          ref: 1c3a01558a435b56f8ef4f8fc0e5c1cd35f006a5
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+  dependencies:
+  - buildrequires:
+      platform: [f28]
+    requires:
+      platform: [f28]
+  references:
+    community: https://www.djangoproject.com
+    documentation: https://docs.djangoproject.com
+    tracker: https://code.djangoproject.com/query
+  profiles:
+    default:
+      rpms:
+      - python2-django
+    python2_development:
+      rpms:
+      - python2-django
+  api:
+    rpms:
+    - python2-django
+  components:
+    rpms:
+      python-django:
+        rationale: The Django python web framework
+        repository: git://pkgs.fedoraproject.org/rpms/python-django
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django
+        ref: 1.6
+  artifacts:
+    rpms:
+    - python-django-bash-completion-0:1.6.11.7-1.module_1560+089ce146.noarch
+    - python2-django-0:1.6.11.7-1.module_1560+089ce146.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: nodejs
+  stream: 6
+  version: 20180308155546
+  context: c2c572ec
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/nodejs.git?#2d349c5055939081aefa37d71cd77051d235cb79
+      commit: 2d349c5055939081aefa37d71cd77051d235cb79
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+      rpms:
+        nodejs:
+          ref: 374ae23edf3676653fec706a5c81c5cdf019ce11
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+  dependencies:
+  - buildrequires:
+      platform: [f28]
+    requires:
+      platform: [f28]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        repository: git://pkgs.fedoraproject.org/rpms/nodejs
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/nodejs
+        ref: 6
+        buildorder: 10
+  artifacts:
+    rpms:
+    - nodejs-1:6.13.1-1.module_1575+55808bea.x86_64
+    - nodejs-devel-1:6.13.1-1.module_1575+55808bea.x86_64
+    - nodejs-docs-1:6.13.1-1.module_1575+55808bea.noarch
+    - npm-1:3.10.10-1.6.13.1.1.module_1575+55808bea.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: nodejs
+  stream: 8
+  version: 20180308143646
+  context: c2c572ec
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/nodejs.git?#4dc5da13fa51c5a5cc9f02a81d71416bc6ce787e
+      commit: 4dc5da13fa51c5a5cc9f02a81d71416bc6ce787e
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+      rpms:
+        nodejs:
+          ref: 64f8f82763943f764d25225c2d95ae065490b10a
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+  dependencies:
+  - buildrequires:
+      platform: [f28]
+    requires:
+      platform: [f28]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        repository: git://pkgs.fedoraproject.org/rpms/nodejs
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/nodejs
+        ref: 8
+        buildorder: 10
+  artifacts:
+    rpms:
+    - nodejs-1:8.10.0-3.module_1572+d7ec111e.x86_64
+    - nodejs-devel-1:8.10.0-3.module_1572+d7ec111e.x86_64
+    - nodejs-docs-1:8.10.0-3.module_1572+d7ec111e.noarch
+    - npm-1:5.6.0-1.8.10.0.3.module_1572+d7ec111e.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: nodejs
+  stream: 9
+  version: 20180308142225
+  context: c2c572ec
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/nodejs.git?#3f3665745cb84576f1faa66646cb8c37913ec461
+      commit: 3f3665745cb84576f1faa66646cb8c37913ec461
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+      rpms:
+        nodejs:
+          ref: 65648a2672dc03641b9eaa4d25a8f19d94fd90c3
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+  dependencies:
+  - buildrequires:
+      platform: [f28]
+    requires:
+      platform: [f28]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        repository: git://pkgs.fedoraproject.org/rpms/nodejs
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/nodejs
+        ref: 9
+        buildorder: 10
+  artifacts:
+    rpms:
+    - nodejs-1:9.8.0-1.module_1571+4f4bc63d.x86_64
+    - nodejs-devel-1:9.8.0-1.module_1571+4f4bc63d.x86_64
+    - nodejs-docs-1:9.8.0-1.module_1571+4f4bc63d.noarch
+    - npm-1:5.6.0-1.9.8.0.1.module_1571+4f4bc63d.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: reviewboard
+  stream: 2.5
+  version: 20180206144254
+  context: e0c83381
+  summary: A web-based code review tool
+  description: >-
+    Review Board is a powerful web-based code review tool that offers developers an
+    easy way to handle code reviews. It scales well from small projects to large companies
+    and offers a variety of tools to take much of the stress and time out of the code
+    review process.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/reviewboard.git?#1738e1ce6352c0d4da31ba137cab0b5dc5f30166
+      commit: 1738e1ce6352c0d4da31ba137cab0b5dc5f30166
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 3
+        django:
+          ref: 14fb96b250feec2e2c883e06255de2c36faa7313
+          stream: 1.6
+          filtered_rpms: []
+          version: 20180117164842
+      rpms:
+        python-django-multiselectfield:
+          ref: 149bf58875fb7b55efe29e1735baf96d44eb99a9
+        ReviewBoard:
+          ref: 5d28213f6a797e5ce28ad05ab23f80fe67353da8
+        python-django-evolution:
+          ref: 512424e1fc4b99f6f74c01a4130a4d9402b56b4e
+        python-django-pipeline:
+          ref: f019137be96cf86f49a81001fef47a0c7ab6aa35
+        python-markdown:
+          ref: 0af9dd03b4822c04be2742b39b5a4d48ef2d2222
+        python-django-haystack:
+          ref: 20fe71a6fc50a83b24578fbaf86e94a4ca584d31
+        python-djblets:
+          ref: d5634779089456ff3d0ac7b78eec81e13ff4c733
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 3
+        django:
+          ref: 14fb96b250feec2e2c883e06255de2c36faa7313
+          stream: 1.6
+          filtered_rpms: []
+          version: 20180117164842
+  dependencies:
+  - buildrequires:
+      django: [1.6]
+      platform: [f28]
+    requires:
+      django: [1.6]
+      platform: [f28]
+  references:
+    community: https://www.reviewboard.org
+    documentation: https://www.reviewboard.org/docs
+    tracker: https://hellosplat.com/s/beanbag/tickets/
+  profiles:
+    default:
+      rpms:
+      - ReviewBoard
+    server:
+      rpms:
+      - ReviewBoard
+  api:
+    rpms:
+    - ReviewBoard
+    - python2-djblets
+  components:
+    rpms:
+      ReviewBoard:
+        rationale: The Review Board code review tool
+        repository: git://pkgs.fedoraproject.org/rpms/ReviewBoard
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/ReviewBoard
+        ref: 2.5
+        buildorder: 20
+      python-django-evolution:
+        rationale: A database modification library used and maintained by the Review
+          Board upstream
+        repository: git://pkgs.fedoraproject.org/rpms/python-django-evolution
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django-evolution
+        ref: 0.7
+      python-django-haystack:
+        rationale: An older version of the Haystack search library for Django, needed
+          for compatibility.
+        repository: git://pkgs.fedoraproject.org/rpms/python-django-haystack
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django-haystack
+        ref: 2.4
+      python-django-multiselectfield:
+        rationale: An older version of a mult-select form field needed by Review Board.
+        repository: git://pkgs.fedoraproject.org/rpms/python-django-multiselectfield
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django-multiselectfield
+        ref: 0.1
+      python-django-pipeline:
+        rationale: An older version of this asset-packaging library for Django that
+          is compatible with Review Board.
+        repository: git://pkgs.fedoraproject.org/rpms/python-django-pipeline
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django-pipeline
+        ref: 1.3
+      python-djblets:
+        rationale: Review Board tool library
+        repository: git://pkgs.fedoraproject.org/rpms/python-djblets
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-djblets
+        ref: 0.9
+        buildorder: 10
+      python-markdown:
+        rationale: An older version of this Markdown implementation that is compatible
+          with Review Board.
+        repository: git://pkgs.fedoraproject.org/rpms/python-markdown
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-markdown
+        ref: 2.4
+  artifacts:
+    rpms:
+    - ReviewBoard-0:2.5.17-17.module_d032b812.noarch
+    - python-django-haystack-docs-0:2.4.1-12.module_d032b812.noarch
+    - python2-django-evolution-1:0.7.7-12.module_d032b812.noarch
+    - python2-django-haystack-0:2.4.1-12.module_d032b812.noarch
+    - python2-django-multiselectfield-0:0.1.3-10.module_d032b812.noarch
+    - python2-django-pipeline-0:1.3.27-11.module_d032b812.noarch
+    - python2-djblets-0:0.9.9-13.module_d032b812.noarch
+    - python2-markdown-0:2.4.1-11.module_d032b812.noarch
+    - python3-markdown-0:2.4.1-11.module_d032b812.noarch
+...


### PR DESCRIPTION
This PR contains two patches. The first is a fix for memory errors when reading complicated XMD structures (including those present in real-world repodata). The second patch is a test I added that discovered those errors.