### PR TITLE
Generate documentation in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
     #   via the "travis encrypt" command using the project repo's public key
     - secure: "mMcLLwYU0rAQkJDQEw3NlX5l1e1DCuUfCHDhhvku4YMgLbMV3ADvrTvwfnZoimgRhVw5hWXLDGSdJ2jkwAraeNHLjyfDXn/NrPNvo8xAgbtlsWaCO76p3yecfdIzawbW2iKpkyIjw8fCgi2xRccvp2ZTinDspiN96aqqZuhwy/5WzavQG+ECTxkFW6tDcly/NUyy/CH6FH6fqp6tswd+VsqKgZLqybhrwW1/OPBr5e+QvVyfn3KAlWWiyUCj33WU1mxL+LhsS2cNXK5S5V1NOO624oXPCy6oJImONWh0feXuPu20LqoWE/uOVXOcNpSB+3EUA5mfj22ST0FPMrvwS9k2oZGLiIVfDyGmI+Hl/kI4tlh/7zolpaeQB/c8GCGRBuEr+k0J0pqVp7ptOSIw3n6l4R113Sp+EBqSOcNxNVgOoW6pMZSKM73Z9tlr1yHVKw0cfge8YUgplGf0cENgExyjW97W535h2VEMKlgdH9PCQgfTXYANBVp2My+u6CytUetjdJXLwjmjuXBiAtIsrSTUtZ3hx/D1RXygAq0l7YI4iHQOmumSy81rgO2xDs484z/Efs6EXg/zdxluPSND6o/A0OXx80FUa6dwDmP6AmBZsHggVUYK7Gduu0Dry/1lcc2avZqdyOSrLs02vnQaRxb84CKFbhUd93gnVlPki3M="
 
+    # This is the DOC_TOKEN
+    - secure: gOGYwbzAQ4fVZ53AdppercJ0w4rA2XzuZK964c7v46qxD64VFqMSra4O/Bk+0A7hHw5jw1aSvKU/eqoJpOOXPfgT/yth8hJ7XmC7powQiw/Atj2/dcWsmCMxX03uefur8LHGQgNWN4W6lbWMdTyLKzmN0snx5A3zbwbfKYpF+d1gYaKrHO1ykeJHuOoIHDGop5Ur9Inl4S3o2U063Wg/YroTuIWvbEjL0Laz7knWuNpSN0g5G2cnF4y0DTDYxZWxFtnfB0npTDggUQqUTHNYrL+a9CPQc+/47FpmXXx0VxwqZ2l3BVO+a+ef5Q6g2VNxU/WJWdnFyRHAjWRKsyKua8zlOsmj+IVmM4nZDtyD0qlS8/nfdI+ZJS16IvKqyA2n9ScHe5YRsNPItd8c6y22nSKnRKlF2h+gWvD56pHUUHFMPlba0dJ7KMiIQZxmY6dKgzerkOylQziBgBMVulvxGz8KILj9+DxTANDlI+8LHt01bIXa4RbsNvOAcjFhNdNgemGv2uXcFyaVsg5w08PVSKb2pQimmB/EOBRSMMhavxOSaAgu/Jjs8xLPj+hMD/yZlav2dlx4Oix3x1humSUsegoa/Az6qulxK+rQdJJA3BuHk389s7e/i+z30KJsbpuIWxH1c/5ETtUFeIflQBYywr++5GqLG7T8WfVxH3ie3aw=
 jobs:
   include:
     - name: "Fedora 28"
@@ -31,3 +33,5 @@ jobs:
       script: ./.travis/travis-fedora.sh
     - name: "CentOS 7"
       script: ./.travis/travis-centos.sh
+    - name: "Documentation Update"
+      script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./travis/travis-docs.sh; fi'

--- a/.travis/docs/Dockerfile
+++ b/.travis/docs/Dockerfile
@@ -1,0 +1,12 @@
+FROM fedora-modularity/libmodulemd-deps-rawhide
+
+MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
+
+RUN dnf -y --setopt=install_weak_deps=False install rsync \
+    && dnf -y clean all
+
+ARG TARBALL
+
+ADD $TARBALL /builddir/
+
+ENTRYPOINT /builddir/.travis/docs/travis-tasks.sh

