### PR TITLE
Drop some deps from CentOS CI

### DIFF
--- a/.travis/centos/Dockerfile.deps.tmpl
+++ b/.travis/centos/Dockerfile.deps.tmpl
@@ -8,7 +8,6 @@ RUN yum -y install epel-release \
     && yum -y install \
         clang \
 	createrepo_c \
-	curl \
 	elinks \
 	gcc \
 	gcc-c++ \
@@ -19,18 +18,12 @@ RUN yum -y install epel-release \
 	libyaml-devel \
 	meson \
 	ninja-build \
-	openssl \
 	pkgconfig \
-	popt-devel \
 	python34-devel \
 	python34-gobject-base \
 	python3-rpm-macros \
 	redhat-rpm-config \
 	rpm-build \
 	rpmdevtools \
-	ruby \
-	"rubygem(json)" \
-	rubygems \
 	sudo \
-	wget \
     && yum -y clean all


### PR DESCRIPTION
These were needed in Fedora for Coverity but not for CentOS.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>