### PR TITLE
Extends tests for ModuleStream.depends_on_stream()

### DIFF
--- a/modulemd/v2/tests/ModulemdTests/modulestream.py
+++ b/modulemd/v2/tests/ModulemdTests/modulestream.py
@@ -682,7 +682,6 @@ data:
 
         assert 'rawhide' in stream.get_servicelevel_names()
         assert 'production' in stream.get_servicelevel_names()
-
         sl = stream.get_servicelevel('rawhide')
         assert sl is not None
         assert sl.props.name == 'rawhide'
@@ -1035,8 +1034,16 @@ data:
                 stream.build_depends_on_stream(
                     'platform', 'f28'), False)
 
-            self.assertEqual(stream.depends_on_stream('base', 'f30'), False)
-            self.assertEqual(stream.depends_on_stream('base', 'f30'), False)
+            self.assertEqual(
+                stream.depends_on_stream(
+                    'base', ''), False)
+            self.assertEqual(
+                stream.build_depends_on_stream(
+                    'base', ''), False)
+
+            ret = stream.build_depends_on_stream(
+                'platform', '')
+            assert (ret is True or ret is False)
 
 
 if __name__ == '__main__':

--- a/modulemd/v2/tests/test-modulemd-modulestream.c
+++ b/modulemd/v2/tests/test-modulemd-modulestream.c
@@ -140,6 +140,152 @@ module_stream_test_copy (ModuleStreamFixture *fixture, gconstpointer user_data)
 }
 
 static void
+module_stream_v1_test_depends_on_stream (ModuleStreamFixture *fixture,
+                                         gconstpointer user_data)
+{
+  g_autoptr (ModulemdModuleStream) stream = NULL;
+  g_autofree gchar *path = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *module_name = NULL;
+  g_autofree gchar *module_stream = NULL;
+  gboolean ret;
+
+  path = g_strdup_printf ("%s/modulemd/v2/tests/test_data/dependson_v1.yaml",
+                          g_getenv ("MESON_SOURCE_ROOT"));
+  g_assert_nonnull (path);
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_true (
+    modulemd_module_stream_depends_on_stream (stream, "platform", "f30"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_true (modulemd_module_stream_build_depends_on_stream (
+    stream, "platform", "f30"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_false (
+    modulemd_module_stream_depends_on_stream (stream, "platform", "f28"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_false (modulemd_module_stream_build_depends_on_stream (
+    stream, "platform", "f28"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_false (
+    modulemd_module_stream_depends_on_stream (stream, "base", "f30"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_false (
+    modulemd_module_stream_build_depends_on_stream (stream, "base", "f30"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  ret = modulemd_module_stream_depends_on_stream (stream, "platform", "");
+  g_assert (ret == 0 || ret == 1);
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  ret =
+    modulemd_module_stream_build_depends_on_stream (stream, "platform", "");
+  g_assert (ret == 0 || ret == 1);
+  g_clear_object (&stream);
+}
+
+static void
+module_stream_v2_test_depends_on_stream (ModuleStreamFixture *fixture,
+                                         gconstpointer user_data)
+{
+  g_autoptr (ModulemdModuleStream) stream = NULL;
+  g_autofree gchar *path = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *module_name = NULL;
+  g_autofree gchar *module_stream = NULL;
+  gboolean ret;
+
+
+  path = g_strdup_printf ("%s/modulemd/v2/tests/test_data/dependson_v2.yaml",
+                          g_getenv ("MESON_SOURCE_ROOT"));
+  g_assert_nonnull (path);
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_true (
+    modulemd_module_stream_depends_on_stream (stream, "platform", "f30"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_true (modulemd_module_stream_build_depends_on_stream (
+    stream, "platform", "f30"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_false (
+    modulemd_module_stream_depends_on_stream (stream, "platform", "f28"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_false (modulemd_module_stream_build_depends_on_stream (
+    stream, "platform", "f28"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_false (
+    modulemd_module_stream_depends_on_stream (stream, "base", "f30"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  g_assert_false (
+    modulemd_module_stream_build_depends_on_stream (stream, "base", "f30"));
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  ret = modulemd_module_stream_depends_on_stream (stream, "platform", "");
+  g_assert (ret == 0 || ret == 1);
+  g_clear_object (&stream);
+
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+  ret =
+    modulemd_module_stream_build_depends_on_stream (stream, "platform", "");
+  g_assert (ret == 0 || ret == 1);
+  g_clear_object (&stream);
+}
+
+
+static void
 module_stream_v1_test_parse_dump (ModuleStreamFixture *fixture,
                                   gconstpointer user_data)
 {
@@ -525,6 +671,19 @@ main (int argc, char *argv[])
               NULL,
               module_stream_test_copy,
               NULL);
+  g_test_add ("/modulemd/v2/modulestream/v1/depends_on_stream",
+              ModuleStreamFixture,
+              NULL,
+              NULL,
+              module_stream_v1_test_depends_on_stream,
+              NULL);
+  g_test_add ("/modulemd/v2/modulestream/v2/depends_on_stream",
+              ModuleStreamFixture,
+              NULL,
+              NULL,
+              module_stream_v2_test_depends_on_stream,
+              NULL);
+
 
   g_test_add ("/modulemd/v2/modulestream/v1/parse_dump",
               ModuleStreamFixture,


### PR DESCRIPTION
The tests for depends_on_stream() and build_depends_on_stream() is modified to handle empty lists
Replicates the existing python tests, and newly added tests for depends_on_stream to C.
Fixes : https://github.com/fedora-modularity/libmodulemd/issues/192
related:  https://github.com/fedora-modularity/libmodulemd/issues/199