### PR TITLE
APIv1: Make unknown YAML keys non-fatal

### DIFF
--- a/.travis/travis-tasks.sh
+++ b/.travis/travis-tasks.sh
@@ -73,8 +73,8 @@ createrepo_c rpmbuild/RPMS/
 
 dnf -y install --nogpgcheck \
                --repofrompath libmodulemd-travis,rpmbuild/RPMS \
-               python3-compat-libmodulemd1 \
-               compat-libmodulemd1-devel \
+               python3-libmodulemd1 \
+               libmodulemd1-devel \
                --exclude libmodulemd
 
 popd #build_rpm

--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -52,40 +52,40 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 Development files for libmodulemd.
 
 
-%package -n compat-libmodulemd1
+%package -n libmodulemd1
 Summary: Compatibility package for libmodulemd 1.x
 Version: %{libmodulemd_v1_version}
 Obsoletes: libmodulemd < 2
 Provides: libmodulemd = %{libmodulemd_v1_version}-%{release}
 Provides: libmodulemd%{?_isa} = %{libmodulemd_v1_version}-%{release}
 
-%description -n compat-libmodulemd1
+%description -n libmodulemd1
 Compatibility library for libmodulemd 1.x
 
 
-%package -n compat-libmodulemd1-devel
+%package -n libmodulemd1-devel
 Summary: Compatibility development package for libmodulemd 1.x
 Version: %{libmodulemd_v1_version}
-Requires: compat-libmodulemd1 = %{version}-%{release}
+Requires: libmodulemd1%{?_isa} = %{version}-%{release}
 Conflicts: %{name}-devel
 Obsoletes: libmodulemd-devel < 2
 Provides: libmodulemd-devel = %{version}-%{release}
 RemovePathPostfixes: .compat
 
 
-%description -n compat-libmodulemd1-devel
+%description -n libmodulemd1-devel
 Development files for libmodulemd 1.x
 
 
-%package -n python3-compat-libmodulemd1
+%package -n python3-libmodulemd1
 Summary: Python 3 bindings for %{name}
 Version: %{libmodulemd_v1_version}
 BuildArch: noarch
-Requires: compat-libmodulemd1 = %{version}-%{release}
+Requires: libmodulemd1 = %{version}-%{release}
 Requires: python3-gobject-base
 
-%description -n python3-compat-libmodulemd1
-Python 3 bindings for compat-libmodulemd1
+%description -n python3-libmodulemd1
+Python 3 bindings for libmodulemd1
 
 
 %prep
@@ -146,10 +146,10 @@ ln -s libmodulemd.so.%{libmodulemd_v1_version} \
 %{python3_sitearch}/gi/overrides/
 
 
-%files -n python3-compat-libmodulemd1
+%files -n python3-libmodulemd1
 
 
-%files -n compat-libmodulemd1
+%files -n libmodulemd1
 %license COPYING
 %doc README.md
 %{_libdir}/%{name}.so.1*
@@ -157,7 +157,7 @@ ln -s libmodulemd.so.%{libmodulemd_v1_version} \
 %{_libdir}/girepository-1.0/Modulemd-1.0.typelib
 
 
-%files -n compat-libmodulemd1-devel
+%files -n libmodulemd1-devel
 %{_libdir}/%{name}.so.compat
 %{_libdir}/pkgconfig/modulemd.pc
 %{_includedir}/modulemd/

--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -126,7 +126,6 @@ ln -s libmodulemd.so.%{libmodulemd_v1_version} \
 %files
 %license COPYING
 %doc README.md
-%{_bindir}/modulemd-validator
 %{_libdir}/%{name}.so.2*
 %dir %{_libdir}/girepository-1.0
 %{_libdir}/girepository-1.0/Modulemd-2.0.typelib
@@ -152,6 +151,7 @@ ln -s libmodulemd.so.%{libmodulemd_v1_version} \
 %files -n libmodulemd1
 %license COPYING
 %doc README.md
+%{_bindir}/modulemd-validator
 %{_libdir}/%{name}.so.1*
 %dir %{_libdir}/girepository-1.0
 %{_libdir}/girepository-1.0/Modulemd-1.0.typelib

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,7 +10,7 @@
 # For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 option('developer_build', type : 'boolean', value : true)
-option('build_api_v1', type : 'boolean', value : true)
-option('build_api_v2', type : 'boolean', value : false)
+option('build_api_v1', type : 'boolean', value : false)
+option('build_api_v2', type : 'boolean', value : true)
 option('test_dirty_git', type : 'boolean', value : false)
 option('test_installed_lib', type: 'boolean', value : false)

--- a/modulemd/v1/include/modulemd-1.0/private/modulemd-yaml.h
+++ b/modulemd/v1/include/modulemd-1.0/private/modulemd-yaml.h
@@ -411,6 +411,9 @@ parse_raw_yaml_sequence (yaml_parser_t *parser,
                          GError **error);
 
 gboolean
+skip_unknown_yaml (yaml_parser_t *parser, GError **error);
+
+gboolean
 emit_yaml_variant (yaml_emitter_t *emitter, GVariant *variant, GError **error);
 
 /* == Common Parsing Functions == */

--- a/modulemd/v1/modulemd-yaml-parser-defaults.c
+++ b/modulemd/v1/modulemd-yaml-parser-defaults.c
@@ -166,8 +166,8 @@ _parse_defaults (yaml_parser_t *parser,
             {
               g_debug ("Unexpected key in root: %s",
                        (const gchar *)event.data.scalar.value);
-              MMD_YAML_ERROR_EVENT_RETURN (
-                error, event, "Unexpected key in root");
+              if (!skip_unknown_yaml (parser, error))
+                goto error;
             }
           break;
 
@@ -303,6 +303,15 @@ _parse_defaults_data (ModulemdDefaults *defaults,
                                "intents"))
             {
               _yaml_parser_defaults_recurse_down (_parse_defaults_intents);
+            }
+
+          /* Other keys */
+          else
+            {
+              g_debug ("Unexpected key in data: %s",
+                       (const gchar *)event.data.scalar.value);
+              if (!skip_unknown_yaml (parser, error))
+                goto error;
             }
           break;
 
