### PR TITLE
Add ModuleStream.depends_on_stream()

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream.h
@@ -70,9 +70,17 @@ struct _ModulemdModuleStreamClass
 
   guint64 (*get_mdversion) (ModulemdModuleStream *self);
 
-  /* Padding to allow adding up to 10 new virtual functions without
+  gboolean (*depends_on_stream) (ModulemdModuleStream *self,
+                                 const gchar *module_name,
+                                 const gchar *stream_name);
+
+  gboolean (*build_depends_on_stream) (ModulemdModuleStream *self,
+                                       const gchar *module_name,
+                                       const gchar *stream_name);
+
+  /* Padding to allow adding up to 8 new virtual functions without
    * breaking ABI. */
-  gpointer padding[10];
+  gpointer padding[8];
 };
 
 
@@ -349,4 +357,34 @@ gchar *
 modulemd_module_stream_get_nsvc_as_string (ModulemdModuleStream *self);
 
 
+/**
+ * modulemd_module_stream_depends_on_stream:
+ * @self: (not nullable): This #ModulemdModuleStream.
+ * @module_name: (not nullable): A module name
+ * @stream_name: (not nullable): The stream of the module
+ *
+ * Since: 2.1
+ *
+ * Stability: unstable
+ */
+gboolean
+modulemd_module_stream_depends_on_stream (ModulemdModuleStream *self,
+                                          const gchar *module_name,
+                                          const gchar *stream_name);
+
+
+/**
+ * modulemd_module_stream_build_depends_on_stream:
+ * @self: (not nullable): This #ModulemdModuleStream.
+ * @module_name: (not nullable): A module name
+ * @stream_name: (not nullable): The stream of the module
+ *
+ * Since: 2.1
+ *
+ * Stability: unstable
+ */
+gboolean
+modulemd_module_stream_build_depends_on_stream (ModulemdModuleStream *self,
+                                                const gchar *module_name,
+                                                const gchar *stream_name);
 G_END_DECLS

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-dependencies-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-dependencies-private.h
@@ -67,3 +67,14 @@ modulemd_dependencies_emit_yaml (ModulemdDependencies *self,
 
 gboolean
 modulemd_dependencies_validate (ModulemdDependencies *self, GError **error);
+
+
+gboolean
+modulemd_dependencies_requires_module_and_stream (ModulemdDependencies *self,
+                                                  const gchar *module_name,
+                                                  const gchar *stream_name);
+gboolean
+modulemd_dependencies_buildrequires_module_and_stream (
+  ModulemdDependencies *self,
+  const gchar *module_name,
+  const gchar *stream_name);

--- a/modulemd/v2/modulemd-module-stream-v1.c
+++ b/modulemd/v2/modulemd-module-stream-v1.c
@@ -1065,6 +1065,52 @@ modulemd_module_stream_v1_copy (ModulemdModuleStream *self,
 }
 
 
+static gboolean
+modulemd_module_stream_v1_depends_on_stream (ModulemdModuleStream *self,
+                                             const gchar *module_name,
+                                             const gchar *stream_name)
+{
+  const gchar *stream = NULL;
+  ModulemdModuleStreamV1 *v1_self = NULL;
+
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), FALSE);
+  g_return_val_if_fail (module_name && stream_name, FALSE);
+
+  v1_self = MODULEMD_MODULE_STREAM_V1 (self);
+
+  stream = g_hash_table_lookup (v1_self->runtime_deps, module_name);
+  if (!stream)
+    {
+      return FALSE;
+    }
+
+  return g_str_equal (stream, stream_name);
+}
+
+
+static gboolean
+modulemd_module_stream_v1_build_depends_on_stream (ModulemdModuleStream *self,
+                                                   const gchar *module_name,
+                                                   const gchar *stream_name)
+{
+  const gchar *stream = NULL;
+  ModulemdModuleStreamV1 *v1_self = NULL;
+
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self), FALSE);
+  g_return_val_if_fail (module_name && stream_name, FALSE);
+
+  v1_self = MODULEMD_MODULE_STREAM_V1 (self);
+
+  stream = g_hash_table_lookup (v1_self->buildtime_deps, module_name);
+  if (!stream)
+    {
+      return FALSE;
+    }
+
+  return g_str_equal (stream, stream_name);
+}
+
+
 static void
 modulemd_module_stream_v1_class_init (ModulemdModuleStreamV1Class *klass)
 {
@@ -1079,6 +1125,10 @@ modulemd_module_stream_v1_class_init (ModulemdModuleStreamV1Class *klass)
   stream_class->get_mdversion = modulemd_module_stream_v1_get_mdversion;
   stream_class->copy = modulemd_module_stream_v1_copy;
   stream_class->validate = modulemd_module_stream_v1_validate;
+  stream_class->depends_on_stream =
+    modulemd_module_stream_v1_depends_on_stream;
+  stream_class->build_depends_on_stream =
+    modulemd_module_stream_v1_build_depends_on_stream;
 
   properties[PROP_ARCH] = g_param_spec_string (
     "arch",

--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -258,8 +258,8 @@ modulemd_module_stream_read_yaml (yaml_parser_t *parser,
     {
       g_set_error_literal (error,
                            MODULEMD_YAML_ERROR,
-                           MODULEMD_YAML_ERROR_PARSE,
-                           "YAML contained more than a single subdocument");
+                           MODULEMD_YAML_ERROR_UNPARSEABLE,
+                           "Parser error");
       return NULL;
     }
 
@@ -267,8 +267,8 @@ modulemd_module_stream_read_yaml (yaml_parser_t *parser,
     {
       g_set_error_literal (error,
                            MODULEMD_YAML_ERROR,
-                           MODULEMD_YAML_ERROR_UNPARSEABLE,
-                           "Parser error");
+                           MODULEMD_YAML_ERROR_PARSE,
+                           "YAML contained more than a single subdocument");
       return NULL;
     }
   yaml_event_delete (&event);

--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -958,3 +958,35 @@ modulemd_module_stream_emit_yaml_base (ModulemdModuleStream *self,
   /* The rest of the fields will be emitted by the version-specific emitters */
   return TRUE;
 }
+
+
+gboolean
+modulemd_module_stream_depends_on_stream (ModulemdModuleStream *self,
+                                          const gchar *module_name,
+                                          const gchar *stream_name)
+{
+  ModulemdModuleStreamClass *klass;
+
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self), FALSE);
+
+  klass = MODULEMD_MODULE_STREAM_GET_CLASS (self);
+  g_return_val_if_fail (klass->depends_on_stream, FALSE);
+
+  return klass->depends_on_stream (self, module_name, stream_name);
+}
+
+
+gboolean
+modulemd_module_stream_build_depends_on_stream (ModulemdModuleStream *self,
+                                                const gchar *module_name,
+                                                const gchar *stream_name)
+{
+  ModulemdModuleStreamClass *klass;
+
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self), FALSE);
+
+  klass = MODULEMD_MODULE_STREAM_GET_CLASS (self);
+  g_return_val_if_fail (klass->build_depends_on_stream, FALSE);
+
+  return klass->build_depends_on_stream (self, module_name, stream_name);
+}

