### PR TITLE
ModuleIndex: add remove_module()

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
@@ -225,6 +225,24 @@ modulemd_module_index_get_module (ModulemdModuleIndex *self,
 
 
 /**
+ * modulemd_module_index_remove_module:
+ * @self: This #ModulemdModuleIndex
+ * @module_name: The name of the module to remove from the index.
+ *
+ * Remove a module, including all of its streams, its defaults and its
+ * translations from a #ModulemdModuleIndex.
+ *
+ * Returns: TRUE if the module name was present in the index. FALSE if it was
+ * not.
+ *
+ * Since: 2.2
+ */
+
+gboolean
+modulemd_module_index_remove_module (ModulemdModuleIndex *self,
+                                     const gchar *module_name);
+
+/**
  * modulemd_module_index_add_module_stream:
  * @self: This #ModulemdModuleIndex
  * @stream: The #ModulemdModuleStream to add to the index. The stream added

--- a/modulemd/v2/modulemd-module-index.c
+++ b/modulemd/v2/modulemd-module-index.c
@@ -587,6 +587,16 @@ modulemd_module_index_get_module (ModulemdModuleIndex *self,
 
 
 gboolean
+modulemd_module_index_remove_module (ModulemdModuleIndex *self,
+                                     const gchar *module_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
+
+  return g_hash_table_remove (self->modules, module_name);
+}
+
+
+gboolean
 modulemd_module_index_add_module_stream (ModulemdModuleIndex *self,
                                          ModulemdModuleStream *stream,
                                          GError **error)


### PR DESCRIPTION
Add the ability to remove an entire module - streams, defaults and
translations - from a ModuleIndex to support filtering out from
repo creation.

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/209

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>