### PR TITLE
Adding Mageia 7 Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,5 @@ jobs:
       script: ./.travis/travis-fedora.sh
     - name: "CentOS 7"
       script: ./.travis/travis-centos.sh
+    - name: "Mageia 7"
+      script: ./.travis/travis-mageia.sh

--- a/.travis/mageia/Dockerfile.deps.tmpl
+++ b/.travis/mageia/Dockerfile.deps.tmpl
@@ -1,0 +1,40 @@
+FROM @IMAGE@
+
+MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
+
+ARG TARBALL
+
+RUN dnf -y --setopt=install_weak_deps=False install \
+	clang \
+	clang-analyzer \
+	createrepo_c \
+	curl \
+	elinks \
+	gcc \
+	gcc-c++ \
+	git-core \
+	glib2-devel \
+	gobject-introspection-devel \
+	gtk-doc \
+	libyaml-devel \
+	meson \
+	ninja-build \
+	openssl \
+	pkgconf \
+	popt-devel \
+	python3-autopep8 \
+	python3-devel \
+	python3-GitPython \
+	python3-gobject-base \
+	python3-pycodestyle \
+	python3-rpm-macros \
+	redhat-rpm-config \
+	rpm-build \
+	rpmdevtools \
+	ruby \
+	"rubygem(json)" \
+	rubygems \
+	sudo \
+	valgrind \
+	wget \
+    && dnf -y clean all

--- a/.travis/mageia/Dockerfile.tmpl
+++ b/.travis/mageia/Dockerfile.tmpl
@@ -6,4 +6,4 @@ ARG TARBALL
 
 ADD $TARBALL /builddir/
 
-ENTRYPOINT /builddir/.travis/centos/travis-tasks.sh
+ENTRYPOINT /builddir/.travis/mageia/travis-tasks.sh

--- a/.travis/mageia/travis-tasks.sh
+++ b/.travis/mageia/travis-tasks.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+#Exit on failures
+set -e
+
+set -x
+
+
+JOB_NAME=${TRAVIS_JOB_NAME:- Mageia 7}
+
+arr=($JOB_NAME)
+os_name=${arr[0]:-Mageia}
+release=${arr[1]:-7}
+
+COMMON_MESON_ARGS="-Dtest_dirty_git=${DIRTY_REPO_CHECK:-true}"
+
+
+pushd /builddir/
+
+# Build the v1 and v2 code under GCC and run standard tests
+meson --buildtype=debug \
+      -Dbuild_api_v1=true \
+      -Dbuild_api_v2=true \
+      $COMMON_MESON_ARGS \
+      travis
+
+set +e
+ninja -C travis test
+if [ $? != 0 ]; then
+    cat travis/meson-logs/testlog.txt
+fi
+set -e
+
+# Test the v2 code with clang-analyzer
+# This requires meson 0.49.0 or later
+set +e
+rpmdev-vercmp `meson --version` 0.49.0
+if [ $? -eq 12 ]; then
+    # Meson was older than 0.49.0, skip this step
+    echo "Meson is too old to run scan-build"
+    set -e
+else
+    set -e
+    meson --buildtype=debug \
+          -Dbuild_api_v1=false \
+          -Dbuild_api_v2=true \
+          -Dskip_introspection=true \
+          $COMMON_MESON_ARGS \
+          travis_scanbuild
+
+    pushd travis_scanbuild
+    /builddir/.travis/scanbuild.sh
+    popd #travis_scanbuild
+fi
+
+meson --buildtype=debug \
+      -Dbuild_api_v1=true \
+      -Dbuild_api_v2=true \
+      $COMMON_MESON_ARGS \
+      coverity
+
+# Always install and run the installed RPM tests last so we don't pollute the
+# testing environment above.
+
+meson --buildtype=debug \
+      -Dbuild_api_v1=true \
+      $COMMON_MESON_ARGS \
+      build_rpm
+
+pushd build_rpm
+
+ninja
+./make_rpms.sh
+
+createrepo_c rpmbuild/RPMS/
+
+dnf -y install --nogpgcheck \
+               --repofrompath libmodulemd-travis,rpmbuild/RPMS \
+               python3-libmodulemd1 \
+               libmodulemd1-devel \
+               --exclude libmodulemd
+
+popd #build_rpm
+
+meson --buildtype=debug \
+      -Dbuild_api_v1=true \
+      -Dbuild_api_v2=false \
+      -Dtest_installed_lib=true \
+      $COMMON_MESON_ARGS \
+      installed_lib_tests_v1
+
+pushd installed_lib_tests_v1
+
+# Run the tests against the installed RPMs
+ninja test
+
+popd #installed_lib_tests_v1
+
+
+pushd build_rpm
+
+dnf -y install --nogpgcheck \
+               --allowerasing \
+               --repofrompath libmodulemd-travis,rpmbuild/RPMS \
+               python3-libmodulemd \
+               "libmodulemd-devel > 2"
+popd
+
+meson --buildtype=debug \
+      -Dbuild_api_v1=false \
+      -Dbuild_api_v2=true \
+      -Dtest_installed_lib=true \
+      $COMMON_MESON_ARGS \
+      installed_lib_tests_v2
+
+pushd installed_lib_tests_v2
+# Run the tests against the installed RPMs
+ninja test
+
+popd #installed_lib_tests_v2
+
+popd #builddir

--- a/.travis/travis-mageia.sh
+++ b/.travis/travis-mageia.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $SCRIPT_DIR
+set -e
+
+set -x
+
+
+JOB_NAME=${TRAVIS_JOB_NAME:- Mageia 7}
+
+arr=($JOB_NAME)
+os_name=${arr[0]:-Mageia}
+release=${arr[1]:-7}
+
+# Create an archive of the current checkout
+TARBALL_PATH=`mktemp -p $SCRIPT_DIR tarball-XXXXXX.tar.bz2`
+TARBALL=`basename $TARBALL_PATH`
+
+pushd $SCRIPT_DIR/..
+git ls-files |xargs tar cfj $TARBALL_PATH .git
+popd
+
+repository="registry.docker.com"
+os="mageia"
+
+
+sed -e "s/@IMAGE@/$repository\/$os:$release/" \
+    $SCRIPT_DIR/fedora/Dockerfile.deps.tmpl > $SCRIPT_DIR/fedora/Dockerfile.deps.$release
+sed -e "s/@RELEASE@/$release/" $SCRIPT_DIR/fedora/Dockerfile.tmpl > $SCRIPT_DIR/fedora/Dockerfile-$release
+
+sudo docker build -f $SCRIPT_DIR/mageia/Dockerfile.deps.$release -t fedora-modularity/libmodulemd-deps-$release .
+sudo docker build -f $SCRIPT_DIR/mageia/Dockerfile-$release -t fedora-modularity/libmodulemd:$release --build-arg TARBALL=$TARBALL .
+
+rm -f $TARBALL_PATH $SCRIPT_DIR/mageia/Dockerfile.deps.$release $SCRIPT_DIR/mageia/Dockerfile-$release
+
+popd
+exit 0


### PR DESCRIPTION
I had made the changes suggested in the previous Pull Request. 
Mageia 7 allows the user to use `dnf` as a system package manager in Mageia, so it did not require many changes compared to Fedora configuration.