### PR TITLE
Tests: Use /bin/bash for interpreter shebangs for shell scripts

### DIFF
--- a/modulemd/common/tests/test-import-headers.sh
+++ b/modulemd/common/tests/test-import-headers.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 # This file is part of libmodulemd
 # Copyright (C) 2017-2018 Stephen Gallagher
 #

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
Not all distributions have done UsrMerge/UsrMove, and in cases where
that hasn't happened, the shebang needs to be /bin/bash. As this
works on UsrMerged systems, it's fine to keep it that way.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>