### PR TITLE
Defaults: add 'modified' field

### DIFF
--- a/mod-defaults/spec.v1.yaml
+++ b/mod-defaults/spec.v1.yaml
@@ -5,6 +5,11 @@ version: 1
 data:
     # Module name that the defaults are for, required.
     module: foo
+    # A 64-bit unsigned integer. Use YYYYMMDDHHMM to easily identify the last
+    # modification time. Use UTC for consistency.
+    # When merging, entries with a newer 'modified' value will override any
+    # earlier values. (optional)
+    modified: 201812071200
     # Module stream that is the default for the module, optional.
     stream: x.y
     # Module profiles indexed by the stream name, optional

--- a/modulemd/include/modulemd-1.0/modulemd-defaults.h
+++ b/modulemd/include/modulemd-1.0/modulemd-defaults.h
@@ -326,6 +326,28 @@ modulemd_defaults_dup_intents (ModulemdDefaults *self);
 
 
 /**
+ * modulemd_defaults_set_modified:
+ *
+ * Sets the modified field for these defaults.
+ *
+ * Since: 1.8
+ */
+void
+modulemd_defaults_set_modified (ModulemdDefaults *self, guint64 modified);
+
+
+/**
+ * modulemd_defaults_get_modified:
+ *
+ * Returns: The modified field for these defaults.
+ *
+ * Since: 1.8
+ */
+guint64
+modulemd_defaults_get_modified (ModulemdDefaults *self);
+
+
+/**
  * modulemd_defaults_new_from_file:
  * @yaml_file: A YAML file containing the module metadata and other related
  * information such as default streams.

--- a/modulemd/v1/modulemd-yaml-emitter-defaults.c
+++ b/modulemd/v1/modulemd-yaml-emitter-defaults.c
@@ -158,6 +158,7 @@ _emit_defaults_data (yaml_emitter_t *emitter,
   yaml_event_t event;
   gchar *name = NULL;
   gchar *value = NULL;
+  guint64 modified;
 
   g_debug ("TRACE: entering _emit_defaults_data");
 
@@ -173,6 +174,16 @@ _emit_defaults_data (yaml_emitter_t *emitter,
   value = modulemd_defaults_dup_module_name (defaults);
   MMD_YAML_EMIT_STR_STR_DICT (&event, name, value, YAML_PLAIN_SCALAR_STYLE);
 
+  /* Modified field */
+  modified = modulemd_defaults_get_modified (defaults);
+  if (modified)
+    {
+      name = g_strdup ("modified");
+      value = g_strdup_printf ("%" PRIu64, modified);
+
+      MMD_YAML_EMIT_STR_STR_DICT (
+        &event, name, value, YAML_PLAIN_SCALAR_STYLE);
+    }
 
   /* Module default stream */
   value = modulemd_defaults_dup_default_stream (defaults);

--- a/test_data/defaults/overriding-modified.yaml
+++ b/test_data/defaults/overriding-modified.yaml
@@ -1,0 +1,40 @@
+---
+# Override the default stream and add new profile defaults
+document: modulemd-defaults
+version: 1
+data:
+    module: httpd
+    modified: 201812061200
+    stream: '2.4'
+    profiles:
+        '2.2': [client, server]
+        '2.4': [client, server]
+    intents:
+        workstation:
+            stream: '2.4'
+            profiles:
+                '2.4': [client]
+                '2.6': [client, server, bindings]
+                '2.8': [client, server, bindings, new]
+---
+# Reduce the number of profile defaults
+document: modulemd-defaults
+version: 1
+data:
+    module: postgresql
+    modified: 201812061200
+    stream: '8.1'
+    profiles:
+        '8.1': [client, server, foo]
+---
+# Override the default stream
+document: modulemd-defaults
+version: 1
+data:
+    module: nodejs
+    modified: 201812061200
+    stream: '9.0'
+    profiles:
+        '6.0': [default]
+        '8.0': [minimal]
+        '9.0': [supermegaultra]


### PR DESCRIPTION
Merging Defaults entries behaves as follows (changes from 1.7 in bold):
- **Within a set of objects, if two or more default entries reference the same module, the one with the highest `modified` field will be used and the others discarded.**
- **When merging sets of objects, if two or more sets contain Defaults for the same module, but different `modified` values, the one with the highest `modified` value will be used and the others discarded.**
- Any module default that is provided by a single repository is authoritative.
- If the repos have different priorities (not common), then the default for this module and stream name coming from the repo of higher priority will be used and the default from the lower-priority repo will not be included **even if it has a higher modified value [(1)](#link_1)**.
- If the repos have the same priority (such as "fedora" and "updates" in the Fedora Project) **and `modified` value**, the entries will be merged as follows:
  - If both repositories specify a default stream for the module, use it.
  - If either repository specifies a default stream for the module and the other does not, use the one specified.
  - If both repositories specify different streams, this is an unresolvable merge conflict and the merge resolution will fail and report an error.
  - If both repositories specify a set of default profiles for a stream and the sets are equivalent, use that set.
  - If one repository specifies a set of default profiles for a stream and the other does not, use the one specified.
  - If both repositories specify a set of default profiles for a stream and each are providing a different set, this is an unresolvable merge conflict and the merge resolution will fail and report an error.

Fixes https://github.com/fedora-modularity/libmodulemd/issues/148

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>