### PR TITLE
Fixes #189: Create Python tutorial: Getting the default stream for a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,17 @@ from gi.repository import Modulemd
 The libmodulemd API provides a number of convenience tools for interacting
 with repodata (that is, streams of YAML that contains information on multiple
 streams, default data and translations). The documentation will use two
-repositories, called "fedora" and "updates" for demonstrative purposes. It
-will assume that the content of the YAML module metadata from those two
-repositories have been loaded into string variables "fedora_yaml" and
-"updates_yaml", respectively.
+repositories, called "fedora" and "updates" for demonstrative purposes. 
+
+## Import repodata YAML from "fedora" and "updates" respectively
+
+```python
+
+fedora_yaml = 
+updates_yaml = 
+```
+
+
 
 First step is to load the metadata from these two repositories into
 ModulemdModuleIndex objects. This is done as follows:
@@ -86,6 +93,38 @@ upgraded to match the highest version of those objects seen. So for
 example if the repodata has a mix of v1 and v2 ModuleStream objects, the
 index will contain only v2 objects (with the v1 objects automatically
 upgraded internally).
+
+Now, we can start operating on the retrieved data. This guide will
+give only a brief overview of the most common operations. See the API
+specification for a full list of information that can be retrieved.
+
+## Discover the default stream for a particular module.
+## Python
+```python
+ module = merged_index.get_module ('modulename')
+ defaults = module.get_defaults()
+ print ('Default stream for modulename is %s' % (
+       defaults.get_default_stream())
+  ```
+ 
+ ## Get the list of RPMs defining the public API for a particular module NSVC
+ ## Python
+```python
+ module = merged_index.get_module ('modulename')
+ stream = module.get_stream_by_NSVC('modulestream', 1, 'deadbeef')
+ api_list = stream.get_rpm_api()
+```
+
+ ## Retrieve the modular runtime dependencies for a particular module NSVC
+## Python
+```python
+ module = merged_index.get_module ('modulename')
+ stream = module.get_stream_by_NSVC('modulestream', 1, 'deadbeef')
+ deps_list = stream.get_dependencies()
+ for dep in deps_list:
+    depstream_list = dep.get_runtime_streams('depstreamname')
+    <do_stuff>
+```
 
 # Working with a single module stream (Packager/MBS use-case)
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,10 @@ from gi.repository import Modulemd
 The libmodulemd API provides a number of convenience tools for interacting
 with repodata (that is, streams of YAML that contains information on multiple
 streams, default data and translations). The documentation will use two
-repositories, called "fedora" and "updates" for demonstrative purposes. 
-
-## Import repodata YAML from "fedora" and "updates" respectively
-
-```python
-
-fedora_yaml = 
-updates_yaml = 
-```
-
-
+repositories, called "fedora" and "updates" for demonstrative purposes. It
+will assume that the content of the YAML module metadata from those two
+repositories have been loaded into string variables "fedora_yaml" and
+"updates_yaml", respectively.
 
 First step is to load the metadata from these two repositories into
 ModulemdModuleIndex objects. This is done as follows:


### PR DESCRIPTION
Fixes #189 

I couldn't find the "fedora" and "updates" repo to get my yaml string. 