### PR TITLE
Include modified value when copying Defaults objects

### DIFF
--- a/modulemd/v2/modulemd-defaults.c
+++ b/modulemd/v2/modulemd-defaults.c
@@ -93,10 +93,14 @@ modulemd_defaults_copy (ModulemdDefaults *self)
 static ModulemdDefaults *
 modulemd_defaults_default_copy (ModulemdDefaults *self)
 {
+  g_autoptr (ModulemdDefaults) copy = NULL;
   g_return_val_if_fail (MODULEMD_IS_DEFAULTS (self), NULL);
 
-  return modulemd_defaults_new (modulemd_defaults_get_mdversion (self),
+  copy = modulemd_defaults_new (modulemd_defaults_get_mdversion (self),
                                 modulemd_defaults_get_module_name (self));
+  modulemd_defaults_set_modified (copy, modulemd_defaults_get_modified (self));
+
+  return g_steal_pointer (&copy);
 }
 
 
@@ -216,7 +220,6 @@ modulemd_defaults_set_modified (ModulemdDefaults *self, guint64 modified)
 
   ModulemdDefaultsPrivate *priv =
     modulemd_defaults_get_instance_private (self);
-
   priv->modified = modified;
 }
 

--- a/modulemd/v2/tests/ModulemdTests/defaults.py
+++ b/modulemd/v2/tests/ModulemdTests/defaults.py
@@ -12,7 +12,9 @@
 # For more information on free software, see
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
+import os
 import sys
+
 try:
     import unittest
     import gi
@@ -93,6 +95,29 @@ class TestDefaults(TestBase):
         # Ensure we cannot set the module_name
         with self.expect_signal():
             defs.props.module_name = None
+
+    def test_modified(self):
+        defs = Modulemd.Defaults.new(
+            Modulemd.DefaultsVersionEnum.LATEST, 'foo')
+        self.assertIsNotNone(defs)
+
+        self.assertEqual(defs.get_modified(), 0)
+
+        defs.set_modified(201901110830)
+
+        self.assertEqual(defs.get_modified(), 201901110830)
+
+        # Load a defaults object into an Index
+        index = Modulemd.ModuleIndex.new()
+        index.update_from_file("%s/mod-defaults/spec.v1.yaml" % (
+            os.getenv('MESON_SOURCE_ROOT')), True)
+        module_names = index.get_module_names()
+        self.assertEqual(len(module_names), 1)
+
+        defs = index.get_module(index.get_module_names()[0]).get_defaults()
+        self.assertIsNotNone(defs)
+
+        self.assertEqual(defs.get_modified(), 201812071200)
 
     def test_validate(self):
         defs = Modulemd.Defaults.new(


### PR DESCRIPTION
The symptom of this was that any defaults object read from a YAML
stream would end up stored in the ModuleIndex with the a zero for
the modified value.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>