### PR TITLE
Don't reinstall up to date packages for Arch Linux CI

### DIFF
--- a/.travis/archlinux/Dockerfile.deps.tmpl
+++ b/.travis/archlinux/Dockerfile.deps.tmpl
@@ -4,7 +4,7 @@ MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
 ARG TARBALL
 
-RUN pacman -Syu --noconfirm \
+RUN pacman -Syu --needed --noconfirm \
 	base-devel \
 	glib2 \
 	gobject-introspection \


### PR DESCRIPTION
Hi,

Here is a small optimization to gain a few seconds when running Arch Linux CI.

Regards.