### PR TITLE
Fixes #217: Provide Modulemd.Profile.equals() method

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-profile.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-profile.h
@@ -29,6 +29,20 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (
   ModulemdProfile, modulemd_profile, MODULEMD, PROFILE, GObject)
 
+
+/**
+ * modulemd_profile_equals:
+ * @self_1: A #ModulemdProfile
+ * @self_2: A #ModulemdProfile
+ *
+ * Returns: TRUE if all elements of self_1 and self_2 are equal. FALSE, otherwise. 
+ *
+ * Since: 2.2
+ */
+gboolean
+modulemd_profile_equals (ModulemdProfile *self_1, ModulemdProfile *self_2);
+
+
 /**
  * modulemd_profile_new:
  * @name: (not nullable): The name of this profile.

--- a/modulemd/v2/modulemd-profile.c
+++ b/modulemd/v2/modulemd-profile.c
@@ -46,6 +46,28 @@ enum
 static GParamSpec *properties[N_PROPS];
 
 
+gboolean
+modulemd_profile_equals (ModulemdProfile *self_1, ModulemdProfile *self_2)
+{
+  g_return_val_if_fail (MODULEMD_IS_PROFILE (self_1), FALSE);
+  g_return_val_if_fail (MODULEMD_IS_PROFILE (self_2), FALSE);
+
+  if (g_strcmp0 (modulemd_profile_get_name (self_1),
+                 modulemd_profile_get_name (self_2)) != 0)
+    return FALSE;
+
+  if (g_strcmp0 (modulemd_profile_get_description (self_1, NULL),
+                 modulemd_profile_get_description (self_2, NULL)))
+    return FALSE;
+
+  //Check rpms: size, set values
+  if (!modulemd_hash_table_sets_are_equal (self_1->rpms, self_2->rpms))
+    return FALSE;
+
+  return TRUE;
+}
+
+
 ModulemdProfile *
 modulemd_profile_new (const gchar *name)
 {

--- a/modulemd/v2/tests/test-modulemd-profile.c
+++ b/modulemd/v2/tests/test-modulemd-profile.c
@@ -81,6 +81,151 @@ profile_test_construct (ProfileFixture *fixture, gconstpointer user_data)
 
 
 static void
+profile_test_equals (ProfileFixture *fixture, gconstpointer user_data)
+{
+  g_autoptr (ModulemdProfile) p_1 = NULL;
+  g_autoptr (ModulemdProfile) p_2 = NULL;
+
+  /*Test 2 objects with same name*/
+  p_1 = modulemd_profile_new ("testprofile");
+  g_assert_nonnull (p_1);
+  g_assert_true (MODULEMD_IS_PROFILE (p_1));
+
+  p_2 = modulemd_profile_new ("testprofile");
+  g_assert_nonnull (p_2);
+  g_assert_true (MODULEMD_IS_PROFILE (p_2));
+
+  g_assert_true (modulemd_profile_equals (p_1, p_2));
+
+  g_clear_object (&p_1);
+  g_clear_object (&p_2);
+
+  /*Test 2 objects with different name*/
+  p_1 = modulemd_profile_new ("testing");
+  g_assert_nonnull (p_1);
+  g_assert_true (MODULEMD_IS_PROFILE (p_1));
+
+  p_2 = modulemd_profile_new ("testprofile");
+  g_assert_nonnull (p_2);
+  g_assert_true (MODULEMD_IS_PROFILE (p_2));
+
+  g_assert_false (modulemd_profile_equals (p_1, p_2));
+
+  g_clear_object (&p_1);
+  g_clear_object (&p_2);
+
+  /* Test 2 profile objects with same name and description */
+  p_1 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_1, "a test");
+  g_assert_nonnull (p_1);
+  g_assert_true (MODULEMD_IS_PROFILE (p_1));
+
+  p_2 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_2, "a test");
+  g_assert_nonnull (p_2);
+  g_assert_true (MODULEMD_IS_PROFILE (p_2));
+
+  g_assert_true (modulemd_profile_equals (p_1, p_2));
+
+  g_clear_object (&p_1);
+  g_clear_object (&p_2);
+
+  /* Test 2 profile objects with same name and different description */
+  p_1 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_1, "a test");
+  g_assert_nonnull (p_1);
+  g_assert_true (MODULEMD_IS_PROFILE (p_1));
+
+  p_2 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_2, "b test");
+  g_assert_nonnull (p_2);
+  g_assert_true (MODULEMD_IS_PROFILE (p_2));
+
+  g_assert_false (modulemd_profile_equals (p_1, p_2));
+
+  g_clear_object (&p_1);
+  g_clear_object (&p_2);
+
+  /* Test 2 profile objects with same name, description, and rpms */
+  p_1 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_1, "a test");
+  modulemd_profile_add_rpm (p_1, "testrpm");
+  g_assert_nonnull (p_1);
+  g_assert_true (MODULEMD_IS_PROFILE (p_1));
+
+  p_2 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_2, "a test");
+  modulemd_profile_add_rpm (p_2, "testrpm");
+  g_assert_nonnull (p_2);
+  g_assert_true (MODULEMD_IS_PROFILE (p_2));
+
+  g_assert_true (modulemd_profile_equals (p_1, p_2));
+
+  g_clear_object (&p_1);
+  g_clear_object (&p_2);
+
+  /* Test 2 profile objects with same name, description, and different rpms */
+  p_1 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_1, "a test");
+  modulemd_profile_add_rpm (p_1, "testrpm");
+  g_assert_nonnull (p_1);
+  g_assert_true (MODULEMD_IS_PROFILE (p_1));
+
+  p_2 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_2, "a test");
+  modulemd_profile_add_rpm (p_2, "testingrpm");
+  g_assert_nonnull (p_2);
+  g_assert_true (MODULEMD_IS_PROFILE (p_2));
+
+  g_assert_false (modulemd_profile_equals (p_1, p_2));
+
+  g_clear_object (&p_1);
+  g_clear_object (&p_2);
+
+  /*Compare two RPM sets where the first sorted value matches and the second does not.*/
+  p_1 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_1, "a test");
+  modulemd_profile_add_rpm (p_1, "a");
+  modulemd_profile_add_rpm (p_1, "b");
+  g_assert_nonnull (p_1);
+  g_assert_true (MODULEMD_IS_PROFILE (p_1));
+
+  p_2 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_2, "a test");
+  modulemd_profile_add_rpm (p_1, "a");
+  modulemd_profile_add_rpm (p_1, "c");
+  g_assert_nonnull (p_2);
+  g_assert_true (MODULEMD_IS_PROFILE (p_2));
+
+  g_assert_false (modulemd_profile_equals (p_1, p_2));
+
+  g_clear_object (&p_1);
+  g_clear_object (&p_2);
+
+  /*Compare two RPM sets where the first sorted value matches, but one has more entries than the other.*/
+  p_1 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_1, "a test");
+  modulemd_profile_add_rpm (p_1, "a");
+  modulemd_profile_add_rpm (p_1, "b");
+  g_assert_nonnull (p_1);
+  g_assert_true (MODULEMD_IS_PROFILE (p_1));
+
+  p_2 = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_description (p_2, "a test");
+  modulemd_profile_add_rpm (p_1, "a");
+  modulemd_profile_add_rpm (p_1, "b");
+  modulemd_profile_add_rpm (p_1, "c");
+  g_assert_nonnull (p_2);
+  g_assert_true (MODULEMD_IS_PROFILE (p_2));
+
+  g_assert_false (modulemd_profile_equals (p_1, p_2));
+
+  g_clear_object (&p_1);
+  g_clear_object (&p_2);
+}
+
+
+static void
 profile_test_copy (ProfileFixture *fixture, gconstpointer user_data)
 {
   g_autoptr (ModulemdProfile) p = NULL;
@@ -351,6 +496,13 @@ main (int argc, char *argv[])
               NULL,
               NULL,
               profile_test_construct,
+              NULL);
+
+  g_test_add ("/modulemd/v2/profile/equals",
+              ProfileFixture,
+              NULL,
+              NULL,
+              profile_test_equals,
               NULL);
 
   g_test_add ("/modulemd/v2/profile/copy",


### PR DESCRIPTION
Fixes #217 

It seemed similar to `buildopts` so decided to give it a try.