--- a/.travis/docs/travis-tasks.sh
+++ b/.travis/docs/travis-tasks.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+#Exit on failures
+set -e
+
+set -x
+
+os_name=Fedora}
+release=rawhide}
+
+pushd /builddir/
+
+# Build the v1 and v2 code under GCC and run standard tests
+meson --buildtype=debug \
+      -Dbuild_api_v1=false \
+      -Dbuild_api_v2=true \
+      $COMMON_MESON_ARGS \
+      doc-generation
+
+set +e
+ninja -C doc-generation modulemd-2.0-doc
+err=$?
+if [ $err != 0 ]; then
+    cat doc-generation/meson-logs/testlog.txt
+    exit $err
+fi
+set -e
+
+git clone https://sgallagher:$DOC_TOKEN@github.com/fedora-modularity/fedora-modularity.github.io
+rsync -avh --delete-before --no-perms --omit-dir-times /builddir/doc-generation/modulemd/v2/html/* fedora-modularity.github.io/libmodulemd/latest
+
+pushd fedora-modularity.github.io
+
+git add libmodulemd/latest
+
+# Check to see if there are any changes
+set +e
+git commit -m "Updating libmodulemd docs for $TRAVIS_COMMIT" --dry-run
+err=$?
+if [ $err = 0 ]; then
+    set -e
+    git config user.name "Travis CI"
+    git config user.email "sgallagh@redhat.com"
+    git commit -m "Updating libmodulemd docs for $TRAVIS_COMMIT"
+    git push origin master
+fi
+set -e
+
+popd #fedora-modularity.github.io
+
+popd #builddir

--- a/.travis/fedora/travis-tasks.sh
+++ b/.travis/fedora/travis-tasks.sh
@@ -25,8 +25,10 @@ meson --buildtype=debug \
 
 set +e
 ninja -C travis test
-if [ $? != 0 ]; then
-    cat travis_v1/meson-logs/testlog.txt
+ret=$?
+if [ $ret != 0 ]; then
+    cat travis/meson-logs/testlog.txt
+    exit $ret
 fi
 set -e
 

--- a/.travis/travis-docs.sh
+++ b/.travis/travis-docs.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $SCRIPT_DIR
+
+set -e
+set -x
+
+JOB_NAME=${TRAVIS_JOB_NAME:-Fedora rawhide}
+
+# Always generate the docs on Fedora Rawhide
+os_name=Fedora
+release=rawhide
+
+# Create an archive of the current checkout
+TARBALL_PATH=`mktemp -p $SCRIPT_DIR tarball-XXXXXX.tar.bz2`
+TARBALL=`basename $TARBALL_PATH`
+
+pushd $SCRIPT_DIR/..
+git ls-files |xargs tar cfj $TARBALL_PATH .git
+popd
+
+repository="registry.fedoraproject.org"
+os="fedora"
+
+sed -e "s/@IMAGE@/$repository\/$os:$release/" \
+    $SCRIPT_DIR/fedora/Dockerfile.deps.tmpl > $SCRIPT_DIR/fedora/Dockerfile.deps.$release
+
+sudo docker build -f $SCRIPT_DIR/fedora/Dockerfile.deps.$release -t fedora-modularity/libmodulemd-deps-$release .
+sudo docker build -f $SCRIPT_DIR/docs/Dockerfile -t fedora-modularity/libmodulemd-docs --build-arg TARBALL=$TARBALL .
+
+rm -f $TARBALL_PATH $SCRIPT_DIR/fedora/Dockerfile.deps.$release $SCRIPT_DIR/fedora/Dockerfile-$release
+
+# Override the standard tasks with the doc-generation
+docker run \
+    -e COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN \
+    -e TRAVIS=$TRAVIS \
+    -e TRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" \
+    -e TRAVIS_COMMIT="$TRAVIS_COMMIT" \
+    -e DOC_TOKEN="$DOC_TOKEN" \
+    --rm fedora-modularity/libmodulemd-docs
+
+popd
+exit 0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 C Library for manipulating module metadata files
 
 Full details can be found in the
-[API Documentation](https://sgallagh.fedorapeople.org/docs/libmodulemd/latest/)
+[API Documentation](https://fedora-modularity.github.io/libmodulemd/latest/)
 
 # Using libmodulemd from Python
 


### PR DESCRIPTION
Use Travis CI to build and publish the upstream libmodulemd docs to https://fedora-modularity.github.io/libmodulemd/latest/

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>