### PR TITLE
Skip coverity when it's broken

### DIFF
--- a/.travis/Dockerfile.tmpl
+++ b/.travis/Dockerfile.tmpl
@@ -4,8 +4,8 @@ MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
 ARG TARBALL
 
-RUN  echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca- && curl -s https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh -o /usr/bin/travisci_build_coverity_scan.sh && chmod a+x /usr/bin/travisci_build_coverity_scan.sh
-
 ADD $TARBALL /builddir/
+
+RUN  /builddir/.travis/coverity_prep.sh
 
 ENTRYPOINT /builddir/.travis/travis-tasks.sh

--- a/.travis/coverity_prep.sh
+++ b/.travis/coverity_prep.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+
+curl -s https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh -o /usr/bin/travisci_build_coverity_scan.sh
+
+if [ "$(file /usr/bin/travisci_build_coverity_scan.sh)" == "text/x-shellscript" ]; then
+    chmod a+x /usr/bin/travisci_build_coverity_scan.sh
+else
+    echo "Warning: Coverity not detected!"
+    # Disable the scanning tool
+    ln -sf /usr/bin/true /usr/bin/travisci_build_coverity_scan.sh
+fi


### PR DESCRIPTION
Coverity scans have been failing lately due to scan.coverity.com
issues. If we can't retrieve the scanning script, log a warning and
proceed with the remaining tests.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>