--- a/modulemd/v2/tests/ModulemdTests/modulestream.py
+++ b/modulemd/v2/tests/ModulemdTests/modulestream.py
@@ -1013,6 +1013,31 @@ data:
                 "%s/spec.v1.yaml" % os.getenv('MESON_SOURCE_ROOT'), True)
             assert stream
 
+    def test_depends_on_stream(self):
+
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.read_file(
+                "%s/modulemd/v2/tests/test_data/dependson_v%d.yaml" % (
+                    os.getenv('MESON_SOURCE_ROOT'),
+                    version),
+                True)
+            self.assertIsNotNone(stream)
+
+            self.assertEqual(stream.depends_on_stream('platform', 'f30'), True)
+            self.assertEqual(
+                stream.build_depends_on_stream(
+                    'platform', 'f30'), True)
+
+            self.assertEqual(
+                stream.depends_on_stream(
+                    'platform', 'f28'), False)
+            self.assertEqual(
+                stream.build_depends_on_stream(
+                    'platform', 'f28'), False)
+
+            self.assertEqual(stream.depends_on_stream('base', 'f30'), False)
+            self.assertEqual(stream.depends_on_stream('base', 'f30'), False)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/modulemd/v2/tests/test_data/dependson_v1.yaml
+++ b/modulemd/v2/tests/test_data/dependson_v1.yaml
@@ -1,0 +1,59 @@
+---
+document: modulemd
+version: 1
+data:
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  dependencies:
+    buildrequires:
+      platform: f30
+    requires:
+      platform: f30
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      libuv:
+        rationale: Platform abstraction layer for Node.js
+        ref: 1
+        buildorder: 0
+      http-parser:
+        rationale: Needed for parsing HTTP requests
+        ref: master
+        buildorder: 0
+      nghttp2:
+        rationale: Needed for HTTP2 support
+        ref: master
+        buildorder: 0
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        ref: 10
+        buildorder: 10
+...

--- a/modulemd/v2/tests/test_data/dependson_v2.yaml
+++ b/modulemd/v2/tests/test_data/dependson_v2.yaml
@@ -1,0 +1,59 @@
+---
+document: modulemd
+version: 2
+data:
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  dependencies:
+  - buildrequires:
+      platform: [ f30 ]
+    requires:
+      platform: [ -f28 ]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      libuv:
+        rationale: Platform abstraction layer for Node.js
+        ref: 1
+        buildorder: 0
+      http-parser:
+        rationale: Needed for parsing HTTP requests
+        ref: master
+        buildorder: 0
+      nghttp2:
+        rationale: Needed for HTTP2 support
+        ref: master
+        buildorder: 0
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        ref: 10
+        buildorder: 10
+...


### PR DESCRIPTION
Adds two new functions for streams to determine whether they apply
to a particular module and stream. This is primarily useful during
mass-rebuild processing.
    
Fixes: https://github.com/fedora-modularity/libmodulemd/issues/173


Also includes a small patch to fix an error message.