@@ -553,8 +562,10 @@ _parse_intent (yaml_parser_t *parser,
           else
             {
               /* Unexpected key in the map */
-              MMD_YAML_ERROR_EVENT_RETURN (
-                error, event, "Unexpected key in intent");
+              g_debug ("Unexpected key in intent: %s",
+                       (const gchar *)event.data.scalar.value);
+              if (!skip_unknown_yaml (parser, error))
+                goto error;
               break;
             }
 

--- a/modulemd/v1/modulemd-yaml-parser-translation.c
+++ b/modulemd/v1/modulemd-yaml-parser-translation.c
@@ -163,10 +163,10 @@ _parse_translation (yaml_parser_t *parser,
 
           else
             {
-              MMD_YAML_SET_ERROR (error,
-                                  "Unexpected key in root: %s",
-                                  (const gchar *)event.data.scalar.value);
-              return FALSE;
+              g_debug ("Unexpected key in root: %s",
+                       (const gchar *)event.data.scalar.value);
+              if (!skip_unknown_yaml (parser, error))
+                return FALSE;
             }
           break;
 
@@ -293,10 +293,10 @@ _parse_translation_data (ModulemdTranslation *translation,
 
           else
             {
-              MMD_YAML_SET_ERROR (error,
-                                  "Unexpected key in root: %s",
-                                  (const gchar *)event.data.scalar.value);
-              return FALSE;
+              g_debug ("Unexpected key in data: %s",
+                       (const gchar *)event.data.scalar.value);
+              if (!skip_unknown_yaml (parser, error))
+                return FALSE;
             }
 
           break;
@@ -455,7 +455,8 @@ _parse_translation_entry (yaml_parser_t *parser,
               yaml_event_delete (&value_event);
             }
 
-          if (!g_strcmp0 ((const gchar *)event.data.scalar.value, "profiles"))
+          else if (!g_strcmp0 ((const gchar *)event.data.scalar.value,
+                               "profiles"))
             {
               if (!_hashtable_from_mapping (parser, &profiles, error))
                 return NULL;
@@ -467,6 +468,14 @@ _parse_translation_entry (yaml_parser_t *parser,
                     entry, (const gchar *)key, (const gchar *)value);
                 }
               g_clear_pointer (&profiles, g_hash_table_unref);
+            }
+
+          else
+            {
+              g_debug ("Unexpected key in entries: %s",
+                       (const gchar *)event.data.scalar.value);
+              if (!skip_unknown_yaml (parser, error))
+                return NULL;
             }
 
           break;

--- a/modulemd/v1/tests/test-modulemd-yaml.c
+++ b/modulemd/v1/tests/test-modulemd-yaml.c
@@ -545,6 +545,30 @@ modulemd_yaml_test_index_from_stream (YamlFixture *fixture,
 }
 
 
+static void
+modulemd_yaml_read_unknown_keys (YamlFixture *fixture, gconstpointer user_data)
+{
+  g_autoptr (ModulemdModule) module = NULL;
+  gchar *yaml_path = NULL;
+  g_autoptr (GError) error = NULL;
+  FILE *stream = NULL;
+
+
+  yaml_path = g_strdup_printf ("%s/test_data/good-v2-extra-keys.yaml",
+                               g_getenv ("MESON_SOURCE_ROOT"));
+  g_assert_nonnull (yaml_path);
+
+  stream = g_fopen (yaml_path, "rb");
+  g_assert_nonnull (stream);
+  g_free (yaml_path);
+
+  module = modulemd_module_new_from_stream (stream, &error);
+  g_assert_true (module);
+  g_assert_null (error);
+  fclose (stream);
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -596,6 +620,13 @@ main (int argc, char *argv[])
               modulemd_yaml_set_up,
               modulemd_yaml_test_v2_stream,
               modulemd_yaml_tear_down);
+
+  g_test_add ("/modulemd/yaml/extra_keys",
+              YamlFixture,
+              NULL,
+              NULL,
+              modulemd_yaml_read_unknown_keys,
+              NULL);
 
   g_test_add ("/modulemd/yaml/test_validate_nevra",
               YamlFixture,

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
@@ -87,6 +87,8 @@ modulemd_module_index_new (void);
  * @self: This #ModulemdModuleIndex object
  * @yaml_file: (in): A YAML file containing the module metadata and other
  * related information such as default streams.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @failures: (out) (element-type ModulemdSubdocumentInfo) (transfer container):
  * An array containing any subdocuments from the YAML file that failed to parse.
  * See #ModulemdSubdocumentInfo for more details.
@@ -102,6 +104,7 @@ modulemd_module_index_new (void);
 gboolean
 modulemd_module_index_update_from_file (ModulemdModuleIndex *self,
                                         const gchar *yaml_file,
+                                        gboolean strict,
                                         GPtrArray **failures,
                                         GError **error);
 
@@ -111,6 +114,8 @@ modulemd_module_index_update_from_file (ModulemdModuleIndex *self,
  * @self: This #ModulemdModuleIndex object
  * @yaml_string: (in): A YAML string containing the module metadata and other
  * related information such as default streams.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @failures: (out) (element-type ModulemdSubdocumentInfo) (transfer container):
  * An array containing any subdocuments from the YAML file that failed to parse.
  * See #ModulemdSubdocumentInfo for more details.
@@ -126,6 +131,7 @@ modulemd_module_index_update_from_file (ModulemdModuleIndex *self,
 gboolean
 modulemd_module_index_update_from_string (ModulemdModuleIndex *self,
                                           const gchar *yaml_string,
+                                          gboolean strict,
                                           GPtrArray **failures,
                                           GError **error);
 
@@ -135,6 +141,8 @@ modulemd_module_index_update_from_string (ModulemdModuleIndex *self,
  * @self: This #ModulemdModuleIndex object
  * @yaml_stream: (in): A YAML stream containing the module metadata and other
  * related information such as default streams.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @failures: (out) (element-type ModulemdSubdocumentInfo) (transfer container):
  * An array containing any subdocuments from the YAML file that failed to parse.
  * See #ModulemdSubdocumentInfo for more details.
@@ -150,6 +158,7 @@ modulemd_module_index_update_from_string (ModulemdModuleIndex *self,
 gboolean
 modulemd_module_index_update_from_stream (ModulemdModuleIndex *self,
                                           FILE *yaml_stream,
+                                          gboolean strict,
                                           GPtrArray **failures,
                                           GError **error);
 

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
@@ -91,11 +91,11 @@ modulemd_module_index_new (void);
  * An array containing any subdocuments from the YAML file that failed to parse.
  * See #ModulemdSubdocumentInfo for more details.
  * @error: (out): A GError containing additional information if this function
- * fails.
+ * fails in a way that prevents program continuation.
  *
  * Returns: TRUE if the update was successful. Returns FALSE and sets failures
- * and error approriately if any of the YAML subdocuments were invalid or if
- * there was a parse error.
+ * approriately if any of the YAML subdocuments were invalid or sets @error if
+ * there was a fatal parse error.
  *
  * Since: 2.0
  */
@@ -115,11 +115,11 @@ modulemd_module_index_update_from_file (ModulemdModuleIndex *self,
  * An array containing any subdocuments from the YAML file that failed to parse.
  * See #ModulemdSubdocumentInfo for more details.
  * @error: (out): A GError containing additional information if this function
- * fails.
+ * fails in a way that prevents program continuation.
  *
  * Returns: TRUE if the update was successful. Returns FALSE and sets failures
- * and error approriately if any of the YAML subdocuments were invalid or if
- * there was a parse error.
+ * approriately if any of the YAML subdocuments were invalid or sets @error if
+ * there was a fatal parse error.
  *
  * Since: 2.0
  */
@@ -139,11 +139,11 @@ modulemd_module_index_update_from_string (ModulemdModuleIndex *self,
  * An array containing any subdocuments from the YAML file that failed to parse.
  * See #ModulemdSubdocumentInfo for more details.
  * @error: (out): A GError containing additional information if this function
- * fails.
+ * fails in a way that prevents program continuation.
  *
  * Returns: TRUE if the update was successful. Returns FALSE and sets failures
- * and error approriately if any of the YAML subdocuments were invalid or if
- * there was a parse error.
+ * approriately if any of the YAML subdocuments were invalid or sets @error if
+ * there was a fatal parse error.
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream.h
@@ -103,6 +103,8 @@ modulemd_module_stream_new (guint64 mdversion,
  * @module_stream: (in) (nullable): An optional module stream name to override
  * the document on disk. Mostly useful in cases where the name is being
  * auto-detected from git.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a failed read.
  *
  * Create a #ModulemdModuleStream object from a YAML file.
@@ -117,6 +119,7 @@ modulemd_module_stream_new (guint64 mdversion,
  */
 ModulemdModuleStream *
 modulemd_module_stream_read_file (const gchar *path,
+                                  gboolean strict,
                                   const gchar *module_name,
                                   const gchar *module_stream,
                                   GError **error);
@@ -132,6 +135,8 @@ modulemd_module_stream_read_file (const gchar *path,
  * @module_stream: (in) (nullable): An optional module stream name to override
  * the document on disk. Mostly useful in cases where the name is being
  * auto-detected from git.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a failed read.
  *
  * Create a #ModulemdModuleStream object from a YAML string.
@@ -146,6 +151,7 @@ modulemd_module_stream_read_file (const gchar *path,
  */
 ModulemdModuleStream *
 modulemd_module_stream_read_string (const gchar *yaml_string,
+                                    gboolean strict,
                                     const gchar *module_name,
                                     const gchar *module_stream,
                                     GError **error);
@@ -161,6 +167,8 @@ modulemd_module_stream_read_string (const gchar *yaml_string,
  * @module_stream: (in) (nullable): An optional module stream name to override
  * the document on disk. Mostly useful in cases where the name is being
  * auto-detected from git.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a failed read.
  *
  * Create a #ModulemdModuleStream object from a YAML file.
@@ -175,6 +183,7 @@ modulemd_module_stream_read_string (const gchar *yaml_string,
  */
 ModulemdModuleStream *
 modulemd_module_stream_read_stream (FILE *stream,
+                                    gboolean strict,
                                     const gchar *module_name,
                                     const gchar *module_stream,
                                     GError **error);

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-buildopts-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-buildopts-private.h
@@ -30,6 +30,8 @@
  * modulemd_buildopts_parse_yaml:
  * @parser: (inout): A libyaml parser object positioned at the beginning of a
  * Buildopts entry in the YAML document.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -40,7 +42,9 @@
  * Since: 2.0
  */
 ModulemdBuildopts *
-modulemd_buildopts_parse_yaml (yaml_parser_t *parser, GError **error);
+modulemd_buildopts_parse_yaml (yaml_parser_t *parser,
+                               gboolean strict,
+                               GError **error);
 
 /**
  * modulemd_buildopts_emitter_yaml:

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-component-module-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-component-module-private.h
@@ -31,6 +31,8 @@
  * @parser: (inout): A libyaml parser object positioned at the beginning of a
  * ComponentModule's mapping entry in the YAML document.
  * @name: (in): A string with the name of the component.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for parsing error.
  *
  * Returns: (transfer full): A newly-allocated #ModulemdComponentModule object
@@ -42,6 +44,7 @@
 ModulemdComponentModule *
 modulemd_component_module_parse_yaml (yaml_parser_t *parser,
                                       const gchar *name,
+                                      gboolean strict,
                                       GError **error);
 
 

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-component-rpm-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-component-rpm-private.h
@@ -31,6 +31,8 @@
  * @parser: (inout): A libyaml parser object positioned at the beginning of a
  * ComponentRpm's mapping entry in the YAML document.
  * @name: (in): A string with the name of the component.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for parsing error.
  *
  * Returns: (transfer full): A newly-allocated #ModulemdComponentRpm object
@@ -42,6 +44,7 @@
 ModulemdComponentRpm *
 modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
                                    const gchar *name,
+                                   gboolean strict,
                                    GError **error);
 
 

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-defaults-v1-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-defaults-v1-private.h
@@ -32,6 +32,8 @@ G_BEGIN_DECLS
  * modulemd_defaults_v1_parse_yaml:
  * @subdoc: (in): A #ModulemdSubdocumentInfo representing a defaults document
  * of metadata version 1.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -43,6 +45,7 @@ G_BEGIN_DECLS
  */
 ModulemdDefaultsV1 *
 modulemd_defaults_v1_parse_yaml (ModulemdSubdocumentInfo *subdoc,
+                                 gboolean strict,
                                  GError **error);
 
 

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-dependencies-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-dependencies-private.h
@@ -30,6 +30,8 @@
  * modulemd_dependencies_parse_yaml:
  * @parser: (inout): A libyaml parser object positioned at a sequence entry for
  * a Dependencies object.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -40,7 +42,9 @@
  * Since: 2.0
  */
 ModulemdDependencies *
-modulemd_dependencies_parse_yaml (yaml_parser_t *parser, GError **error);
+modulemd_dependencies_parse_yaml (yaml_parser_t *parser,
+                                  gboolean strict,
+                                  GError **error);
 
 /**
  * modulemd_dependenciesemitter_yaml:

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-dependencies-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-dependencies-private.h
@@ -59,3 +59,7 @@ gboolean
 modulemd_dependencies_emit_yaml (ModulemdDependencies *self,
                                  yaml_emitter_t *emitter,
                                  GError **error);
+
+
+gboolean
+modulemd_dependencies_validate (ModulemdDependencies *self, GError **error);

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-module-stream-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-module-stream-private.h
@@ -33,9 +33,6 @@ G_BEGIN_DECLS
  */
 
 
-#define MODULESTREAM_PLACEHOLDER "__MODULESTREAM_PLACEHOLDER__"
-
-
 void
 modulemd_module_stream_set_module_name (ModulemdModuleStream *self,
                                         const gchar *module_name);

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-module-stream-v1-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-module-stream-v1-private.h
@@ -72,6 +72,8 @@ struct _ModulemdModuleStreamV1
  * modulemd_module_stream_v1_parse_yaml:
  * @subdoc: (in): A #ModulemdSubdocumentInfo representing a stream v1
  * document
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -83,6 +85,7 @@ struct _ModulemdModuleStreamV1
  */
 ModulemdModuleStreamV1 *
 modulemd_module_stream_v1_parse_yaml (ModulemdSubdocumentInfo *subdoc,
+                                      gboolean strict,
                                       GError **error);
 
 /**

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-module-stream-v2-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-module-stream-v2-private.h
@@ -71,6 +71,8 @@ struct _ModulemdModuleStreamV2
  * modulemd_module_stream_v2_parse_yaml:
  * @subdoc: (in): A #ModulemdSubdocumentInfo representing a stream v2
  * document
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -82,6 +84,7 @@ struct _ModulemdModuleStreamV2
  */
 ModulemdModuleStreamV2 *
 modulemd_module_stream_v2_parse_yaml (ModulemdSubdocumentInfo *subdoc,
+                                      gboolean strict,
                                       GError **error);
 
 /**

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-profile-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-profile-private.h
@@ -31,6 +31,8 @@
  * @parser: (inout): A libyaml parser object positioned at the beginning of a
  * Profile entry in the YAML document.
  * @name: (in): The name of this profile.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -43,6 +45,7 @@
 ModulemdProfile *
 modulemd_profile_parse_yaml (yaml_parser_t *parser,
                              const gchar *name,
+                             gboolean strict,
                              GError **error);
 
 /**

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-service-level-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-service-level-private.h
@@ -31,6 +31,8 @@
  * @parser: (inout): A libyaml parser object positioned at the beginning of a
  * Service Level entry in the YAML document.
  * @name: (in): The name of this service level.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -43,6 +45,7 @@
 ModulemdServiceLevel *
 modulemd_service_level_parse_yaml (yaml_parser_t *parser,
                                    const gchar *name,
+                                   gboolean strict,
                                    GError **error);
 
 /**

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-subdocument-info-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-subdocument-info-private.h
@@ -127,10 +127,14 @@ modulemd_subdocument_info_set_gerror (ModulemdSubdocumentInfo *self,
  * modulemd_subdocument_info_get_data_parser:
  * @self: This #ModulemdSubdocumentInfo
  * @parser: (inout): An unconfigured libyaml parser
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
+ * @error: (out): A #GError containing the parser error if this function fails.
  *
  * Since: 2.0
  */
 gboolean
 modulemd_subdocument_info_get_data_parser (ModulemdSubdocumentInfo *self,
                                            yaml_parser_t *parser,
+                                           gboolean strict,
                                            GError **error);

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-translation-entry-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-translation-entry-private.h
@@ -30,7 +30,9 @@
  * modulemd_translation_entry_parse_yaml:
  * @parser: (inout): A libyaml parser object positioned at the beginning of a
  * Translation Entry's mapping entry in the YAML document.
- * locale: (int): A string with the locale for the current translation entry.
+ * @locale: (int): A string with the locale for the current translation entry.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -43,6 +45,7 @@
 ModulemdTranslationEntry *
 modulemd_translation_entry_parse_yaml (yaml_parser_t *parser,
                                        const gchar *locale,
+                                       gboolean strict,
                                        GError **error);
 
 /**

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-translation-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-translation-private.h
@@ -45,6 +45,8 @@ modulemd_translation_get_modified (ModulemdTranslation *self);
  * modulemd_translation_parse_yaml:
  * @subdoc: (in): A #ModulemdSubdocumentInfo representing a translation
  * document
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a parsing or
  * validation error.
  *
@@ -56,6 +58,7 @@ modulemd_translation_get_modified (ModulemdTranslation *self);
  */
 ModulemdTranslation *
 modulemd_translation_parse_yaml (ModulemdSubdocumentInfo *subdoc,
+                                 gboolean strict,
                                  GError **error);
 
 /**

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-util.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-util.h
@@ -92,6 +92,9 @@ modulemd_variant_deep_copy (GVariant *variant);
 void
 modulemd_hash_table_unref (void *table);
 
+gboolean
+modulemd_validate_nevra (const gchar *nevra);
+
 
 #define MODULEMD_REPLACE_SET(_dest, _set)                                     \
   do                                                                          \

--- a/modulemd/v2/modulemd-component-module.c
+++ b/modulemd/v2/modulemd-component-module.c
@@ -259,6 +259,7 @@ modulemd_component_module_emit_yaml (ModulemdComponentModule *self,
 ModulemdComponentModule *
 modulemd_component_module_parse_yaml (yaml_parser_t *parser,
                                       const gchar *name,
+                                      gboolean strict,
                                       GError **error)
 {
   MODULEMD_INIT_TRACE ();
@@ -352,8 +353,11 @@ modulemd_component_module_parse_yaml (yaml_parser_t *parser,
             }
           else
             {
-              MMD_YAML_ERROR_EVENT_EXIT (
-                error, event, "Unknown key in module component body");
+              SKIP_UNKNOWN (parser,
+                            NULL,
+                            "Unexpected key in module component body: %s",
+                            (const gchar *)event.data.scalar.value);
+              break;
             }
           break;
         default:

--- a/modulemd/v2/modulemd-component-rpm.c
+++ b/modulemd/v2/modulemd-component-rpm.c
@@ -428,6 +428,7 @@ modulemd_component_rpm_emit_yaml (ModulemdComponentRpm *self,
 ModulemdComponentRpm *
 modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
                                    const gchar *name,
+                                   gboolean strict,
                                    GError **error)
 {
   MODULEMD_INIT_TRACE ();
@@ -564,11 +565,11 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
             }
           else
             {
-              MMD_YAML_ERROR_EVENT_EXIT (
-                error,
-                event,
-                "Unknown key in rpm component body: %s",
-                (const gchar *)event.data.scalar.value);
+              SKIP_UNKNOWN (parser,
+                            NULL,
+                            "Unexpected key in rpm component body: %s",
+                            (const gchar *)event.data.scalar.value);
+              break;
             }
           break;
         default:

--- a/modulemd/v2/modulemd-defaults-v1.c
+++ b/modulemd/v2/modulemd-defaults-v1.c
@@ -611,13 +611,11 @@ modulemd_defaults_v1_parse_yaml (ModulemdSubdocumentInfo *subdoc,
       yaml_event_delete (&event);
     }
 
-  /* Make sure we have a real module name set */
-  if (g_str_equal (
-        modulemd_defaults_get_module_name (MODULEMD_DEFAULTS (defaults)),
-        DEFAULT_PLACEHOLDER))
+  if (!modulemd_defaults_validate (MODULEMD_DEFAULTS (defaults),
+                                   &nested_error))
     {
-      MMD_YAML_ERROR_EVENT_EXIT (
-        error, event, "Defaults did not specify a module name.");
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return NULL;
     }
 
   return g_steal_pointer (&defaults);

--- a/modulemd/v2/modulemd-defaults.c
+++ b/modulemd/v2/modulemd-defaults.c
@@ -151,6 +151,17 @@ modulemd_defaults_default_validate (ModulemdDefaults *self, GError **error)
       return FALSE;
     }
 
+  /* Make sure we have a real module name set */
+  if (g_str_equal (modulemd_defaults_get_module_name (self),
+                   DEFAULT_PLACEHOLDER))
+    {
+      g_set_error_literal (error,
+                           MODULEMD_ERROR,
+                           MODULEMD_ERROR_VALIDATE,
+                           "Defaults did not specify a module name.");
+      return FALSE;
+    }
+
   return TRUE;
 }
 

--- a/modulemd/v2/modulemd-dependencies.c
+++ b/modulemd/v2/modulemd-dependencies.c
@@ -396,12 +396,13 @@ modulemd_dependencies_parse_yaml_nested_set (yaml_parser_t *parser,
 }
 
 ModulemdDependencies *
-modulemd_dependencies_parse_yaml (yaml_parser_t *parser, GError **error)
+modulemd_dependencies_parse_yaml (yaml_parser_t *parser,
+                                  gboolean strict,
+                                  GError **error)
 {
   MODULEMD_INIT_TRACE ();
   MMD_INIT_YAML_EVENT (event);
   gboolean done = FALSE;
-  g_autofree gchar *value = NULL;
   g_autoptr (ModulemdDependencies) d = NULL;
   g_autoptr (GError) nested_error = NULL;
 
@@ -448,8 +449,11 @@ modulemd_dependencies_parse_yaml (yaml_parser_t *parser, GError **error)
             }
           else
             {
-              MMD_YAML_ERROR_EVENT_EXIT (
-                error, event, "Unknown key in dependencies body");
+              SKIP_UNKNOWN (parser,
+                            NULL,
+                            "Unexpected key in dependencies body: %s",
+                            (const gchar *)event.data.scalar.value);
+              break;
             }
           break;
 

--- a/modulemd/v2/modulemd-module-index.c
+++ b/modulemd/v2/modulemd-module-index.c
@@ -207,6 +207,7 @@ modulemd_module_index_update_from_parser (ModulemdModuleIndex *self,
                                           GError **error)
 {
   gboolean done = FALSE;
+  gboolean all_passed = TRUE;
   g_autoptr (ModulemdSubdocumentInfo) subdoc = NULL;
   MMD_INIT_YAML_EVENT (event);
 
@@ -228,6 +229,7 @@ modulemd_module_index_update_from_parser (ModulemdModuleIndex *self,
             {
               /* Add to failures and ignore */
               g_ptr_array_add (*failures, g_steal_pointer (&subdoc));
+              all_passed = FALSE;
             }
           else
             {
@@ -238,6 +240,7 @@ modulemd_module_index_update_from_parser (ModulemdModuleIndex *self,
                   g_clear_pointer (error, g_error_free);
                   /* Add to failures and ignore */
                   g_ptr_array_add (*failures, g_steal_pointer (&subdoc));
+                  all_passed = FALSE;
                 }
               g_clear_pointer (&subdoc, g_object_unref);
             }
@@ -254,7 +257,7 @@ modulemd_module_index_update_from_parser (ModulemdModuleIndex *self,
       yaml_event_delete (&event);
     }
 
-  return TRUE;
+  return all_passed;
 }
 
 

--- a/modulemd/v2/modulemd-module-stream-v1.c
+++ b/modulemd/v2/modulemd-module-stream-v1.c
@@ -891,6 +891,34 @@ modulemd_module_stream_v1_validate (ModulemdModuleStream *self, GError **error)
       return FALSE;
     }
 
+  /* Make sure that mandatory fields are present */
+  if (!modulemd_module_stream_v1_get_summary (v1_self, "C"))
+    {
+      g_set_error (error,
+                   MODULEMD_YAML_ERROR,
+                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
+                   "Summary is missing");
+      return FALSE;
+    }
+
+  if (!modulemd_module_stream_v1_get_description (v1_self, "C"))
+    {
+      g_set_error (error,
+                   MODULEMD_YAML_ERROR,
+                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
+                   "Description is missing");
+      return FALSE;
+    }
+
+  if (!g_hash_table_size (v1_self->module_licenses))
+    {
+      g_set_error (error,
+                   MODULEMD_YAML_ERROR,
+                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
+                   "Module license is missing");
+      return FALSE;
+    }
+
   /* Iterate through the artifacts and validate that they are in the proper
    * NEVRA format
    */
@@ -1474,31 +1502,10 @@ modulemd_module_stream_v1_parse_yaml (ModulemdSubdocumentInfo *subdoc,
     }
 
 
-  /* Make sure that mandatory fields are present */
-  if (!modulemd_module_stream_v1_get_summary (modulestream, "C"))
+  if (!modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (modulestream),
+                                        &nested_error))
     {
-      g_set_error (error,
-                   MODULEMD_YAML_ERROR,
-                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
-                   "Summary is missing");
-      return NULL;
-    }
-
-  if (!modulemd_module_stream_v1_get_description (modulestream, "C"))
-    {
-      g_set_error (error,
-                   MODULEMD_YAML_ERROR,
-                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
-                   "Description is missing");
-      return NULL;
-    }
-
-  if (!g_hash_table_size (modulestream->module_licenses))
-    {
-      g_set_error (error,
-                   MODULEMD_YAML_ERROR,
-                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
-                   "Module license is missing");
+      g_propagate_error (error, g_steal_pointer (&nested_error));
       return NULL;
     }
 

--- a/modulemd/v2/modulemd-module-stream-v2.c
+++ b/modulemd/v2/modulemd-module-stream-v2.c
@@ -767,6 +767,34 @@ modulemd_module_stream_v2_validate (ModulemdModuleStream *self, GError **error)
       return FALSE;
     }
 
+  /* Make sure that mandatory fields are present */
+  if (!modulemd_module_stream_v2_get_summary (v2_self, "C"))
+    {
+      g_set_error (error,
+                   MODULEMD_YAML_ERROR,
+                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
+                   "Summary is missing");
+      return FALSE;
+    }
+
+  if (!modulemd_module_stream_v2_get_description (v2_self, "C"))
+    {
+      g_set_error (error,
+                   MODULEMD_YAML_ERROR,
+                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
+                   "Description is missing");
+      return FALSE;
+    }
+
+  if (!g_hash_table_size (v2_self->module_licenses))
+    {
+      g_set_error (error,
+                   MODULEMD_YAML_ERROR,
+                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
+                   "Module license is missing");
+      return FALSE;
+    }
+
   /* Iterate through the artifacts and validate that they are in the proper
    * NEVRA format
    */
@@ -1333,31 +1361,10 @@ modulemd_module_stream_v2_parse_yaml (ModulemdSubdocumentInfo *subdoc,
     }
 
 
-  /* Make sure that mandatory fields are present */
-  if (!modulemd_module_stream_v2_get_summary (modulestream, "C"))
+  if (!modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (modulestream),
+                                        &nested_error))
     {
-      g_set_error (error,
-                   MODULEMD_YAML_ERROR,
-                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
-                   "Summary is missing");
-      return NULL;
-    }
-
-  if (!modulemd_module_stream_v2_get_description (modulestream, "C"))
-    {
-      g_set_error (error,
-                   MODULEMD_YAML_ERROR,
-                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
-                   "Description is missing");
-      return NULL;
-    }
-
-  if (!g_hash_table_size (modulestream->module_licenses))
-    {
-      g_set_error (error,
-                   MODULEMD_YAML_ERROR,
-                   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
-                   "Module license is missing");
+      g_propagate_error (error, g_steal_pointer (&nested_error));
       return NULL;
     }
 

--- a/modulemd/v2/modulemd-module-stream-v2.c
+++ b/modulemd/v2/modulemd-module-stream-v2.c
@@ -755,6 +755,8 @@ modulemd_module_stream_v2_validate (ModulemdModuleStream *self, GError **error)
   gpointer key, value;
   gchar *nevra = NULL;
   ModulemdModuleStreamV2 *v2_self = NULL;
+  ModulemdDependencies *deps = NULL;
+  g_autoptr (GError) nested_error = NULL;
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self), FALSE);
   v2_self = MODULEMD_MODULE_STREAM_V2 (self);
@@ -779,6 +781,20 @@ modulemd_module_stream_v2_validate (ModulemdModuleStream *self, GError **error)
                        MODULEMD_ERROR_VALIDATE,
                        "Artifact '%s' was not in valid N-E:V-R.A format.",
                        nevra);
+          return FALSE;
+        }
+    }
+
+  /* Iterate through the Dependencies and validate them */
+  for (guint i = 0; i < v2_self->dependencies->len; i++)
+    {
+      deps =
+        MODULEMD_DEPENDENCIES (g_ptr_array_index (v2_self->dependencies, i));
+      if (!modulemd_dependencies_validate (deps, &nested_error))
+        {
+          g_propagate_prefixed_error (error,
+                                      g_steal_pointer (&nested_error),
+                                      "Dependency failed to validate: ");
           return FALSE;
         }
     }

--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -531,8 +531,6 @@ modulemd_module_stream_default_validate (ModulemdModuleStream *self,
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self), FALSE);
 
   guint64 mdversion = modulemd_module_stream_get_mdversion (self);
-  ModulemdModuleStreamPrivate *priv =
-    modulemd_module_stream_get_instance_private (self);
 
   if (mdversion == 0)
     {
@@ -548,16 +546,6 @@ modulemd_module_stream_default_validate (ModulemdModuleStream *self,
                            MODULEMD_ERROR,
                            MODULEMD_ERROR_VALIDATE,
                            "Unknown metadata version.");
-      return FALSE;
-    }
-
-  if (!priv->module_name ||
-      g_str_equal (priv->module_name, MODULESTREAM_PLACEHOLDER))
-    {
-      g_set_error_literal (error,
-                           MODULEMD_ERROR,
-                           MODULEMD_ERROR_VALIDATE,
-                           "Module name is unset.");
       return FALSE;
     }
 
@@ -841,7 +829,7 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     "module-name",
     "Module Name",
     "The name of the module providing this stream.",
-    MODULESTREAM_PLACEHOLDER,
+    NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT_ONLY);
 
   properties[PROP_STREAM_NAME] = g_param_spec_string (

--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -75,11 +75,13 @@ static ModulemdModuleStream *
 modulemd_module_stream_read_yaml (yaml_parser_t *parser,
                                   const gchar *module_name,
                                   const gchar *module_stream,
+                                  gboolean strict,
                                   GError **error);
 
 
 ModulemdModuleStream *
 modulemd_module_stream_read_file (const gchar *path,
+                                  gboolean strict,
                                   const gchar *module_name,
                                   const gchar *module_stream,
                                   GError **error)
@@ -108,12 +110,13 @@ modulemd_module_stream_read_file (const gchar *path,
   yaml_parser_set_input_file (&parser, yaml_stream);
 
   return modulemd_module_stream_read_yaml (
-    &parser, module_name, module_stream, error);
+    &parser, module_name, module_stream, strict, error);
 }
 
 
 ModulemdModuleStream *
 modulemd_module_stream_read_string (const gchar *yaml_string,
+                                    gboolean strict,
                                     const gchar *module_name,
                                     const gchar *module_stream,
                                     GError **error)
@@ -127,12 +130,13 @@ modulemd_module_stream_read_string (const gchar *yaml_string,
     &parser, (const unsigned char *)yaml_string, strlen (yaml_string));
 
   return modulemd_module_stream_read_yaml (
-    &parser, module_name, module_stream, error);
+    &parser, module_name, module_stream, strict, error);
 }
 
 
 ModulemdModuleStream *
 modulemd_module_stream_read_stream (FILE *stream,
+                                    gboolean strict,
                                     const gchar *module_name,
                                     const gchar *module_stream,
                                     GError **error)
@@ -141,7 +145,7 @@ modulemd_module_stream_read_stream (FILE *stream,
   yaml_parser_set_input_file (&parser, stream);
 
   return modulemd_module_stream_read_yaml (
-    &parser, module_name, module_stream, error);
+    &parser, module_name, module_stream, strict, error);
 }
 
 
