### PR TITLE
Defaults: add 'modified' field for v2 API

### DIFF
--- a/mod-defaults/spec.v1.yaml
+++ b/mod-defaults/spec.v1.yaml
@@ -5,6 +5,11 @@ version: 1
 data:
     # Module name that the defaults are for, required.
     module: foo
+    # A 64-bit unsigned integer. Use YYYYMMDDHHMM to easily identify the last
+    # modification time. Use UTC for consistency.
+    # When merging, entries with a newer 'modified' value will override any
+    # earlier values. (optional)
+    modified: 201812071200
     # Module stream that is the default for the module, optional.
     stream: x.y
     # Module profiles indexed by the stream name, optional

--- a/modulemd/v1/include/modulemd-1.0/modulemd-defaults.h
+++ b/modulemd/v1/include/modulemd-1.0/modulemd-defaults.h
@@ -326,6 +326,28 @@ modulemd_defaults_dup_intents (ModulemdDefaults *self);
 
 
 /**
+ * modulemd_defaults_set_modified:
+ *
+ * Sets the modified field for these defaults.
+ *
+ * Since: 1.8
+ */
+void
+modulemd_defaults_set_modified (ModulemdDefaults *self, guint64 modified);
+
+
+/**
+ * modulemd_defaults_get_modified:
+ *
+ * Returns: The modified field for these defaults.
+ *
+ * Since: 1.8
+ */
+guint64
+modulemd_defaults_get_modified (ModulemdDefaults *self);
+
+
+/**
  * modulemd_defaults_new_from_file:
  * @yaml_file: A YAML file containing the module metadata and other related
  * information such as default streams.

--- a/modulemd/v1/modulemd-yaml-emitter-defaults.c
+++ b/modulemd/v1/modulemd-yaml-emitter-defaults.c
@@ -158,6 +158,7 @@ _emit_defaults_data (yaml_emitter_t *emitter,
   yaml_event_t event;
   gchar *name = NULL;
   gchar *value = NULL;
+  guint64 modified;
 
   g_debug ("TRACE: entering _emit_defaults_data");
 
@@ -173,6 +174,16 @@ _emit_defaults_data (yaml_emitter_t *emitter,
   value = modulemd_defaults_dup_module_name (defaults);
   MMD_YAML_EMIT_STR_STR_DICT (&event, name, value, YAML_PLAIN_SCALAR_STYLE);
 
+  /* Modified field */
+  modified = modulemd_defaults_get_modified (defaults);
+  if (modified)
+    {
+      name = g_strdup ("modified");
+      value = g_strdup_printf ("%" PRIu64, modified);
+
+      MMD_YAML_EMIT_STR_STR_DICT (
+        &event, name, value, YAML_PLAIN_SCALAR_STYLE);
+    }
 
   /* Module default stream */
   value = modulemd_defaults_dup_default_stream (defaults);

--- a/modulemd/v2/include/modulemd-2.0/modulemd-defaults.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-defaults.h
@@ -150,4 +150,29 @@ modulemd_defaults_get_module_name (ModulemdDefaults *self);
 guint64
 modulemd_defaults_get_mdversion (ModulemdDefaults *self);
 
+
+/**
+ * modulemd_defaults_set_modified:
+ * @self: (in): This #ModulemdDefaults object
+ * @modified: (in): The last modified time represented as a 64-bit integer
+ * (such as 201807011200)
+ *
+ * Since: 2.0
+ */
+void
+modulemd_defaults_set_modified (ModulemdDefaults *self, guint64 modified);
+
+
+/**
+ * modulemd_defaults_get_modified:
+ * @self: (in): This #ModulemdDefaults object
+ *
+ * Returns: The last modified time represented as a 64-bit integer
+ * (such as 201807011200)
+ *
+ * Since: 2.0
+ */
+guint64
+modulemd_defaults_get_modified (ModulemdDefaults *self);
+
 G_END_DECLS

