### PR TITLE
Add 'buildonly' option to Components

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-component.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-component.h
@@ -103,6 +103,31 @@ modulemd_component_get_buildafter_as_strv (ModulemdComponent *self);
 
 
 /**
+ * modulemd_component_set_buildonly:
+ * @self: This #ModulemdComponent object
+ * @buildonly: Whether this component is used only for building this module. If
+ * set to TRUE, the build system should add any artifacts produced by this
+ * component to the data.filters section of the output modulemd.
+ *
+ * Since: 2.2
+ */
+void
+modulemd_component_set_buildonly (ModulemdComponent *self, gboolean buildonly);
+
+
+/**
+ * modulemd_component_get_buildonly:
+ * @self: This #ModulemdComponent object
+ *
+ * Returns: TRUE if this component is used only for building this module.
+ *
+ * Since: 2.2
+ */
+gboolean
+modulemd_component_get_buildonly (ModulemdComponent *self);
+
+
+/**
  * modulemd_component_set_buildorder:
  * @self: This #ModulemdComponent object
  * @buildorder: The order this component should be built relative to others.

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-component-private.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-component-private.h
@@ -44,6 +44,22 @@ modulemd_component_parse_buildafter (ModulemdComponent *self,
                                      GError **error);
 
 /**
+ * modulemd_component_parse_buildonly:
+ * @self: This #ModulemdComponent
+ * @emitter: (inout): A libyaml emitter object positioned just after the
+ * "buildonly" key in a #ModulemdComponent section of a YAML document.
+ * @error: (out): A #GError that will return the reason for a parse failure.
+ *
+ * Returns: TRUE if the buildafter list could be parsed successfully.
+ *
+ * Since: 2.2
+ */
+gboolean
+modulemd_component_parse_buildonly (ModulemdComponent *self,
+                                    yaml_parser_t *parser,
+                                    GError **error);
+
+/**
  * modulemd_component_has_buildafter:
  * @self: This #ModulemdComponent
  *
@@ -87,18 +103,19 @@ modulemd_component_emit_yaml_start (ModulemdComponent *self,
                                     GError **error);
 
 /**
- * modulemd_component_emit_yaml_buildorder:
+ * modulemd_component_emit_yaml_build_common:
  * @self: This #ModulemdComponent
- * @emitter: (inout): A libyaml emitter object positioned where a Component
- * buildorder item should appear in the YAML document.
+ * @emitter: (inout): A libyaml emitter object positioned where a Component's
+ * buildorder, buildafter and/or buildonly item(s) should appear in the YAML
+ * document.
  * @error: (out): A #GError that will return the reason for an emission error.
  *
- * Returns: TRUE if the component buildorder was emitted succesfully. FALSE and sets
- * @error appropriately if the YAML could not be emitted.
+ * Returns: TRUE if the component buildorder was emitted succesfully. FALSE and
+ * sets @error appropriately if the YAML could not be emitted.
  *
- * Since: 2.0
+ * Since: 2.2
  */
 gboolean
-modulemd_component_emit_yaml_buildorder (ModulemdComponent *self,
-                                         yaml_emitter_t *emitter,
-                                         GError **error);
+modulemd_component_emit_yaml_build_common (ModulemdComponent *self,
+                                           yaml_emitter_t *emitter,
+                                           GError **error);

