### PR TITLE
Don't fail merges when default streams differ

### DIFF
--- a/modulemd/v1/include/modulemd-1.0/private/modulemd-private.h
+++ b/modulemd/v1/include/modulemd-1.0/private/modulemd-private.h
@@ -26,6 +26,8 @@ enum
 
 #define MD_VERSION_LATEST MD_VERSION_2
 
+#define DEFAULT_MERGE_CONFLICT "__merge_conflict__"
+
 ModulemdModule *
 modulemd_module_new_from_modulestream (ModulemdModuleStream *stream);
 

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index-merger.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index-merger.h
@@ -71,8 +71,8 @@ G_BEGIN_DECLS
  *     it.
  *   - If either repository specifies a default stream for the module and the
  *     other does not, use the one specified.
- *   - If both repositories specify different streams, this is an unresolvable
- *     merge conflict and the merge resolution will fail and report an error.
+ *   - If both repositories specify different default streams, the merge will
+ *     unset the default stream and proceed with the merge.
  *   - If both repositories specify a set of default profiles for a stream and
  *     the sets are equivalent, use that set.
  *   - If one repository specifies a set of default profiles for a stream and

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-defaults-v1-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-defaults-v1-private.h
@@ -28,6 +28,8 @@ G_BEGIN_DECLS
  * internal consumers.
  */
 
+#define DEFAULT_MERGE_CONFLICT "__merge_conflict__"
+
 /**
  * modulemd_defaults_v1_parse_yaml:
  * @subdoc: (in): A #ModulemdSubdocumentInfo representing a defaults document

--- a/modulemd/v2/tests/test_data/overriding-nodejs.yaml
+++ b/modulemd/v2/tests/test_data/overriding-nodejs.yaml
@@ -1,0 +1,11 @@
+---
+# Override the default stream
+document: modulemd-defaults
+version: 1
+data:
+    module: nodejs
+    stream: '9.0'
+    profiles:
+        '6.0': [default]
+        '8.0': [super]
+        '9.0': [supermegaultra]

--- a/test_data/defaults/overriding-nodejs.yaml
+++ b/test_data/defaults/overriding-nodejs.yaml
@@ -1,0 +1,10 @@
+---
+document: modulemd-defaults
+version: 1
+data:
+    module: nodejs
+    stream: '9.0'
+    profiles:
+        '6.0': [default]
+        '8.0': [super]
+        '9.0': [supermegaultra]


### PR DESCRIPTION
Instead of failing the merge on a default stream conflict, we will
instead treat it as having no default set. This is safe because if
the module is not yet installed, then this just means its packages
aren't visible and it needs to be selected explicitly.

If some packages from it are already installed, then the module
stream is already set, and thus changing the default won't matter.

Resolves: rhbz#[1666871](https://bugzilla.redhat.com/show_bug.cgi?id=1666871)

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>