### PR TITLE
ModuleStreamV2: add clear_dependencies() and remove_dependencies()

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
@@ -716,6 +716,34 @@ modulemd_module_stream_v2_add_dependencies (ModulemdModuleStreamV2 *self,
 
 
 /**
+ * modulemd_module_stream_v2_clear_dependencies:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Empties the list of dependencies for this #ModulemdModuleStream
+ *
+ * Since: 2.4
+ */
+void
+modulemd_module_stream_v2_clear_dependencies (ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_remove_dependencies:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @deps: (in): A #ModulemdDependencies object to remove from the list for this
+ * module stream.
+ *
+ * Removes all entries matching @deps from the array of #ModulemdDependencies
+ * objects.
+ *
+ * Since: 2.4
+ */
+void
+modulemd_module_stream_v2_remove_dependencies (ModulemdModuleStreamV2 *self,
+                                               ModulemdDependencies *deps);
+
+
+/**
  * modulemd_module_stream_v2_get_dependencies:
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *

--- a/modulemd/v2/modulemd-module-stream-v2.c
+++ b/modulemd/v2/modulemd-module-stream-v2.c
@@ -777,6 +777,38 @@ modulemd_module_stream_v2_replace_dependencies (ModulemdModuleStreamV2 *self,
 }
 
 
+void
+modulemd_module_stream_v2_clear_dependencies (ModulemdModuleStreamV2 *self)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_ptr_array_set_size (self->dependencies, 0);
+}
+
+
+static gboolean
+dep_equal_wrapper (gconstpointer a, gconstpointer b)
+{
+  return modulemd_dependencies_equals ((ModulemdDependencies *)a,
+                                       (ModulemdDependencies *)b);
+}
+
+
+void
+modulemd_module_stream_v2_remove_dependencies (ModulemdModuleStreamV2 *self,
+                                               ModulemdDependencies *deps)
+{
+  guint index;
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  while (g_ptr_array_find_with_equal_func (
+    self->dependencies, deps, dep_equal_wrapper, &index))
+    {
+      g_ptr_array_remove_index (self->dependencies, index);
+    }
+}
+
+
 GPtrArray *
 modulemd_module_stream_v2_get_dependencies (ModulemdModuleStreamV2 *self)
 {

--- a/modulemd/v2/tests/ModulemdTests/modulestream.py
+++ b/modulemd/v2/tests/ModulemdTests/modulestream.py
@@ -514,6 +514,17 @@ class TestModuleStream(TestBase):
         assert 'bar' in stream.get_dependencies(
         )[0].get_runtime_modules()
 
+        retrieved_deps = stream.get_dependencies()
+        stream.clear_dependencies()
+        self.assertEquals(len(retrieved_deps), 1)
+        self.assertEquals(len(stream.get_dependencies()), 0)
+
+        stream.add_dependencies(deps)
+        self.assertEquals(len(stream.get_dependencies()), 1)
+
+        stream.remove_dependencies(deps)
+        self.assertEquals(len(stream.get_dependencies()), 0)
+
     def test_xmd(self):
         if '_overrides_module' in dir(Modulemd):
             # The XMD python tests can only be run against the installed lib


### PR DESCRIPTION
Adds two new methods to make management of dependencies on a stream
simpler.

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/286

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>