--- a/modulemd/v2/include/modulemd-2.0/private/modulemd-yaml.h
+++ b/modulemd/v2/include/modulemd-2.0/private/modulemd-yaml.h
@@ -293,6 +293,22 @@ modulemd_yaml_parse_string (yaml_parser_t *parser, GError **error);
 
 
 /**
+ * modulemd_yaml_parse_bool:
+ * @parser: (inout): A libyaml parser object positioned at the beginning of a
+ * int64 scalar entry.
+ * @error: (out): A #GError that will return the reason for a parsing or
+ * validation error.
+ *
+ * Returns: A boolean representing the parsed value. Returns FALSE if a parse
+ * error occured and sets @error appropriately.
+ *
+ * Since: 2.2
+ */
+gboolean
+modulemd_yaml_parse_bool (yaml_parser_t *parser, GError **error);
+
+
+/**
  * modulemd_yaml_parse_int64:
  * @parser: (inout): A libyaml parser object positioned at the beginning of a
  * int64 scalar entry.

--- a/modulemd/v2/modulemd-component-module.c
+++ b/modulemd/v2/modulemd-component-module.c
@@ -245,7 +245,7 @@ modulemd_component_module_emit_yaml (ModulemdComponentModule *self,
         return FALSE;
     }
 
-  if (!modulemd_component_emit_yaml_buildorder (
+  if (!modulemd_component_emit_yaml_build_common (
         MODULEMD_COMPONENT (self), emitter, error))
     return FALSE;
 
@@ -336,6 +336,19 @@ modulemd_component_module_parse_yaml (yaml_parser_t *parser,
 
               modulemd_component_module_set_ref (m, value);
               g_clear_pointer (&value, g_free);
+            }
+          else if (g_str_equal ((const gchar *)event.data.scalar.value,
+                                "buildonly"))
+            {
+              if (!modulemd_component_parse_buildonly (
+                    MODULEMD_COMPONENT (m), parser, &nested_error))
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse buildonly in component: %s",
+                    nested_error->message);
+                }
             }
           else if (g_str_equal ((const gchar *)event.data.scalar.value,
                                 "buildorder"))

--- a/modulemd/v2/modulemd-component-rpm.c
+++ b/modulemd/v2/modulemd-component-rpm.c
@@ -417,7 +417,7 @@ modulemd_component_rpm_emit_yaml (ModulemdComponentRpm *self,
 
   EMIT_KEY_VALUE_IF_SET (emitter, error, "ref", self->ref);
 
-  if (!modulemd_component_emit_yaml_buildorder (
+  if (!modulemd_component_emit_yaml_build_common (
         MODULEMD_COMPONENT (self), emitter, error))
     return FALSE;
 
@@ -605,6 +605,19 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
                     error,
                     event,
                     "Failed to parse buildafter in component: %s",
+                    nested_error->message);
+                }
+            }
+          else if (g_str_equal ((const gchar *)event.data.scalar.value,
+                                "buildonly"))
+            {
+              if (!modulemd_component_parse_buildonly (
+                    MODULEMD_COMPONENT (r), parser, &nested_error))
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse buildonly in component: %s",
                     nested_error->message);
                 }
             }

--- a/modulemd/v2/modulemd-yaml-util.c
+++ b/modulemd/v2/modulemd-yaml-util.c
@@ -392,6 +392,35 @@ modulemd_yaml_parse_string (yaml_parser_t *parser, GError **error)
 }
 
 
+gboolean
+modulemd_yaml_parse_bool (yaml_parser_t *parser, GError **error)
+{
+  MMD_INIT_YAML_EVENT (event);
+
+  YAML_PARSER_PARSE_WITH_EXIT_BOOL (parser, &event, error);
+  if (event.type != YAML_SCALAR_EVENT)
+    {
+      MMD_YAML_ERROR_EVENT_EXIT_INT (
+        error, event, "Expected a scalar boolean");
+    }
+
+  if (g_strcmp0 ((const gchar *)event.data.scalar.value, "false"))
+    {
+      return FALSE;
+    }
+  else if (g_strcmp0 ((const gchar *)event.data.scalar.value, "true"))
+    {
+      return TRUE;
+    }
+
+  MMD_YAML_ERROR_EVENT_EXIT_INT (
+    error,
+    event,
+    "Boolean value was neither \"true\" nor \"false\": %s",
+    (const gchar *)event.data.scalar.value);
+}
+
+
 gint64
 modulemd_yaml_parse_int64 (yaml_parser_t *parser, GError **error)
 {

--- a/modulemd/v2/tests/test-modulemd-modulestream.c
+++ b/modulemd/v2/tests/test-modulemd-modulestream.c
@@ -522,6 +522,7 @@ module_stream_v2_test_parse_dump (ModuleStreamFixture *fixture,
     "        repository: https://pagure.io/bar.git\n"
     "        cache: https://example.com/cache\n"
     "        ref: 26ca0c0\n"
+    "        buildonly: true\n"
     "      baz:\n"
     "        rationale: This one is here to demonstrate other stuff.\n"
     "      xxx:\n"

--- a/spec.v2.yaml
+++ b/spec.v2.yaml
@@ -279,6 +279,12 @@ data:
                 # prohibited, as they will conflict.
                 # buildafter:
                 #    - baz
+                # Use the "buildonly" value to indicate that all artifacts
+                # produced by this component are intended only for building
+                # this component and should be automatically added to the
+                # data.filter.rpms list after the build is complete.
+                # Optional. Defaults to "false" if not specified.
+                buildonly: false
             # baz has no extra options
             baz:
                 rationale: This one is here to demonstrate other stuff.


### PR DESCRIPTION
Fixes: https://github.com/fedora-modularity/libmodulemd/issues/95

Also adds a utility function to parse boolean values from the modulemd YAML.

When emitting, we will omit the `buildonly` field only if it is `TRUE` for backwards-compatibility.