### PR TITLE
Extends tests for ModuleStream.depends_on_stream()

### DIFF
--- a/modulemd/v2/tests/ModulemdTests/modulestream.py
+++ b/modulemd/v2/tests/ModulemdTests/modulestream.py
@@ -1085,7 +1085,17 @@ data:
                     'platform', 'f28'), False)
 
             self.assertEqual(stream.depends_on_stream('base', 'f30'), False)
-            self.assertEqual(stream.depends_on_stream('base', 'f30'), False)
+            self.assertEqual(
+                stream.build_depends_on_stream(
+                    'base', 'f30'), False)
+
+            if version >= Modulemd.ModuleStreamVersionEnum.TWO:
+                self.assertEqual(
+                    stream.depends_on_stream(
+                        'streamname', 'f30'), True)
+                self.assertEqual(
+                    stream.build_depends_on_stream(
+                        'streamname', 'f30'), True)
 
 
 if __name__ == '__main__':

--- a/modulemd/v2/tests/test_data/dependson_v2.yaml
+++ b/modulemd/v2/tests/test_data/dependson_v2.yaml
@@ -14,8 +14,10 @@ data:
   dependencies:
   - buildrequires:
       platform: [ f30 ]
+      streamname: [ ] 
     requires:
       platform: [ -f28 ]
+      streamname: [ ]     
   references:
     community: http://nodejs.org
     documentation: http://nodejs.org/en/docs


### PR DESCRIPTION
The tests for depends_on_stream() and build_depends_on_stream() is modified to handle empty lists

issue: https://github.com/fedora-modularity/libmodulemd/issues/192