### PR TITLE
Copies some python test of modulestream into C

### DIFF
--- a/modulemd/v2/tests/test-modulemd-modulestream.c
+++ b/modulemd/v2/tests/test-modulemd-modulestream.c
@@ -503,6 +503,74 @@ module_stream_v2_test_parse_dump (ModuleStreamFixture *fixture,
     "...\n");
 }
 
+static void
+module_stream_v1_test_depends_on_stream (ModuleStreamFixture *fixture,
+                                         gconstpointer user_data)
+{
+  g_autoptr (ModulemdModuleStream) stream = NULL;
+  g_autofree gchar *path = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *module_name = NULL;
+  g_autofree gchar *module_stream = NULL;
+
+  path = g_strdup_printf ("%s/modulemd/v2/tests/test_data/dependson_v1.yaml",
+                          g_getenv ("MESON_SOURCE_ROOT"));
+  g_assert_nonnull (path);
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+
+  g_assert_true (
+    modulemd_module_stream_depends_on_stream (stream, "platform", "f30"));
+  g_assert_true (modulemd_module_stream_build_depends_on_stream (
+    stream, "platform", "f30"));
+
+  g_assert_false (
+    modulemd_module_stream_depends_on_stream (stream, "platform", "f28"));
+  g_assert_false (modulemd_module_stream_build_depends_on_stream (
+    stream, "platform", "f28"));
+
+  g_assert_false (
+    modulemd_module_stream_depends_on_stream (stream, "base", "f30"));
+  g_assert_false (
+    modulemd_module_stream_build_depends_on_stream (stream, "base", "f30"));
+  g_clear_object (&stream);
+}
+
+static void
+module_stream_v2_test_depends_on_stream (ModuleStreamFixture *fixture,
+                                         gconstpointer user_data)
+{
+  g_autoptr (ModulemdModuleStream) stream = NULL;
+  g_autofree gchar *path = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *module_name = NULL;
+  g_autofree gchar *module_stream = NULL;
+
+  path = g_strdup_printf ("%s/modulemd/v2/tests/test_data/dependson_v2.yaml",
+                          g_getenv ("MESON_SOURCE_ROOT"));
+  g_assert_nonnull (path);
+  stream = modulemd_module_stream_read_file (
+    path, TRUE, module_name, module_stream, &error);
+  g_assert_nonnull (stream);
+
+  g_assert_true (
+    modulemd_module_stream_depends_on_stream (stream, "platform", "f30"));
+  g_assert_true (modulemd_module_stream_build_depends_on_stream (
+    stream, "platform", "f30"));
+
+  g_assert_false (
+    modulemd_module_stream_depends_on_stream (stream, "platform", "f28"));
+  g_assert_false (modulemd_module_stream_build_depends_on_stream (
+    stream, "platform", "f28"));
+
+  g_assert_false (
+    modulemd_module_stream_depends_on_stream (stream, "base", "f30"));
+  g_assert_false (
+    modulemd_module_stream_build_depends_on_stream (stream, "base", "f30"));
+  g_clear_object (&stream);
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -539,6 +607,20 @@ main (int argc, char *argv[])
               NULL,
               module_stream_v2_test_parse_dump,
               NULL);
+
+  g_test_add ("/modulemd/v2/modulestream/v1/depends_on_stream",
+              ModuleStreamFixture,
+              NULL,
+              NULL,
+              module_stream_v1_test_depends_on_stream,
+              NULL);
+  g_test_add ("/modulemd/v2/modulestream/v2/depends_on_stream",
+              ModuleStreamFixture,
+              NULL,
+              NULL,
+              module_stream_v2_test_depends_on_stream,
+              NULL);
+
 
   return g_test_run ();
 }


### PR DESCRIPTION
Most of the tests for ModuleStream objects are run under Python.
The valgrind tests for identifying memory leaks and errors can only
run against tests in the C code.
The tests for ModuleStream.depends_on_stream have been copied from
Python to C.
issue : https://github.com/fedora-modularity/libmodulemd/issues/199