### PR TITLE
Add Modulemd.ModuleIndex.update_from_custom()

### DIFF
--- a/modulemd/v2/modulemd-module-index.c
+++ b/modulemd/v2/modulemd-module-index.c
@@ -537,6 +537,29 @@ modulemd_module_index_update_from_stream (ModulemdModuleIndex *self,
 }
 
 
+gboolean
+modulemd_module_index_update_from_custom (ModulemdModuleIndex *self,
+                                          ModulemdReadHandler custom_read_fn,
+                                          void *custom_pvt_data,
+                                          gboolean strict,
+                                          GPtrArray **failures,
+                                          GError **error)
+{
+  if (*failures == NULL)
+    *failures = g_ptr_array_new_full (0, g_object_unref);
+
+  g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
+  g_return_val_if_fail (custom_read_fn, FALSE);
+
+  MMD_INIT_YAML_PARSER (parser);
+
+  yaml_parser_set_input (&parser, custom_read_fn, custom_pvt_data);
+
+  return modulemd_module_index_update_from_parser (
+    self, &parser, strict, FALSE, failures, error);
+}
+
+
 gchar *
 modulemd_module_index_dump_to_string (ModulemdModuleIndex *self,
                                       GError **error)


### PR DESCRIPTION
In order to support YAML streams from arbitrary sources (such as those
being read from a compressed file through an intermediate library), we
need to support reading from a custom function. This patch enables
consumers of libmodulemd to have indirect access to libyaml's
yaml_parser_set_input() to accomplish this.

Adds a basic test to read through a long string and verify that it
produced an index with the read module.

Related: https://github.com/fedora-modularity/libmodulemd/issues/208

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>