### PR TITLE
Implement 'buildafter' functionality

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-component.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-component.h
@@ -35,6 +35,7 @@ struct _ModulemdComponentClass
   ModulemdComponent *(*copy) (ModulemdComponent *self, const gchar *key);
   void (*set_name) (ModulemdComponent *self, const gchar *name);
   const gchar *(*get_name) (ModulemdComponent *self);
+  gboolean (*validate) (ModulemdComponent *self, GError **error);
 
   /* Padding to allow adding up to 8 new virtual functions without
    * breaking ABI. */
@@ -54,6 +55,24 @@ struct _ModulemdComponentClass
  */
 ModulemdComponent *
 modulemd_component_copy (ModulemdComponent *self, const gchar *key);
+
+
+/**
+ * modulemd_component_validate:
+ * @self: (in): This #ModulemdComponent.
+ * @error: (out): A #GError that will return the reason for a validation error.
+ *
+ * Verifies that all stored values are internally consistent and that the
+ * component is sufficiently-complete for emitting. This function is called
+ * implicitly before attempting to emit the contents.
+ *
+ * Returns: TRUE if the #ModulemdComponent passed validation. FALSE and sets
+ * @error appropriately if validation fails.
+ *
+ * Since: 2.2
+ */
+gboolean
+modulemd_component_validate (ModulemdComponent *self, GError **error);
 
 
 /**

--- a/modulemd/v2/include/modulemd-2.0/modulemd-component.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-component.h
@@ -57,14 +57,14 @@ modulemd_component_copy (ModulemdComponent *self, const gchar *key);
 
 
 /**
- * modulemd_component_set_builderder:
+ * modulemd_component_set_buildorder:
  * @self: This #ModulemdComponent object
  * @buildorder: The order this component should be built relative to others.
  *
  * Since: 2.0
  */
 void
-modulemd_component_set_buildorder (ModulemdComponent *self, gint64 builderder);
+modulemd_component_set_buildorder (ModulemdComponent *self, gint64 buildorder);
 
 
 /**

--- a/modulemd/v2/include/modulemd-2.0/modulemd-component.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-component.h
@@ -57,6 +57,33 @@ modulemd_component_copy (ModulemdComponent *self, const gchar *key);
 
 
 /**
+ * modulemd_component_add_buildafter:
+ * @self: This #ModulemdComponent object
+ * @key: (in): A key representing another component in the
+ * #ModulemdModuleStream components map.
+ *
+ * Add a build dependency of this component.
+ *
+ * Since: 2.2
+ */
+void
+modulemd_component_add_buildafter (ModulemdComponent *self, const gchar *key);
+
+
+/**
+ * modulemd_component_get_buildafter_as_strv: (rename-to modulemd_component_get_buildafter)
+ * @self: This #ModulemdComponent object
+ *
+ * Returns: (transfer full): The set of component keys that this component
+ * depends upon.
+ *
+ * Since: 2.2
+ */
+GStrv
+modulemd_component_get_buildafter_as_strv (ModulemdComponent *self);
+
+
+/**
  * modulemd_component_set_buildorder:
  * @self: This #ModulemdComponent object
  * @buildorder: The order this component should be built relative to others.

--- a/modulemd/v2/include/modulemd-2.0/private/gi-binding-renames.h
+++ b/modulemd/v2/include/modulemd-2.0/private/gi-binding-renames.h
@@ -30,6 +30,12 @@ gchar **
 modulemd_buildopts_get_rpm_whitelist (ModulemdBuildopts *self);
 
 /**
+ * modulemd_component_get_buildafter: (skip)
+ */
+GStrv
+modulemd_component_get_buildafter (ModulemdComponent *self);
+
+/**
  * modulemd_component_rpm_get_arches: (skip)
  */
 GStrv

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-component-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-component-private.h
@@ -28,6 +28,23 @@
 
 
 /**
+ * modulemd_component_parse_buildafter:
+ * @self: This #ModulemdComponent
+ * @emitter: (inout): A libyaml emitter object positioned just after the
+ * "buildafter" key in a #ModulemdComponent section of a YAML document.
+ * @error: (out): A #GError that will return the reason for a parse failure.
+ *
+ * Returns: TRUE if the buildafter list could be parsed successfully.
+ *
+ * Since: 2.2
+ */
+gboolean
+modulemd_component_parse_buildafter (ModulemdComponent *self,
+                                     yaml_parser_t *parser,
+                                     GError **error);
+
+
+/**
  * modulemd_component_emit_yaml_start:
  * @self: This #ModulemdComponent
  * @emitter: (inout): A libyaml emitter object positioned where Component start

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-component-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-component-private.h
@@ -43,6 +43,31 @@ modulemd_component_parse_buildafter (ModulemdComponent *self,
                                      yaml_parser_t *parser,
                                      GError **error);
 
+/**
+ * modulemd_component_has_buildafter:
+ * @self: This #ModulemdComponent
+ *
+ * Returns: Whether one or more buildafter entries have been added to this
+ * component.
+ *
+ * Since: 2.2
+ */
+gboolean
+modulemd_component_has_buildafter (ModulemdComponent *self);
+
+
+/**
+ * modulemd_component_get_buildafter_internal:
+ * @self: This #ModulemdComponentModule
+ *
+ * Returns: The internal hash table representing the set of buildafter
+ * dependencies.
+ *
+ * Since: 2.2
+ */
+GHashTable *
+modulemd_component_get_buildafter_internal (ModulemdComponent *self);
+
 
 /**
  * modulemd_component_emit_yaml_start:

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-module-stream-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-module-stream-private.h
@@ -76,6 +76,10 @@ void
 modulemd_module_stream_v2_replace_dependencies (ModulemdModuleStreamV2 *self,
                                                 GPtrArray *array);
 
+gboolean
+modulemd_module_stream_validate_components (GHashTable *components,
+                                            GError **error);
+
 
 /* Some macros used for copy operations */
 #define STREAM_COPY_IF_SET(version, dest, src, property)                      \

