### PR TITLE
Fix the Python bindings for get_xmd when the xmd value is None

### DIFF
--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -129,6 +129,8 @@ if float(Modulemd._version) >= 2:
 
         def get_xmd(self):
             variant_xmd = super(ModuleStreamV2, self).get_xmd()
+            if variant_xmd is None:
+                return {}
             return variant_xmd.unpack()
 
     ModuleStreamV2 = override(ModuleStreamV2)
@@ -143,6 +145,8 @@ if float(Modulemd._version) >= 2:
 
         def get_xmd(self):
             variant_xmd = super(ModuleStreamV1, self).get_xmd()
+            if variant_xmd is None:
+                return {}
             return variant_xmd.unpack()
 
     ModuleStreamV1 = override(ModuleStreamV1)

--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -26,8 +26,6 @@
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 
-import gi
-
 from ..module import get_introspection_module
 from ..overrides import override
 

--- a/modulemd/v2/tests/ModulemdTests/modulestream.py
+++ b/modulemd/v2/tests/ModulemdTests/modulestream.py
@@ -532,6 +532,8 @@ class TestModuleStream(TestBase):
             # must be installed in /usr/lib/python*/site-packages/gi/overrides
             # or they are not included when importing Modulemd
             stream = Modulemd.ModuleStreamV2.new()
+            # An empty dictionary should be returned if no xmd value is set
+            assert stream.get_xmd() == {}
 
             xmd = {'outer_key': ['scalar', {'inner_key': 'another_scalar'}]}
 


### PR DESCRIPTION
This will prevent the Python bindings from calling `unpack()` on `None` when xmd is not set and `get_xmd` is called.