### PR TITLE
V2: Add missing include for string.h to modulemd-util.h

### DIFF
--- a/modulemd/v2/modulemd-util.c
+++ b/modulemd/v2/modulemd-util.c
@@ -11,6 +11,8 @@
  * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
  */
 
+#include <string.h>
+
 #include "private/modulemd-util.h"
 
 


### PR DESCRIPTION
This fixes building libmodulemd on openSUSE.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>