@@ -149,6 +153,7 @@ static ModulemdModuleStream *
 modulemd_module_stream_read_yaml (yaml_parser_t *parser,
                                   const gchar *module_name,
                                   const gchar *module_stream,
+                                  gboolean strict,
                                   GError **error)
 {
   MMD_INIT_YAML_EVENT (event);
@@ -221,7 +226,7 @@ modulemd_module_stream_read_yaml (yaml_parser_t *parser,
     {
     case MD_MODULESTREAM_VERSION_ONE:
       stream = MODULEMD_MODULE_STREAM (
-        modulemd_module_stream_v1_parse_yaml (subdoc, &nested_error));
+        modulemd_module_stream_v1_parse_yaml (subdoc, strict, &nested_error));
       if (!stream)
         {
           g_propagate_error (error, g_steal_pointer (&nested_error));
@@ -231,7 +236,7 @@ modulemd_module_stream_read_yaml (yaml_parser_t *parser,
 
     case MD_MODULESTREAM_VERSION_TWO:
       stream = MODULEMD_MODULE_STREAM (
-        modulemd_module_stream_v2_parse_yaml (subdoc, &nested_error));
+        modulemd_module_stream_v2_parse_yaml (subdoc, strict, &nested_error));
       if (!stream)
         {
           g_propagate_error (error, g_steal_pointer (&nested_error));

--- a/modulemd/v2/modulemd-profile.c
+++ b/modulemd/v2/modulemd-profile.c
@@ -222,6 +222,7 @@ modulemd_profile_init (ModulemdProfile *self)
 ModulemdProfile *
 modulemd_profile_parse_yaml (yaml_parser_t *parser,
                              const gchar *name,
+                             gboolean strict,
                              GError **error)
 {
   MODULEMD_INIT_TRACE ();
@@ -281,8 +282,11 @@ modulemd_profile_parse_yaml (yaml_parser_t *parser,
             }
           else
             {
-              MMD_YAML_ERROR_EVENT_EXIT (
-                error, event, "Unknown key in profile body");
+              SKIP_UNKNOWN (parser,
+                            FALSE,
+                            "Unexpected key in profile body: %s",
+                            (const gchar *)event.data.scalar.value);
+              break;
             }
           break;
 

--- a/modulemd/v2/modulemd-service-level.c
+++ b/modulemd/v2/modulemd-service-level.c
@@ -255,6 +255,7 @@ modulemd_service_level_init (ModulemdServiceLevel *self)
 ModulemdServiceLevel *
 modulemd_service_level_parse_yaml (yaml_parser_t *parser,
                                    const gchar *name,
+                                   gboolean strict,
                                    GError **error)
 {
   MODULEMD_INIT_TRACE ();
@@ -323,8 +324,10 @@ modulemd_service_level_parse_yaml (yaml_parser_t *parser,
           else
             {
               /* Unknown field in service level */
-              MMD_YAML_ERROR_EVENT_EXIT (
-                error, event, "Unknown key in service level body");
+              SKIP_UNKNOWN (parser,
+                            FALSE,
+                            "Unexpected key in service level body: %s",
+                            (const gchar *)event.data.scalar.value);
             }
           break;
 

--- a/modulemd/v2/modulemd-translation-entry.c
+++ b/modulemd/v2/modulemd-translation-entry.c
@@ -375,6 +375,7 @@ modulemd_translation_entry_parse_yaml_profiles (yaml_parser_t *parser,
 ModulemdTranslationEntry *
 modulemd_translation_entry_parse_yaml (yaml_parser_t *parser,
                                        const gchar *locale,
+                                       gboolean strict,
                                        GError **error)
 {
   MODULEMD_INIT_TRACE ();
@@ -458,8 +459,10 @@ modulemd_translation_entry_parse_yaml (yaml_parser_t *parser,
             }
           else
             {
-              MMD_YAML_ERROR_EVENT_EXIT (
-                error, event, "Unknown key in translation entry body");
+              SKIP_UNKNOWN (parser,
+                            NULL,
+                            "Unexpected key in translation entry body: %s",
+                            (const gchar *)event.data.scalar.value);
             }
           break;
 

--- a/modulemd/v2/tests/ModulemdTests/merger.py
+++ b/modulemd/v2/tests/ModulemdTests/merger.py
@@ -44,12 +44,12 @@ class TestModuleIndexMerger(TestBase):
         idx2 = Modulemd.ModuleIndex()
 
         res, failures = idx1.update_from_file(path.join(
-            self.source_root, "modulemd/v2/tests/test_data/long-valid.yaml"))
+            self.source_root, "modulemd/v2/tests/test_data/long-valid.yaml"), True)
         self.assertTrue(res)
         self.assertEqual(len(failures), 0)
 
         res, failures = idx2.update_from_file(path.join(
-            self.source_root, "modulemd/v2/tests/test_data/long-valid.yaml"))
+            self.source_root, "modulemd/v2/tests/test_data/long-valid.yaml"), True)
         self.assertTrue(res)
         self.assertEqual(len(failures), 0)
 
@@ -74,7 +74,7 @@ class TestModuleIndexMerger(TestBase):
         base_index.update_from_file(
             path.join(
                 self.source_root,
-                "modulemd/v2/tests/test_data/merging-base.yaml"))
+                "modulemd/v2/tests/test_data/merging-base.yaml"), True)
 
         # Baseline
         httpd_defaults = base_index.get_module('httpd').get_defaults()
@@ -111,7 +111,7 @@ class TestModuleIndexMerger(TestBase):
         override_index.update_from_file(
             path.join(
                 self.source_root,
-                "modulemd/v2/tests/test_data/overriding.yaml"))
+                "modulemd/v2/tests/test_data/overriding.yaml"), True)
 
         # Test that adding both of these at the same priority level fails
         # with a merge conflict.

--- a/modulemd/v2/tests/ModulemdTests/moduleindex.py
+++ b/modulemd/v2/tests/ModulemdTests/moduleindex.py
@@ -55,9 +55,9 @@ class TestModuleIndex(TestBase):
             self.assertTrue(res)
             self.assertListEqual(failures, [])
 
-        res, failures = idx.update_from_file(
-            path.join(self.source_root, "modulemd/v2/tests/test_data/te.yaml"))
-        self.assertTrue(res)
+        res, failures = idx.update_from_file(path.join(
+            self.source_root, "modulemd/v2/tests/test_data/te.yaml"))
+        self.assertFalse(res)
         self.assertEqual(len(failures), 1)
         self.assertIn(
             "No document type specified", str(

--- a/modulemd/v2/tests/ModulemdTests/moduleindex.py
+++ b/modulemd/v2/tests/ModulemdTests/moduleindex.py
@@ -42,7 +42,7 @@ class TestModuleIndex(TestBase):
         idx = ModuleIndex.new()
 
         with open(path.join(self.source_root, "spec.v1.yaml"), 'r') as v1:
-            res, failures = idx.update_from_string(v1.read())
+            res, failures = idx.update_from_string(v1.read(), True)
             self.assertTrue(res)
             self.assertListEqual(failures, [])
 
@@ -51,12 +51,12 @@ class TestModuleIndex(TestBase):
                 "translations/spec.v1.yaml",
                 "mod-defaults/spec.v1.yaml"]:
             res, failures = idx.update_from_file(
-                path.join(self.source_root, fname))
+                path.join(self.source_root, fname), True)
             self.assertTrue(res)
             self.assertListEqual(failures, [])
 
         res, failures = idx.update_from_file(path.join(
-            self.source_root, "modulemd/v2/tests/test_data/te.yaml"))
+            self.source_root, "modulemd/v2/tests/test_data/te.yaml"), True)
         self.assertFalse(res)
         self.assertEqual(len(failures), 1)
         self.assertIn(

--- a/modulemd/v2/tests/ModulemdTests/modulestream.py
+++ b/modulemd/v2/tests/ModulemdTests/modulestream.py
@@ -659,7 +659,7 @@ data:
         can_bool: TRUE
 ...
 """
-        stream = Modulemd.ModuleStream.read_string(yaml)
+        stream = Modulemd.ModuleStream.read_string(yaml, True)
 
         assert stream is not None
         assert stream.props.module_name == 'modulename'
@@ -756,12 +756,12 @@ data:
 ...
 """
 
-        stream = Modulemd.ModuleStream.read_string(trivial_yaml)
+        stream = Modulemd.ModuleStream.read_string(trivial_yaml, True)
         assert stream
 
         # Sanity check of spec.v2.yaml
         stream = Modulemd.ModuleStream.read_file(
-            "%s/spec.v2.yaml" % os.getenv('MESON_SOURCE_ROOT'))
+            "%s/spec.v2.yaml" % os.getenv('MESON_SOURCE_ROOT'), True)
         assert stream
 
     def test_v1_yaml(self):