--- a/modulemd/v2/modulemd-component-rpm.c
+++ b/modulemd/v2/modulemd-component-rpm.c
@@ -596,6 +596,19 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
               r->multilib = g_steal_pointer (&list);
             }
           else if (g_str_equal ((const gchar *)event.data.scalar.value,
+                                "buildafter"))
+            {
+              if (!modulemd_component_parse_buildafter (
+                    MODULEMD_COMPONENT (r), parser, &nested_error))
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse buildafter in component: %s",
+                    nested_error->message);
+                }
+            }
+          else if (g_str_equal ((const gchar *)event.data.scalar.value,
                                 "buildorder"))
             {
               buildorder = modulemd_yaml_parse_int64 (parser, &nested_error);

--- a/modulemd/v2/modulemd-component.c
+++ b/modulemd/v2/modulemd-component.c
@@ -170,6 +170,30 @@ modulemd_component_get_buildafter_as_strv (ModulemdComponent *self)
 }
 
 
+GHashTable *
+modulemd_component_get_buildafter_internal (ModulemdComponent *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), NULL);
+
+  ModulemdComponentPrivate *priv =
+    modulemd_component_get_instance_private (self);
+
+  return priv->buildafter;
+}
+
+
+gboolean
+modulemd_component_has_buildafter (ModulemdComponent *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), FALSE);
+
+  ModulemdComponentPrivate *priv =
+    modulemd_component_get_instance_private (self);
+
+  return !!g_hash_table_size (priv->buildafter);
+}
+
+
 void
 modulemd_component_set_buildorder (ModulemdComponent *self, gint64 buildorder)
 {

--- a/modulemd/v2/modulemd-module-stream-v2.c
+++ b/modulemd/v2/modulemd-module-stream-v2.c
@@ -21,6 +21,7 @@
 #include "modulemd-profile.h"
 #include "modulemd-service-level.h"
 #include "private/modulemd-buildopts-private.h"
+#include "private/modulemd-component-private.h"
 #include "private/modulemd-component-rpm-private.h"
 #include "private/modulemd-component-module-private.h"
 #include "private/modulemd-dependencies-private.h"
@@ -792,6 +793,17 @@ modulemd_module_stream_v2_validate (ModulemdModuleStream *self, GError **error)
                    "Module license is missing");
       return FALSE;
     }
