### PR TITLE
Fixes #216: Provide Modulemd.Dependencies.equals() method

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-dependencies.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-dependencies.h
@@ -41,6 +41,22 @@ modulemd_dependencies_new (void);
 
 
 /**
+ * modulemd_dependencies_equals:
+ * @self_1: A #ModulemdDependencies
+ * @self_2: A #ModulemdDependencies
+ *
+ * Check if self_1 and self_2 are equal objects
+ *
+ * Returns: TRUE, if the're equal. FALSE, otherwise.
+ *
+ * Since: 2.2
+ */
+gboolean
+modulemd_dependencies_equals (ModulemdDependencies *self_1,
+                              ModulemdDependencies *self_2);
+
+
+/**
  * modulemd_dependencies_copy:
  * @self: This #ModulemdDependencies
  *

--- a/modulemd/v2/modulemd-dependencies.c
+++ b/modulemd/v2/modulemd-dependencies.c
@@ -24,7 +24,14 @@ struct _ModulemdDependencies
 {
   GObject parent_instance;
 
+  /* @key: dependent modules.
+   * @value: GHashTable set of compatible streams
+   */
   GHashTable *buildtime_deps;
+
+  /* @key: dependent modules.
+   * @value: GHashTable set of compatible streams
+   */
   GHashTable *runtime_deps;
 };
 
@@ -34,6 +41,33 @@ ModulemdDependencies *
 modulemd_dependencies_new (void)
 {
   return g_object_new (MODULEMD_TYPE_DEPENDENCIES, NULL);
+}
+
+
+gboolean
+modulemd_dependencies_equals (ModulemdDependencies *self_1,
+                              ModulemdDependencies *self_2)
+{
+  if (!self_1 && !self_2)
+    return TRUE;
+
+  if (!self_1 || !self_2)
+    return FALSE;
+
+  g_return_val_if_fail (MODULEMD_IS_DEPENDENCIES (self_1), FALSE);
+  g_return_val_if_fail (MODULEMD_IS_DEPENDENCIES (self_2), FALSE);
+
+  if (!modulemd_hash_table_equals (self_1->buildtime_deps,
+                                   self_2->buildtime_deps,
+                                   modulemd_hash_table_sets_are_equal_wrapper))
+    return FALSE;
+
+  if (!modulemd_hash_table_equals (self_1->runtime_deps,
+                                   self_2->runtime_deps,
+                                   modulemd_hash_table_sets_are_equal_wrapper))
+    return FALSE;
+
+  return TRUE;
 }
 
 

