### PR TITLE
Fixes #243: Eliminate typecasting warning for modulemd_hash_table_equals()

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-util.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-util.h
@@ -77,6 +77,9 @@ GHashTable *
 modulemd_hash_table_deep_str_str_set_copy (GHashTable *orig);
 
 gboolean
+modulemd_hash_table_sets_are_equal_wrapper (const void *a, const void *b);
+
+gboolean
 modulemd_hash_table_sets_are_equal (GHashTable *a, GHashTable *b);
 
 gboolean

--- a/modulemd/v2/modulemd-defaults-v1.c
+++ b/modulemd/v2/modulemd-defaults-v1.c
@@ -73,7 +73,7 @@ modulemd_defaults_v1_equals (ModulemdDefaults *self_1,
   /*Check profile_defaults: size, keys, values*/
   if (!modulemd_hash_table_equals (v1_self_1->profile_defaults,
                                    v1_self_2->profile_defaults,
-                                   modulemd_hash_table_sets_are_equal))
+                                   modulemd_hash_table_sets_are_equal_wrapper))
     {
       return FALSE;
     }
@@ -89,7 +89,7 @@ modulemd_defaults_v1_equals (ModulemdDefaults *self_1,
   /*Check intent_default_profiles: size, keys, values*/
   if (!modulemd_hash_table_equals (v1_self_1->intent_default_profiles,
                                    v1_self_2->intent_default_profiles,
-                                   modulemd_hash_table_sets_are_equal))
+                                   modulemd_hash_table_sets_are_equal_wrapper))
     {
       return FALSE;
     }

--- a/modulemd/v2/modulemd-util.c
+++ b/modulemd/v2/modulemd-util.c
@@ -134,6 +134,11 @@ modulemd_hash_table_deep_str_str_set_copy (GHashTable *orig)
   return new;
 }
 
+gboolean
+modulemd_hash_table_sets_are_equal_wrapper (const void *a, const void *b)
+{
+  return modulemd_hash_table_sets_are_equal ((GHashTable *)a, (GHashTable *)b);
+}
 
 gboolean
 modulemd_hash_table_sets_are_equal (GHashTable *a, GHashTable *b)
@@ -218,7 +223,6 @@ modulemd_hash_table_equals (GHashTable *a,
 
   return TRUE;
 }
-
 
 gint
 modulemd_strcmp_sort (gconstpointer a, gconstpointer b)


### PR DESCRIPTION
Fixes #243 

Now I'm getting this warning  :- 

```
/modulemd/v2/modulemd-util.c: In function ‘modulemd_hash_table_sets_are_equal_wrapper’:
../modulemd/v2/modulemd-util.c:140:10: warning: returning ‘gboolean’ {aka ‘int’} from a function with return type ‘GEqualFunc’ {aka ‘int (*)(const void *, const void *)’} makes pointer from integer without a cast [-Wint-conversion]
   return modulemd_hash_table_sets_are_equal ((GHashTable *)a, (GHashTable *)b);
```
But `GEqualFunc` has a `gboolean` return type as well. Also, how is it working for `g_compare_string` and not for this?

Btw, I did cast `modulemd_hash_table_sets_are_equal ()` to `GEqualFunc` but that gave a whole new set of warnings.