### PR TITLE
Add Module.remove_stream_by_NSVCA()

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module.h
@@ -149,6 +149,44 @@ modulemd_module_get_stream_by_NSVCA (ModulemdModule *self,
 
 
 /**
+ * modulemd_module_remove_streams_by_NSVCA:
+ * @self: This #ModulemdModule object
+ * @stream_name: (not nullable): The name of the stream to remove
+ * @version: The version of the stream to remove. If set to zero, matches all
+ * versions.
+ * @context: (nullable): The context of the stream to remove. If NULL, matches
+ * all stream contexts.
+ * @arch: (nullable): The processor architecture of the stream to remove. If
+ * NULL, matches all architectures.
+ *
+ * Remove one or more #ModulemdModuleStream objects from this #ModulemdModule
+ * that match the provided parameters.
+ *
+ * Since: 2.3
+ */
+void
+modulemd_module_remove_streams_by_NSVCA (ModulemdModule *self,
+                                         const gchar *stream_name,
+                                         const guint64 version,
+                                         const gchar *context,
+                                         const gchar *arch);
+
+
+/**
+ * modulemd_module_remove_streams_by_name:
+ * @self: This #ModulemdModule object
+ * @stream_name: (not nullable): The name of the stream to remove
+ *
+ * Remove one or more #ModulemdModuleStream objects from this #ModulemdModule
+ * that match the provided stream name.
+ *
+ * Since: 2.3
+ */
+#define modulemd_module_remove_streams_by_name(self, stream_name)             \
+  modulemd_module_remove_streams_by_NSVCA (self, stream_name, 0, NULL, NULL)
+
+
+/**
  * modulemd_module_get_defaults:
  * @self: This #ModulemdModule object
  *

--- a/modulemd/v2/meson.build
+++ b/modulemd/v2/meson.build
@@ -92,12 +92,12 @@ install_headers(
 # Test env with release values
 test_release_env = environment()
 test_release_env.set('LC_ALL', 'C')
-test_release_env.set('G_MESSAGES_DEBUG', 'all')
 test_release_env.set ('MESON_SOURCE_ROOT', meson.source_root())
 
 # Test env with fatal warnings and criticals
 test_env = test_release_env
 test_env.set('G_DEBUG', 'fatal-warnings,fatal-criticals')
+test_env.set('G_MESSAGES_DEBUG', 'all')
 
 # Python test env with fatal warnings and criticals
 py_test_env = test_env

--- a/modulemd/v2/modulemd-module-index.c
+++ b/modulemd/v2/modulemd-module-index.c
@@ -814,7 +814,11 @@ modulemd_module_index_upgrade_defaults (ModulemdModuleIndex *self,
 
       /* Skip any module without defaults */
       if (!defaults)
-        continue;
+        {
+          g_clear_object (&module);
+          continue;
+        }
+
       g_object_ref (defaults);
 
       returned_mdversion = modulemd_module_set_defaults (

--- a/modulemd/v2/modulemd-module.c
+++ b/modulemd/v2/modulemd-module.c
@@ -486,7 +486,7 @@ modulemd_module_get_stream_by_NSVCA (ModulemdModule *self,
 
       if (arch &&
           g_strcmp0 (modulemd_module_stream_get_arch (under_consideration),
-                     context) != 0)
+                     arch) != 0)
         continue;
 
       g_ptr_array_add (matching_streams, under_consideration);

--- a/modulemd/v2/modulemd-module.c
+++ b/modulemd/v2/modulemd-module.c
@@ -514,6 +514,91 @@ modulemd_module_get_stream_by_NSVCA (ModulemdModule *self,
 }
 
 
+typedef struct _modulemd_nsvca
+{
+  const gchar *stream_name;
+  guint64 version;
+  const gchar *context;
+  const gchar *arch;
+} modulemd_nsvca;
+
+
+static void
+modulemd_nsvca_free (gpointer nsvca)
+{
+  /* All of the fields are just pointers to static data,
+   * so nothing to free here.
+   */
+
+  g_free ((modulemd_nsvca *)nsvca);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (modulemd_nsvca, modulemd_nsvca_free);
+
+
+static gboolean
+match_nsvca (gconstpointer haystraw, gconstpointer needle)
+{
+  ModulemdModuleStream *stream = (ModulemdModuleStream *)haystraw;
+  modulemd_nsvca *nsvca = (modulemd_nsvca *)needle;
+
+  if (!g_str_equal (nsvca->stream_name,
+                    modulemd_module_stream_get_stream_name (stream)))
+    return FALSE;
+
+  if (nsvca->version)
+    {
+      if (nsvca->version != modulemd_module_stream_get_version (stream))
+        return FALSE;
+    }
+
+  if (nsvca->context)
+    {
+      if (!g_str_equal (nsvca->context,
+                        modulemd_module_stream_get_context (stream)))
+        return FALSE;
+    }
+
+  if (nsvca->arch)
+    {
+      if (!g_str_equal (nsvca->arch, modulemd_module_stream_get_arch (stream)))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+
+void
+modulemd_module_remove_streams_by_NSVCA (ModulemdModule *self,
+                                         const gchar *stream_name,
+                                         const guint64 version,
+                                         const gchar *context,
+                                         const gchar *arch)
+{
+  gboolean found = FALSE;
+  guint index;
+  g_autoptr (modulemd_nsvca) nsvca = g_malloc0_n (1, sizeof (modulemd_nsvca));
+
+  nsvca->stream_name = stream_name;
+  nsvca->version = version;
+  nsvca->context = context;
+  nsvca->arch = arch;
+
+  /* Iterate through the streams and remove any that match the requested
+   * parameters
+   */
+  do
+    {
+      found = g_ptr_array_find_with_equal_func (
+        self->streams, nsvca, match_nsvca, &index);
+      if (found)
+        g_ptr_array_remove_index (self->streams, index);
+    }
+  while (found);
+}
+
+
 void
 modulemd_module_add_translation (ModulemdModule *self,
                                  ModulemdTranslation *translation)

--- a/modulemd/v2/modulemd-yaml-util.c
+++ b/modulemd/v2/modulemd-yaml-util.c
@@ -944,7 +944,7 @@ modulemd_yaml_emit_variant (yaml_emitter_t *emitter,
     {
       EMIT_SEQUENCE_START (emitter, error);
       g_variant_iter_init (&iter, variant);
-      while (g_variant_iter_next (&iter, "v", &value))
+      while ((value = g_variant_iter_next_value (&iter)))
         {
           if (!modulemd_yaml_emit_variant (emitter, value, error))
             return FALSE;

--- a/modulemd/v2/tests/test-modulemd-merger.c
+++ b/modulemd/v2/tests/test-modulemd-merger.c
@@ -52,7 +52,7 @@ merger_test_deduplicate (CommonMmdTestFixture *fixture,
   g_autofree gchar *deduplicated = NULL;
 
   yaml_path =
-    g_strdup_printf ("%s/modulemd/v2/tests/test_data/long-valid.yaml",
+    g_strdup_printf ("%s/modulemd/v2/tests/test_data/f29-updates.yaml",
                      g_getenv ("MESON_SOURCE_ROOT"));
 
   index = modulemd_module_index_new ();

--- a/modulemd/v2/tests/test_data/long-valid.yaml
+++ b/modulemd/v2/tests/test_data/long-valid.yaml
@@ -219,6 +219,10 @@ data:
           stream: f28
           filtered_rpms: []
           version: 4
+      mbs_options:
+        blocked_pacakges:
+        - blocked1
+        - blocked2
   dependencies:
   - buildrequires:
       platform: [f28]


### PR DESCRIPTION
While adding tests for `Module.remove_stream_by_NSVCA()`, I discovered two other bugs that needed to be fixed to get this working. I also added a simple patch to reduce the size of the test logs, since they were getting enormous.

Patch 0001: I discovered that XMD sections that contained lists of scalars could be read properly, but would fail to output correctly. This has been fixed.

Patch 0002: Only do the full debug output for the debug configurations of the tests, not the release configurations. This reduces the test logs by half their previous size.

Patch 0003: Fixed a bug in deduplication caused by a copy-paste error. Extending the test to catch such cases also revealed a subtle memory-leak which is fixed in the same patch.

Patch 0004: Add `Module.remove_stream_by_NSVCA()`