+
+  /* Verify that the components are consistent with regards to buildorder and
+   * buildafter values.
+   */
+  if (!modulemd_module_stream_validate_components (v2_self->rpm_components,
+                                                   &nested_error))
+    {
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return FALSE;
+    }
+
 
   /* Iterate through the artifacts and validate that they are in the proper
    * NEVRA format

--- a/modulemd/v2/tests/ModulemdTests/modulestream.py
+++ b/modulemd/v2/tests/ModulemdTests/modulestream.py
@@ -1097,6 +1097,38 @@ data:
                     stream.build_depends_on_stream(
                         'streamname', 'f30'), True)
 
+    def test_validate_buildafter(self):
+        # buildafter is supported only on v2
+
+        # Test a valid module stream with buildafter set
+        stream = Modulemd.ModuleStream.read_file(
+            "%s/modulemd/v2/tests/test_data/buildafter/good_buildafter.yaml" %
+            (os.getenv('MESON_SOURCE_ROOT')), True)
+
+        self.assertIsNotNone(stream)
+        self.assertTrue(stream.validate())
+
+        # Should fail validation if both buildorder and buildafter are set for
+        # the same component.
+        with self.assertRaisesRegex(gi.repository.GLib.GError, "Cannot mix buildorder and buildafter"):
+            stream = Modulemd.ModuleStream.read_file(
+                "%s/modulemd/v2/tests/test_data/buildafter/both_same_component.yaml" %
+                (os.getenv('MESON_SOURCE_ROOT')), True)
+
+        # Should fail validation if both buildorder and buildafter are set in
+        # different components of the same stream.
+        with self.assertRaisesRegex(gi.repository.GLib.GError, "Cannot mix buildorder and buildafter"):
+            stream = Modulemd.ModuleStream.read_file(
+                "%s/modulemd/v2/tests/test_data/buildafter/mixed_buildorder.yaml" %
+                (os.getenv('MESON_SOURCE_ROOT')), True)
+
+        # Should fail if a key specified in a buildafter set does not exist
+        # for this module stream.
+        with self.assertRaisesRegex(gi.repository.GLib.GError, "not found in components list"):
+            stream = Modulemd.ModuleStream.read_file(
+                "%s/modulemd/v2/tests/test_data/buildafter/invalid_key.yaml" %
+                (os.getenv('MESON_SOURCE_ROOT')), True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/modulemd/v2/tests/test_data/buildafter/both_same_component.yaml
+++ b/modulemd/v2/tests/test_data/buildafter/both_same_component.yaml
@@ -1,0 +1,60 @@
+---
+document: modulemd
+version: 2
+data:
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  dependencies:
+  - buildrequires:
+      platform: [ ]
+    requires:
+      platform: [ ]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      libuv:
+        rationale: Platform abstraction layer for Node.js
+        ref: 1
+      http-parser:
+        rationale: Needed for parsing HTTP requests
+        ref: master
+      nghttp2:
+        rationale: Needed for HTTP2 support
+        ref: master
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        ref: 10
+        buildorder: 30
+        buildafter:
+        - libuv
+        - http-parser
+        - nghttp2
+...

--- a/modulemd/v2/tests/test_data/buildafter/good_buildafter.yaml
+++ b/modulemd/v2/tests/test_data/buildafter/good_buildafter.yaml
@@ -1,0 +1,59 @@
+---
+document: modulemd
+version: 2
+data:
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  dependencies:
+  - buildrequires:
+      platform: [ ]
+    requires:
+      platform: [ ]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      libuv:
+        rationale: Platform abstraction layer for Node.js
+        ref: 1
+      http-parser:
+        rationale: Needed for parsing HTTP requests
+        ref: master
+      nghttp2:
+        rationale: Needed for HTTP2 support
+        ref: master
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        ref: 10
+        buildafter:
+        - libuv
+        - http-parser
+        - nghttp2
+...

--- a/modulemd/v2/tests/test_data/buildafter/invalid_key.yaml
+++ b/modulemd/v2/tests/test_data/buildafter/invalid_key.yaml
@@ -1,0 +1,60 @@
+---
+document: modulemd
+version: 2
+data:
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  dependencies:
+  - buildrequires:
+      platform: [ ]
+    requires:
+      platform: [ ]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      libuv:
+        rationale: Platform abstraction layer for Node.js
+        ref: 1
+      http-parser:
+        rationale: Needed for parsing HTTP requests
+        ref: master
+      nghttp2:
+        rationale: Needed for HTTP2 support
+        ref: master
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        ref: 10
+        buildafter:
+        - libuv
+        - http-parser
+        - nghttp2
+        - nosuchkey
+...

--- a/modulemd/v2/tests/test_data/buildafter/mixed_buildorder.yaml
+++ b/modulemd/v2/tests/test_data/buildafter/mixed_buildorder.yaml
@@ -1,0 +1,60 @@
+---
+document: modulemd
+version: 2
+data:
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  dependencies:
+  - buildrequires:
+      platform: [ ]
+    requires:
+      platform: [ ]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      libuv:
+        rationale: Platform abstraction layer for Node.js
+        ref: 1
+        buildorder: 10
+      http-parser:
+        rationale: Needed for parsing HTTP requests
+        ref: master
+        buildorder: 10
+      nghttp2:
+        rationale: Needed for HTTP2 support
+        ref: master
+        buildorder: 10
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        ref: 10
+        buildafter:
+          - libuv
+...

--- a/spec.v2.yaml
+++ b/spec.v2.yaml
@@ -271,6 +271,14 @@ data:
                 # is assumed.
                 # Optional.
                 ref: 26ca0c0
+                # Use the "buildafter" value to specify that this component
+                # must be be ordered later than some other entries in this map.
+                # The values of this array come from the keys of this map and
+                # not the real component name to enable bootstrapping.
+                # Use of both buildafter and buildorder in the same document is
+                # prohibited, as they will conflict.
+                # buildafter:
+                #    - baz
             # baz has no extra options
             baz:
                 rationale: This one is here to demonstrate other stuff.
@@ -301,6 +309,8 @@ data:
                 # In this example, bar, baz and xxx are built first in
                 # no particular order, then tagged into the buildroot,
                 # then, finally, xyz is built.
+                # Use of both buildafter and buildorder in the same document is
+                # prohibited, as they will conflict.
                 buildorder: 10
         # Module content of this module
         # Included modules are built in the shared buildroot, together with


### PR DESCRIPTION
Adds support for `buildafter` in components. These patches also add support for validation routines that ensure that `buildorder` and `buildafter` cannot be used together within the same `Modulemd.ModuleStream`.

Also includes a patch to fix a typo in the header documentation for `modulemd_component_set_buildorder()`.

This patch series includes tests for parsing and validating documents with correct and invalid usages of buildafter and buildorder. It's missing some more comprehensive tests for buildafter functionality on the `Modulemd.Component` objects directly, but I am planning to add that as an Outreachy task once this patch series is approved. (The common cases should be exercised by the validation tests included.)

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/96