--- a/modulemd/v2/modulemd-defaults.c
+++ b/modulemd/v2/modulemd-defaults.c
@@ -23,6 +23,7 @@
 typedef struct
 {
   gchar *module_name;
+  guint64 modified;
 } ModulemdDefaultsPrivate;
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE (ModulemdDefaults,
@@ -194,6 +195,29 @@ modulemd_defaults_get_mdversion (ModulemdDefaults *self)
   g_return_val_if_fail (klass->get_mdversion, 0);
 
   return klass->get_mdversion (self);
+}
+
+void
+modulemd_defaults_set_modified (ModulemdDefaults *self, guint64 modified)
+{
+  g_return_if_fail (MODULEMD_IS_DEFAULTS (self));
+
+  ModulemdDefaultsPrivate *priv =
+    modulemd_defaults_get_instance_private (self);
+
+  priv->modified = modified;
+}
+
+
+guint64
+modulemd_defaults_get_modified (ModulemdDefaults *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_DEFAULTS, 0);
+
+  ModulemdDefaultsPrivate *priv =
+    modulemd_defaults_get_instance_private (self);
+
+  return priv->modified;
 }
 
 

--- a/modulemd/v2/tests/test-modulemd-defaults-v1.c
+++ b/modulemd/v2/tests/test-modulemd-defaults-v1.c
@@ -321,12 +321,11 @@ defaults_test_parse_yaml (CommonMmdTestFixture *fixture,
   g_assert_cmpstr (
     modulemd_subdocument_info_get_yaml (subdoc),
     ==,
-    "---\ndocument: modulemd-defaults\nversion: 1\ndata:\n  module: "
-    "foo\n  "
-    "stream: x.y\n  profiles:\n    'x.y': []\n    bar: [baz, snafu]\n  "
-    "intents:\n    desktop:\n      stream: y.z\n      profiles:\n        "
-    "'y.z': [blah]\n        'x.y': [other]\n    server:\n      stream: x.y\n  "
-    "    profiles:\n        'x.y': []\n");
+    "---\ndocument: modulemd-defaults\nversion: 1\ndata:\n  module: foo\n  "
+    "modified: 201812071200\n  stream: x.y\n  profiles:\n    'x.y': []\n    "
+    "bar: [baz, snafu]\n  intents:\n    desktop:\n      stream: y.z\n      "
+    "profiles:\n        'y.z': [blah]\n        'x.y': [other]\n    server:\n  "
+    "    stream: x.y\n      profiles:\n        'x.y': []\n");
 
   /* Parse the data section and validate the content */
   defaults = modulemd_defaults_v1_parse_yaml (subdoc, &error);

--- a/test_data/defaults/overriding-modified.yaml
+++ b/test_data/defaults/overriding-modified.yaml
@@ -1,0 +1,40 @@
+---
+# Override the default stream and add new profile defaults
+document: modulemd-defaults
+version: 1
+data:
+    module: httpd
+    modified: 201812061200
+    stream: '2.4'
+    profiles:
+        '2.2': [client, server]
+        '2.4': [client, server]
+    intents:
+        workstation:
+            stream: '2.4'
+            profiles:
+                '2.4': [client]
+                '2.6': [client, server, bindings]
+                '2.8': [client, server, bindings, new]
+---
+# Reduce the number of profile defaults
+document: modulemd-defaults
+version: 1
+data:
+    module: postgresql
+    modified: 201812061200
+    stream: '8.1'
+    profiles:
+        '8.1': [client, server, foo]
+---
+# Override the default stream
+document: modulemd-defaults
+version: 1
+data:
+    module: nodejs
+    modified: 201812061200
+    stream: '9.0'
+    profiles:
+        '6.0': [default]
+        '8.0': [minimal]
+        '9.0': [supermegaultra]


### PR DESCRIPTION
This patch depends on https://github.com/fedora-modularity/libmodulemd/pull/155 and implements the getter, setter and YAML routines for the new `modified` field in the 2.0 API. It also updates the sanity test of the specification YAML.

It does not yet implement the merge logic, because that's still being written and will follow as part of the `ModulemdIndexMerger` patch.