### PR TITLE
Fix the syntax in the single module stream Python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ string variables named 'module_name' and 'stream_name', respectively.
 ## Python
 ```python
 stream = Modulemd.ModuleStream.read_file ('/path/to/module_name.yaml',
+                                          True,
                                           module_name,
                                           stream_name)
 v2_stream = stream.upgrade(Modulemd.ModuleStreamVersion.TWO)

--- a/modulemd/v2/include/modulemd-2.0/modulemd.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd.h
@@ -162,6 +162,7 @@ G_BEGIN_DECLS
  *
  * |[<!-- language="Python" -->
  * stream = Modulemd.ModuleStream.read_file ('/path/to/module_name.yaml',
+ *                                           True,
  *                                           module_name,
  *                                           stream_name)
  * v2_stream = stream.upgrade(Modulemd.ModuleStreamVersion.TWO)


### PR DESCRIPTION
This will prevent further confusion like in the issue #273