### PR TITLE
rpmspec: require python-six for python bindings

### DIFF
--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -51,6 +51,7 @@ more details.
 Summary: Python 2 bindings for %{name}
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: python-gobject-base
+Requires: python-six
 Obsoletes: python2-modulemd < 1.3.4
 
 %description -n python2-%{name}
@@ -62,6 +63,7 @@ Python 3 bindings for %{name}
 Summary: Python 3 bindings for %{name}
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: python3-gobject-base
+Requires: %{py3_dist six}
 Obsoletes: python3-modulemd < 1.3.4
 
 %description -n python3-%{name}


### PR DESCRIPTION
Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>