--- a/modulemd/v2/tests/test-modulemd-dependencies.c
+++ b/modulemd/v2/tests/test-modulemd-dependencies.c
@@ -133,6 +133,174 @@ dependencies_test_dependencies (DependenciesFixture *fixture,
 
 
 static void
+dependencies_test_equals (DependenciesFixture *fixture,
+                          gconstpointer user_data)
+{
+  g_autoptr (ModulemdDependencies) d_1 = NULL;
+  g_autoptr (ModulemdDependencies) d_2 = NULL;
+
+  /*With no hashtables*/
+  d_1 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_1);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_1));
+
+  d_2 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_2);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_2));
+
+  g_assert_true (modulemd_dependencies_equals (d_1, d_2));
+  g_clear_object (&d_1);
+  g_clear_object (&d_2);
+
+  /*With same buildtime_stream hashtables*/
+  d_1 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_1);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_1));
+  modulemd_dependencies_add_buildtime_stream (d_1, "buildmod1", "stream2");
+  modulemd_dependencies_add_buildtime_stream (d_1, "buildmod1", "stream1");
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
+    d_1, "builddef");
+
+  d_2 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_2);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_2));
+  modulemd_dependencies_add_buildtime_stream (d_2, "buildmod1", "stream2");
+  modulemd_dependencies_add_buildtime_stream (d_2, "buildmod1", "stream1");
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
+    d_2, "builddef");
+
+  g_assert_true (modulemd_dependencies_equals (d_1, d_2));
+  g_clear_object (&d_1);
+  g_clear_object (&d_2);
+
+  /*With different buildtime_stream hashtables*/
+  d_1 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_1);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_1));
+  modulemd_dependencies_add_buildtime_stream (d_1, "buildmod1", "stream2");
+  modulemd_dependencies_add_buildtime_stream (d_1, "buildmod1", "stream1");
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
+    d_1, "builddef");
+
+  d_2 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_2);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_2));
+  modulemd_dependencies_add_buildtime_stream (d_2, "buildmod1", "stream2");
+  modulemd_dependencies_add_buildtime_stream (d_2, "buildmod1", "stream1");
+  modulemd_dependencies_add_buildtime_stream (d_2, "buildmod1", "stream3");
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
+    d_2, "builddef");
+
+  g_assert_false (modulemd_dependencies_equals (d_1, d_2));
+  g_clear_object (&d_1);
+  g_clear_object (&d_2);
+
+  /*With same runtime_stream hashtables*/
+  d_1 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_1);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_1));
+  modulemd_dependencies_add_runtime_stream (d_1, "runmod1", "stream3");
+  modulemd_dependencies_add_runtime_stream (d_1, "runmod1", "stream4");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d_1,
+                                                                   "rundef");
+
+  d_2 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_2);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_2));
+  modulemd_dependencies_add_runtime_stream (d_2, "runmod1", "stream3");
+  modulemd_dependencies_add_runtime_stream (d_2, "runmod1", "stream4");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d_2,
+                                                                   "rundef");
+
+  g_assert_true (modulemd_dependencies_equals (d_1, d_2));
+  g_clear_object (&d_1);
+  g_clear_object (&d_2);
+
+  /*With different runtime_stream hashtables*/
+  d_1 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_1);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_1));
+  modulemd_dependencies_add_runtime_stream (d_1, "runmod1", "stream3");
+  modulemd_dependencies_add_runtime_stream (d_1, "runmod1", "stream4");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d_1,
+                                                                   "rundef");
+
+  d_2 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_2);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_2));
+  modulemd_dependencies_add_runtime_stream (d_2, "runmod1", "stream3");
+  modulemd_dependencies_add_runtime_stream (d_2, "runmod1", "stream4");
+  modulemd_dependencies_add_runtime_stream (d_2, "runmod1", "stream5");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d_2,
+                                                                   "rundef");
+
+  g_assert_false (modulemd_dependencies_equals (d_1, d_2));
+  g_clear_object (&d_1);
+  g_clear_object (&d_2);
+
+  /*With same bulidtime_stream and runtime_stream hashtables*/
+  d_1 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_1);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_1));
+  modulemd_dependencies_add_buildtime_stream (d_1, "buildmod1", "stream2");
+  modulemd_dependencies_add_buildtime_stream (d_1, "buildmod1", "stream1");
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
+    d_1, "builddef");
+  modulemd_dependencies_add_runtime_stream (d_1, "runmod1", "stream3");
+  modulemd_dependencies_add_runtime_stream (d_1, "runmod1", "stream4");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d_1,
+                                                                   "rundef");
+
+  d_2 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_2);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_2));
+  modulemd_dependencies_add_buildtime_stream (d_2, "buildmod1", "stream2");
+  modulemd_dependencies_add_buildtime_stream (d_2, "buildmod1", "stream1");
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
+    d_2, "builddef");
+  modulemd_dependencies_add_runtime_stream (d_2, "runmod1", "stream3");
+  modulemd_dependencies_add_runtime_stream (d_2, "runmod1", "stream4");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d_2,
+                                                                   "rundef");
+
+  g_assert_true (modulemd_dependencies_equals (d_1, d_2));
+  g_clear_object (&d_1);
+  g_clear_object (&d_2);
+
+  /*With different bulidtime_stream and same runtime_stream hashtables*/
+  d_1 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_1);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_1));
+  modulemd_dependencies_add_buildtime_stream (d_1, "buildmod1", "stream2");
+  modulemd_dependencies_add_buildtime_stream (d_1, "buildmod1", "stream1");
+  modulemd_dependencies_add_buildtime_stream (d_1, "buildmod1", "stream8");
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
+    d_1, "builddef");
+  modulemd_dependencies_add_runtime_stream (d_1, "runmod1", "stream3");
+  modulemd_dependencies_add_runtime_stream (d_1, "runmod1", "stream4");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d_1,
+                                                                   "rundef");
+
+  d_2 = modulemd_dependencies_new ();
+  g_assert_nonnull (d_2);
+  g_assert_true (MODULEMD_IS_DEPENDENCIES (d_2));
+  modulemd_dependencies_add_buildtime_stream (d_2, "buildmod1", "stream2");
+  modulemd_dependencies_add_buildtime_stream (d_2, "buildmod1", "stream1");
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
+    d_2, "builddef");
+  modulemd_dependencies_add_runtime_stream (d_2, "runmod1", "stream3");
+  modulemd_dependencies_add_runtime_stream (d_2, "runmod1", "stream4");
+  modulemd_dependencies_add_runtime_stream (d_2, "runmod1", "stream5");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d_2,
+                                                                   "rundef");
+
+  g_assert_false (modulemd_dependencies_equals (d_1, d_2));
+  g_clear_object (&d_1);
+  g_clear_object (&d_2);
+}
+
+
+static void
 dependencies_test_copy (DependenciesFixture *fixture, gconstpointer user_data)
 {
   g_autoptr (ModulemdDependencies) d = NULL;
@@ -380,6 +548,13 @@ main (int argc, char *argv[])
               NULL,
               NULL,
               dependencies_test_dependencies,
+              NULL);
+
+  g_test_add ("/modulemd/v2/dependencies/equals",
+              DependenciesFixture,
+              NULL,
+              NULL,
+              dependencies_test_equals,
               NULL);
 
   g_test_add ("/modulemd/v2/dependencies/copy",


### PR DESCRIPTION
Fixes #216 

This is my error log:
```
/home/orionstar25/libmodulemd/api2/modulemd/v2/dependencies_v2:8907): 
libmodulemd-WARNING **: 15:31:18.568: Streams requested for unknown module: buildmod1** 
libmodulemd:ERROR:../modulemd/v2/tests/test-modulemd-dependencies.c:194:dependencies_test_equals: 
'modulemd_dependencies_equals (d_1, d_2)' should be FALSE
```

I tried the individual assertions and turns out that the `modulemd_dependencies_add_buildtime_stream (d_1, "buildmod1", "stream2");` is not even adding any streams but directly going to `modulemd_dependencies_set_empty_buildtime_dependencies_for_module (d_1, "builddef");` 