@@ -885,7 +885,7 @@ data:
         can_bool: TRUE
 ...
 """
-            stream = Modulemd.ModuleStream.read_string(yaml)
+            stream = Modulemd.ModuleStream.read_string(yaml, True)
 
             assert stream is not None
             assert stream.props.module_name == 'modulename'
@@ -1000,12 +1000,12 @@ data:
 ...
 """
 
-            stream = Modulemd.ModuleStream.read_string(trivial_yaml)
+            stream = Modulemd.ModuleStream.read_string(trivial_yaml, True)
             assert stream
 
             # Sanity check of spec.v1.yaml
             stream = Modulemd.ModuleStream.read_file(
-                "%s/spec.v1.yaml" % os.getenv('MESON_SOURCE_ROOT'))
+                "%s/spec.v1.yaml" % os.getenv('MESON_SOURCE_ROOT'), True)
             assert stream
 
 

--- a/modulemd/v2/tests/test-modulemd-buildopts.c
+++ b/modulemd/v2/tests/test-modulemd-buildopts.c
@@ -218,7 +218,7 @@ buildopts_test_parse_yaml (BuildoptsFixture *fixture, gconstpointer user_data)
 
   parser_skip_document_start (&parser);
 
-  b = modulemd_buildopts_parse_yaml (&parser, &error);
+  b = modulemd_buildopts_parse_yaml (&parser, TRUE, &error);
   g_assert_nonnull (b);
   g_assert_true (MODULEMD_IS_BUILDOPTS (b));
   g_assert_cmpstr (modulemd_buildopts_get_rpm_macros (b),

--- a/modulemd/v2/tests/test-modulemd-component-module.c
+++ b/modulemd/v2/tests/test-modulemd-component-module.c
@@ -42,6 +42,7 @@ component_module_test_construct (ComponentModuleFixture *fixture,
 {
   g_autoptr (ModulemdComponentModule) m = NULL;
   ModulemdComponent *mc = NULL;
+  gint64 buildorder = 42;
 
   /* Test that the new() function works */
   m = modulemd_component_module_new ("testmodule");
@@ -63,22 +64,19 @@ component_module_test_construct (ComponentModuleFixture *fixture,
   g_clear_object (&m);
 
   /* Instantiate with some argument */
+  // clang-format off
   m = g_object_new (MODULEMD_TYPE_COMPONENT_MODULE,
-                    "buildorder",
-                    42,
-                    "name",
-                    "testmodule",
-                    "rationale",
-                    "Testing all the stuff",
-                    "ref",
-                    "someref",
-                    "repository",
-                    "somerepo",
+                    "buildorder", buildorder,
+                    "name", "testmodule",
+                    "rationale", "Testing all the stuff",
+                    "ref", "someref",
+                    "repository", "somerepo",
                     NULL);
+  // clang-format on
   g_assert_nonnull (m);
   g_assert_true (MODULEMD_IS_COMPONENT_MODULE (m));
   mc = MODULEMD_COMPONENT (m);
-  g_assert_cmpint (modulemd_component_get_buildorder (mc), ==, 42);
+  g_assert_cmpint (modulemd_component_get_buildorder (mc), ==, buildorder);
   g_assert_cmpstr (modulemd_component_get_name (mc), ==, "testmodule");
   g_assert_cmpstr (
     modulemd_component_get_rationale (mc), ==, "Testing all the stuff");

--- a/modulemd/v2/tests/test-modulemd-component-module.c
+++ b/modulemd/v2/tests/test-modulemd-component-module.c
@@ -234,7 +234,8 @@ component_module_test_parse_yaml (ComponentModuleFixture *fixture,
   g_assert_cmpint (event.type, ==, YAML_SCALAR_EVENT);
   yaml_event_delete (&event);
 
-  m = modulemd_component_module_parse_yaml (&parser, "includedmodule", &error);
+  m = modulemd_component_module_parse_yaml (
+    &parser, "includedmodule", TRUE, &error);
   g_assert_nonnull (m);
   g_assert_true (MODULEMD_IS_COMPONENT_MODULE (m));
   g_assert_cmpstr (modulemd_component_get_name (MODULEMD_COMPONENT (m)),

--- a/modulemd/v2/tests/test-modulemd-component-rpm.c
+++ b/modulemd/v2/tests/test-modulemd-component-rpm.c
@@ -244,7 +244,7 @@ component_rpm_test_parse_yaml (ComponentRpmFixture *fixture,
   g_assert_cmpint (event.type, ==, YAML_SCALAR_EVENT);
   yaml_event_delete (&event);
 
-  r = modulemd_component_rpm_parse_yaml (&parser, "bar", &error);
+  r = modulemd_component_rpm_parse_yaml (&parser, "bar", TRUE, &error);
   g_assert_nonnull (r);
   g_assert_true (MODULEMD_IS_COMPONENT_RPM (r));
   g_assert_cmpstr (

--- a/modulemd/v2/tests/test-modulemd-component-rpm.c
+++ b/modulemd/v2/tests/test-modulemd-component-rpm.c
@@ -35,6 +35,7 @@ component_rpm_test_construct (ComponentRpmFixture *fixture,
 {
   g_autoptr (ModulemdComponentRpm) r = NULL;
   ModulemdComponent *mc = NULL;
+  gint64 buildorder = 42;
 
   /* Test that the new() function works */
   r = modulemd_component_rpm_new ("testcomponent");
@@ -57,24 +58,20 @@ component_rpm_test_construct (ComponentRpmFixture *fixture,
   g_clear_object (&r);
 
   /* Instantiate with some argument */
+  // clang-format off
   r = g_object_new (MODULEMD_TYPE_COMPONENT_RPM,
-                    "buildorder",
-                    42,
-                    "name",
-                    "testmodule",
-                    "rationale",
-                    "Testing all the stuff",
-                    "ref",
-                    "someref",
-                    "repository",
-                    "somerepo",
-                    "cache",
-                    "somecache",
+                    "buildorder", buildorder,
+                    "name", "testmodule",
+                    "rationale", "Testing all the stuff",
+                    "ref", "someref",
+                    "repository", "somerepo",
+                    "cache", "somecache",
                     NULL);
+  // clang-format on
   g_assert_nonnull (r);
   g_assert_true (MODULEMD_IS_COMPONENT_RPM (r));
   mc = MODULEMD_COMPONENT (r);
-  g_assert_cmpint (modulemd_component_get_buildorder (mc), ==, 42);
+  g_assert_cmpint (modulemd_component_get_buildorder (mc), ==, buildorder);
   g_assert_cmpstr (modulemd_component_get_name (mc), ==, "testmodule");
   g_assert_cmpstr (
     modulemd_component_get_rationale (mc), ==, "Testing all the stuff");

--- a/modulemd/v2/tests/test-modulemd-defaults-v1.c
+++ b/modulemd/v2/tests/test-modulemd-defaults-v1.c
@@ -330,7 +330,7 @@ defaults_test_parse_yaml (CommonMmdTestFixture *fixture,
     "    stream: x.y\n      profiles:\n        'x.y': []\n");
 
   /* Parse the data section and validate the content */
-  defaults = modulemd_defaults_v1_parse_yaml (subdoc, &error);
+  defaults = modulemd_defaults_v1_parse_yaml (subdoc, TRUE, &error);
   g_assert_nonnull (defaults);
   g_assert_null (error);
 

--- a/modulemd/v2/tests/test-modulemd-dependencies.c
+++ b/modulemd/v2/tests/test-modulemd-dependencies.c
@@ -244,7 +244,7 @@ dependencies_test_parse_yaml (DependenciesFixture *fixture,
 
   parser_skip_headers (&parser);
 
-  d = modulemd_dependencies_parse_yaml (&parser, &error);
+  d = modulemd_dependencies_parse_yaml (&parser, TRUE, &error);
   g_assert_nonnull (d);
   g_assert_true (MODULEMD_IS_DEPENDENCIES (d));
 
@@ -295,7 +295,7 @@ dependencies_test_parse_bad_yaml (DependenciesFixture *fixture,
 
   parser_skip_headers (&parser);
 
-  d = modulemd_dependencies_parse_yaml (&parser, &error);
+  d = modulemd_dependencies_parse_yaml (&parser, TRUE, &error);
   g_assert_nonnull (d);
   g_assert_true (MODULEMD_IS_DEPENDENCIES (d));
 

--- a/modulemd/v2/tests/test-modulemd-merger.c
+++ b/modulemd/v2/tests/test-modulemd-merger.c
@@ -60,7 +60,7 @@ merger_test_deduplicate (CommonMmdTestFixture *fixture,
   g_assert_nonnull (yaml_path);
 
   g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, &failures, &error));
+    index, yaml_path, TRUE, &failures, &error));
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&failures, g_ptr_array_unref);
 
@@ -75,7 +75,7 @@ merger_test_deduplicate (CommonMmdTestFixture *fixture,
   g_assert_nonnull (yaml_path);
 
   g_assert_true (modulemd_module_index_update_from_file (
-    index2, yaml_path, &failures, &error));
+    index2, yaml_path, TRUE, &failures, &error));
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&failures, g_ptr_array_unref);
 

--- a/modulemd/v2/tests/test-modulemd-moduleindex.c
+++ b/modulemd/v2/tests/test-modulemd-moduleindex.c
@@ -23,6 +23,7 @@
 #include "modulemd-module-stream-v2.h"
 #include "private/glib-extensions.h"
 #include "private/modulemd-module-private.h"
+#include "private/modulemd-util.h"
 #include "private/modulemd-yaml.h"
 #include "private/test-utils.h"
 
@@ -180,7 +181,7 @@ module_index_test_read (ModuleIndexFixture *fixture, gconstpointer user_data)
   yaml_path =
     g_strdup_printf ("%s/modulemd/v2/tests/test_data/broken_stream.yaml",
                      g_getenv ("MESON_SOURCE_ROOT"));
-  g_assert_true (modulemd_module_index_update_from_file (
+  g_assert_false (modulemd_module_index_update_from_file (
     index, yaml_path, &failures, &error));
   g_assert_no_error (error);
   g_assert_cmpint (failures->len, ==, 1);
@@ -227,7 +228,7 @@ module_index_test_read (ModuleIndexFixture *fixture, gconstpointer user_data)
    */
   yaml_path = g_strdup_printf ("%s/modulemd/v2/tests/test_data/te.yaml",
                                g_getenv ("MESON_SOURCE_ROOT"));
-  g_assert_true (modulemd_module_index_update_from_file (
+  g_assert_false (modulemd_module_index_update_from_file (
     index, yaml_path, &failures, &error));
   g_assert_no_error (error);
   g_assert_cmpint (failures->len, ==, 1);

--- a/modulemd/v2/tests/test-modulemd-modulestream.c
+++ b/modulemd/v2/tests/test-modulemd-modulestream.c
@@ -179,7 +179,7 @@ module_stream_v1_test_parse_dump (ModuleStreamFixture *fixture,
   g_assert_cmpint (modulemd_subdocument_info_get_mdversion (subdoc), ==, 1);
   g_assert_nonnull (modulemd_subdocument_info_get_yaml (subdoc));
 
-  stream = modulemd_module_stream_v1_parse_yaml (subdoc, &error);
+  stream = modulemd_module_stream_v1_parse_yaml (subdoc, TRUE, &error);
   g_assert_no_error (error);
   g_assert_nonnull (stream);
 
@@ -279,7 +279,7 @@ module_stream_v2_test_parse_dump (ModuleStreamFixture *fixture,
   g_assert_cmpint (modulemd_subdocument_info_get_mdversion (subdoc), ==, 2);
   g_assert_nonnull (modulemd_subdocument_info_get_yaml (subdoc));
 
-  stream = modulemd_module_stream_v2_parse_yaml (subdoc, &error);
+  stream = modulemd_module_stream_v2_parse_yaml (subdoc, TRUE, &error);
   g_assert_no_error (error);
   g_assert_nonnull (stream);
 

--- a/modulemd/v2/tests/test-modulemd-profile.c
+++ b/modulemd/v2/tests/test-modulemd-profile.c
@@ -271,7 +271,7 @@ profile_test_parse_yaml (ProfileFixture *fixture, gconstpointer user_data)
   g_assert_nonnull (name);
   g_assert_cmpstr (name, ==, "default");
 
-  p = modulemd_profile_parse_yaml (&parser, name, &error);
+  p = modulemd_profile_parse_yaml (&parser, name, TRUE, &error);
   g_assert_nonnull (p);
   g_assert_true (MODULEMD_IS_PROFILE (p));
   g_assert_cmpstr (modulemd_profile_get_name (p), ==, "default");

--- a/modulemd/v2/tests/test-modulemd-service-level.c
+++ b/modulemd/v2/tests/test-modulemd-service-level.c
@@ -172,7 +172,6 @@ service_level_test_get_set_eol (ServiceLevelFixture *fixture,
   g_autoptr (ModulemdServiceLevel) sl = NULL;
   g_autoptr (GDate) eol = NULL;
   GDate *returned_eol = NULL;
-  g_autoptr (GDate) copied_eol = NULL;
   g_autofree gchar *eol_string = NULL;
 
 
@@ -270,7 +269,7 @@ service_level_test_parse_yaml (ServiceLevelFixture *fixture,
   g_assert_nonnull (name);
   g_assert_cmpstr (name, ==, "sl_name");
 
-  sl = modulemd_service_level_parse_yaml (&parser, name, &error);
+  sl = modulemd_service_level_parse_yaml (&parser, name, TRUE, &error);
   g_assert_nonnull (sl);
   g_assert_true (MODULEMD_IS_SERVICE_LEVEL (sl));
   g_assert_cmpstr (modulemd_service_level_get_name (sl), ==, "sl_name");

--- a/modulemd/v2/tests/test-modulemd-translation-entry.c
+++ b/modulemd/v2/tests/test-modulemd-translation-entry.c
@@ -503,7 +503,7 @@ translation_entry_test_parse_yaml (TranslationEntryFixture *fixture,
   /* Advance the parser past STREAM_START and DOCUMENT_START */
   parser_skip_document_start (&parser);
 
-  te = modulemd_translation_entry_parse_yaml (&parser, "en_GB", &error);
+  te = modulemd_translation_entry_parse_yaml (&parser, "en_GB", TRUE, &error);
   g_assert_nonnull (te);
   g_assert_true (MODULEMD_IS_TRANSLATION_ENTRY (te));
   g_assert_cmpstr (modulemd_translation_entry_get_locale (te), ==, "en_GB");

--- a/modulemd/v2/tests/test-modulemd-translation.c
+++ b/modulemd/v2/tests/test-modulemd-translation.c
@@ -44,6 +44,8 @@ translation_test_construct (TranslationFixture *fixture,
 {
   g_autoptr (ModulemdTranslation) t = NULL;
   g_auto (GStrv) locales;
+  guint64 translation_version = 1;
+  guint64 modified = 3;
 
   /* Test that the new() function works */
   t = modulemd_translation_new (1, "testmodule", "teststream", 2);
@@ -60,14 +62,13 @@ translation_test_construct (TranslationFixture *fixture,
   g_clear_object (&t);
 
   /* Test that object_new works */
+  // clang-format off
   t = g_object_new (MODULEMD_TYPE_TRANSLATION,
-                    "version",
-                    1,
-                    "module_name",
-                    "testmod",
-                    "module_stream",
-                    "teststr",
+                    "version", translation_version,
+                    "module_name", "testmod",
+                    "module_stream", "teststr",
                     NULL);
+  //clang-format on
   g_assert_nonnull (t);
   g_assert_true (MODULEMD_IS_TRANSLATION (t));
   g_assert_cmpint (modulemd_translation_get_version (t), ==, 1);
@@ -77,49 +78,55 @@ translation_test_construct (TranslationFixture *fixture,
   g_clear_object (&t);
 
   /* Test that object_new works with modified */
+  // clang-format off
   t = g_object_new (MODULEMD_TYPE_TRANSLATION,
-                    "version",
-                    1,
-                    "module_name",
-                    "testmod",
-                    "module_stream",
-                    "teststr",
-                    "modified",
-                    3,
+                    "version", translation_version,
+                    "module_name", "testmod",
+                    "module_stream", "teststr",
+                    "modified", modified,
                     NULL);
+  // clang-format on
   g_assert_nonnull (t);
   g_assert_true (MODULEMD_IS_TRANSLATION (t));
-  g_assert_cmpint (modulemd_translation_get_version (t), ==, 1);
+  g_assert_cmpint (
+    modulemd_translation_get_version (t), ==, translation_version);
   g_assert_cmpstr (modulemd_translation_get_module_name (t), ==, "testmod");
   g_assert_cmpstr (modulemd_translation_get_module_stream (t), ==, "teststr");
-  g_assert_cmpint (modulemd_translation_get_modified (t), ==, 3);
+  g_assert_cmpint (modulemd_translation_get_modified (t), ==, modified);
   g_clear_object (&t);
 
   /* Test that object_new does not work without a version */
   signaled = FALSE;
   signal (SIGTRAP, sigtrap_handler);
+  // clang-format off
   t = g_object_new (MODULEMD_TYPE_TRANSLATION,
-                    "module_name",
-                    "testmod",
-                    "module_stream",
-                    "teststr",
+                    "module_name", "testmod",
+                    "module_stream", "teststr",
                     NULL);
+  // clang-format on
   g_assert_true (signaled);
   g_clear_object (&t);
 
   /* Test that object_new does not work without a name */
   signaled = FALSE;
   signal (SIGTRAP, sigtrap_handler);
-  t = g_object_new (
-    MODULEMD_TYPE_TRANSLATION, "version", 1, "module_stream", "teststr", NULL);
+  // clang-format off
+  t = g_object_new (MODULEMD_TYPE_TRANSLATION,
+                    "version", translation_version,
+                    "module_stream", "teststr", NULL);
+  // clang-format on
   g_assert_true (signaled);
   g_clear_object (&t);
 
   /* Test that object_new does not work without a stream */
   signaled = FALSE;
   signal (SIGTRAP, sigtrap_handler);
-  t = g_object_new (
-    MODULEMD_TYPE_TRANSLATION, "version", 1, "module_name", "testmod", NULL);
+  // clang-format off
+  t = g_object_new (MODULEMD_TYPE_TRANSLATION,
+                    "version", translation_version,
+                    "module_name", "testmod",
+                    NULL);
+  // clang-format on
   g_assert_true (signaled);
   g_clear_object (&t);
 }

--- a/modulemd/v2/tests/test-modulemd-translation.c
+++ b/modulemd/v2/tests/test-modulemd-translation.c
@@ -281,7 +281,7 @@ translation_test_parse_yaml (TranslationFixture *fixture,
   g_assert_cmpint (modulemd_subdocument_info_get_mdversion (subdoc), ==, 1);
   g_assert_nonnull (modulemd_subdocument_info_get_yaml (subdoc));
 
-  t = modulemd_translation_parse_yaml (subdoc, &error);
+  t = modulemd_translation_parse_yaml (subdoc, TRUE, &error);
   g_assert_no_error (error);
   g_assert_null (error);
   g_assert_nonnull (t);

--- a/modulemd/v2/tests/test_data/good-v2-extra-keys.yaml
+++ b/modulemd/v2/tests/test_data/good-v2-extra-keys.yaml
@@ -1,0 +1,324 @@
+---
+# Document type identifier
+document: modulemd
+# Module metadata format version
+version: 2
+data:
+
+    # An extra key that should be ignored
+    unknown_key: foo
+    # Another unknown key with contents
+    unknown_map:
+        stuff: [ a, b ]
+        junk: [ b, c ]
+        morestuff:
+            yay: [ d, e ]
+    unknown_sequence:
+        - foo
+        - bar
+
+    name: foo
+    stream: stream-name
+    version: 20160927144203
+    context: c0ffee43
+    arch: x86_64
+    summary: An example module
+    description: >-
+        A module for the demonstration of the metadata format. Also,
+        the obligatory lorem ipsum dolor sit amet goes right here.
+    servicelevels:
+        rawhide:
+            eol: 2077-10-23
+        stable_api:
+            eol: 2077-10-23
+        bug_fixes:
+            eol: 2077-10-23
+        security_fixes:
+            eol: 2077-10-23
+    license:
+        module:
+            - MIT
+        content:
+            - Beerware
+            - GPLv2+
+            - zlib
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
+    xmd:
+        some_key: some_data
+        some_list:
+            - a
+            - b
+        some_dict:
+            a: alpha
+            b: beta
+            some_other_list:
+                - c
+                - d
+            some_other_dict:
+                another_key: more_data
+                yet_another_key:
+                    - this
+                    - is
+                    - getting
+                    - silly
+        empty_dict: {}
+        empty_list: []
+    dependencies:
+        - buildrequires:
+              platform: [-f27, -f28, -epel7]
+          requires:
+              platform: [-f27, -f28, -epel7]
+        - buildrequires:
+              platform: [f27]
+              buildtools: [v1, v2]
+              compatible: [v3]
+          requires:
+              platform: [f27]
+              compatible: [v3, v4]
+        - buildrequires:
+              platform: [f28]
+          requires:
+              platform: [f28]
+              runtime: [a, b]
+        - buildrequires:
+              platform: [epel7]
+              extras: []
+              moreextras: [foo, bar]
+          requires:
+              platform: [epel7]
+              extras: []
+              moreextras: [foo, bar]
+
+          unknown_key: foo
+          unknown_map:
+              stuff: [ a, b ]
+              junk: [ b, c ]
+              morestuff:
+                  yay: [ d, e ]
+          unknown_sequence:
+          - foo
+          - bar
+
+    references:
+        community: http://www.example.com/
+        documentation: http://www.example.com/
+        tracker: http://www.example.com/
+
+        # An extra key that should be ignored
+        unknown_key: foo
+
+    profiles:
+        default:
+            rpms:
+                - bar
+                - bar-extras
+                - baz
+
+            unknown_key: foo
+            unknown_map:
+                stuff: [ a, b ]
+                junk: [ b, c ]
+                morestuff:
+                    yay: [ d, e ]
+            unknown_sequence:
+            - foo
+            - bar
+        container:
+            rpms:
+                - bar
+                - bar-devel
+        minimal:
+            description: Minimal profile installing only the bar package.
+            rpms:
+                - bar
+        buildroot:
+            rpms:
+                - bar-devel
+        srpm-buildroot:
+            rpms:
+                - bar-extras
+        unusual:
+            rpms: []
+        moreunusual: {}
+    api:
+        rpms:
+            - bar
+            - bar-extras
+            - bar-devel
+            - baz
+            - xxx
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
+    filter:
+        rpms:
+            - baz-nonfoo
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
+
+    buildopts:
+        rpms:
+            macros: |
+                %demomacro 1
+                %demomacro2 %{demomacro}23
+
+            unknown_key: foo
+            unknown_map:
+                stuff: [ a, b ]
+                junk: [ b, c ]
+                morestuff:
+                    yay: [ d, e ]
+            unknown_sequence:
+            - foo
+            - bar
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
+
+    components:
+        rpms:
+            bar:
+                rationale: We need this to demonstrate stuff.
+                repository: https://pagure.io/bar.git
+                cache: https://example.com/cache
+                ref: 26ca0c0
+            baz:
+                rationale: This one is here to demonstrate other stuff.
+            xxx:
+                rationale: xxx demonstrates arches and multilib.
+                arches: [ i686, x86_64 ]
+                multilib: [ x86_64 ]
+            xyz:
+                rationale: xyz is a bundled dependency of xxx.
+                buildorder: 10
+
+                unknown_key: foo
+                unknown_map:
+                    stuff: [ a, b ]
+                    junk: [ b, c ]
+                    morestuff:
+                        yay: [ d, e ]
+                unknown_sequence:
+                - foo
+                - bar
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
+
+        modules:
+            includedmodule:
+                rationale: Included in the stack, just because.
+                repository: https://pagure.io/includedmodule.git
+                ref: somecoolbranchname
+                buildorder: 100
+
+                unknown_key: foo
+                unknown_map:
+                    stuff: [ a, b ]
+                    junk: [ b, c ]
+                    morestuff:
+                        yay: [ d, e ]
+                unknown_sequence:
+                - foo
+                - bar
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+            unknown_sequence:
+            - foo
+            - bar
+
+    artifacts:
+        rpms:
+            - bar-0:1.23-1.module_deadbeef.x86_64
+            - bar-devel-0:1.23-1.module_deadbeef.x86_64
+            - bar-extras-0:1.23-1.module_deadbeef.x86_64
+            - baz-0:42-42.module_deadbeef.x86_64
+            - xxx-0:1-1.module_deadbeef.x86_64
+            - xxx-0:1-1.module_deadbeef.i686
+            - xyz-0:1-1.module_deadbeef.x86_64
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+            unknown_sequence:
+            - foo
+            - bar
+...
+---
+document: modulemd-translations
+version: 1
+unknown: foo
+data:
+  module: nodejs
+  stream: 8
+  modified: 1
+  unknown: blah
+...
+---
+document: modulemd-defaults
+version: 1
+unknown:
+  - a
+  - b
+data:
+  module: nodejs
+  unknown:
+    a: b
+    c: d
+  profiles:
+    6: [default]
+    8: [default]
+    9: [default]
+  intents:
+    server:
+      stream: 8
+      unknown: [a, b]
+      profiles:
+        6: [server]
+        8: [server]
+...

--- a/modulemd/v2/tests/test_data/mismatched-deps.yaml
+++ b/modulemd/v2/tests/test_data/mismatched-deps.yaml
@@ -1,0 +1,6 @@
+---
+buildrequires:
+    platform: [-f27, -f28, epel7]
+requires:
+    platform: [-f27, -f28, -epel7]
+...

--- a/test_data/good-v2-extra-keys.yaml
+++ b/test_data/good-v2-extra-keys.yaml
@@ -1,0 +1,290 @@
+---
+# Document type identifier
+document: modulemd
+# Module metadata format version
+version: 2
+data:
+
+    # An extra key that should be ignored
+    unknown_key: foo
+    # Another unknown key with contents
+    unknown_map:
+        stuff: [ a, b ]
+        junk: [ b, c ]
+        morestuff:
+            yay: [ d, e ]
+    unknown_sequence:
+        - foo
+        - bar
+
+    name: foo
+    stream: stream-name
+    version: 20160927144203
+    context: c0ffee43
+    arch: x86_64
+    summary: An example module
+    description: >-
+        A module for the demonstration of the metadata format. Also,
+        the obligatory lorem ipsum dolor sit amet goes right here.
+    servicelevels:
+        rawhide:
+            eol: 2077-10-23
+        stable_api:
+            eol: 2077-10-23
+        bug_fixes:
+            eol: 2077-10-23
+        security_fixes:
+            eol: 2077-10-23
+    license:
+        module:
+            - MIT
+        content:
+            - Beerware
+            - GPLv2+
+            - zlib
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
+    xmd:
+        some_key: some_data
+        some_list:
+            - a
+            - b
+        some_dict:
+            a: alpha
+            b: beta
+            some_other_list:
+                - c
+                - d
+            some_other_dict:
+                another_key: more_data
+                yet_another_key:
+                    - this
+                    - is
+                    - getting
+                    - silly
+        empty_dict: {}
+        empty_list: []
+    dependencies:
+        - buildrequires:
+              platform: [-f27, -f28, -epel7]
+          requires:
+              platform: [-f27, -f28, -epel7]
+        - buildrequires:
+              platform: [f27]
+              buildtools: [v1, v2]
+              compatible: [v3]
+          requires:
+              platform: [f27]
+              compatible: [v3, v4]
+        - buildrequires:
+              platform: [f28]
+          requires:
+              platform: [f28]
+              runtime: [a, b]
+        - buildrequires:
+              platform: [epel7]
+              extras: []
+              moreextras: [foo, bar]
+          requires:
+              platform: [epel7]
+              extras: []
+              moreextras: [foo, bar]
+
+          unknown_key: foo
+          unknown_map:
+              stuff: [ a, b ]
+              junk: [ b, c ]
+              morestuff:
+                  yay: [ d, e ]
+          unknown_sequence:
+          - foo
+          - bar
+
+    references:
+        community: http://www.example.com/
+        documentation: http://www.example.com/
+        tracker: http://www.example.com/
+
+        # An extra key that should be ignored
+        unknown_key: foo
+
+    profiles:
+        default:
+            rpms:
+                - bar
+                - bar-extras
+                - baz
+
+            unknown_key: foo
+            unknown_map:
+                stuff: [ a, b ]
+                junk: [ b, c ]
+                morestuff:
+                    yay: [ d, e ]
+            unknown_sequence:
+            - foo
+            - bar
+        container:
+            rpms:
+                - bar
+                - bar-devel
+        minimal:
+            description: Minimal profile installing only the bar package.
+            rpms:
+                - bar
+        buildroot:
+            rpms:
+                - bar-devel
+        srpm-buildroot:
+            rpms:
+                - bar-extras
+        unusual:
+            rpms: []
+        moreunusual: {}
+    api:
+        rpms:
+            - bar
+            - bar-extras
+            - bar-devel
+            - baz
+            - xxx
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
+    filter:
+        rpms:
+            - baz-nonfoo
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
+
+    buildopts:
+        rpms:
+            macros: |
+                %demomacro 1
+                %demomacro2 %{demomacro}23
+
+            unknown_key: foo
+            unknown_map:
+                stuff: [ a, b ]
+                junk: [ b, c ]
+                morestuff:
+                    yay: [ d, e ]
+            unknown_sequence:
+            - foo
+            - bar
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
+
+    components:
+        rpms:
+            bar:
+                rationale: We need this to demonstrate stuff.
+                repository: https://pagure.io/bar.git
+                cache: https://example.com/cache
+                ref: 26ca0c0
+            baz:
+                rationale: This one is here to demonstrate other stuff.
+            xxx:
+                rationale: xxx demonstrates arches and multilib.
+                arches: [ i686, x86_64 ]
+                multilib: [ x86_64 ]
+            xyz:
+                rationale: xyz is a bundled dependency of xxx.
+                buildorder: 10
+
+                unknown_key: foo
+                unknown_map:
+                    stuff: [ a, b ]
+                    junk: [ b, c ]
+                    morestuff:
+                        yay: [ d, e ]
+                unknown_sequence:
+                - foo
+                - bar
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
+
+        modules:
+            includedmodule:
+                rationale: Included in the stack, just because.
+                repository: https://pagure.io/includedmodule.git
+                ref: somecoolbranchname
+                buildorder: 100
+
+                unknown_key: foo
+                unknown_map:
+                    stuff: [ a, b ]
+                    junk: [ b, c ]
+                    morestuff:
+                        yay: [ d, e ]
+                unknown_sequence:
+                - foo
+                - bar
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+            unknown_sequence:
+            - foo
+            - bar
+
+    artifacts:
+        rpms:
+            - bar-0:1.23-1.module_deadbeef.x86_64
+            - bar-devel-0:1.23-1.module_deadbeef.x86_64
+            - bar-extras-0:1.23-1.module_deadbeef.x86_64
+            - baz-0:42-42.module_deadbeef.x86_64
+            - xxx-0:1-1.module_deadbeef.x86_64
+            - xxx-0:1-1.module_deadbeef.i686
+            - xyz-0:1-1.module_deadbeef.x86_64
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+            unknown_sequence:
+            - foo
+            - bar


### PR DESCRIPTION
In order to be more forward-compatible, libmodulemd 1.x will ignore
unexpected keys instead of treating them as an error. A companion
patch to 2.x will be forthcoming that will make the strictness an
option to the parsing routines.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>