### PR TITLE
Fix issues with XMD handling

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v1.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v1.h
@@ -817,7 +817,7 @@ modulemd_module_stream_v1_get_runtime_requirement_stream (
 /**
  * modulemd_module_stream_v1_set_xmd:
  * @self: (in): This #ModulemdModuleStreamV1 object.
- * @xmd: (in) (transfer full): A #GVariant representing arbitrary YAML.
+ * @xmd: (in) (transfer none): A #GVariant representing arbitrary YAML.
  *
  * Sets the eXtensible MetaData (XMD) for this module. XMD is arbitrary YAML
  * data that will be set and returned as-is (with the exception that the

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
@@ -759,7 +759,7 @@ modulemd_module_stream_v2_get_dependencies (ModulemdModuleStreamV2 *self);
 /**
  * modulemd_module_stream_v2_set_xmd:
  * @self: (in): This #ModulemdModuleStreamV2 object.
- * @xmd: (in) (transfer full): A #GVariant representing arbitrary YAML.
+ * @xmd: (in) (transfer none): A #GVariant representing arbitrary YAML.
  *
  * Sets the eXtensible MetaData (XMD) for this module. XMD is arbitrary YAML
  * data that will be set and returned as-is (with the exception that the

--- a/modulemd/v2/modulemd-module-stream-v1.c
+++ b/modulemd/v2/modulemd-module-stream-v1.c
@@ -860,6 +860,10 @@ modulemd_module_stream_v1_set_xmd (ModulemdModuleStreamV1 *self, GVariant *xmd)
 {
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
+  /* Do nothing if we were passed the same pointer */
+  if (self->xmd == xmd)
+    return;
+
   g_clear_pointer (&self->xmd, g_variant_unref);
   self->xmd = modulemd_variant_deep_copy (xmd);
 }
@@ -1068,8 +1072,7 @@ modulemd_module_stream_v1_copy (ModulemdModuleStream *self,
   COPY_HASHTABLE_BY_VALUE_ADDER (
     copy, v1_self, servicelevels, modulemd_module_stream_v1_add_servicelevel);
 
-  if (v1_self->xmd != NULL)
-    modulemd_module_stream_v1_set_xmd (copy, v1_self->xmd);
+  STREAM_COPY_IF_SET (v1, copy, v1_self, xmd);
 
   return MODULEMD_MODULE_STREAM (g_steal_pointer (&copy));
 }

--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -502,7 +502,7 @@ modulemd_module_stream_upgrade_to_v2 (ModulemdModuleStream *from,
 
 
   if (v1_stream->xmd != NULL)
-    modulemd_module_stream_v2_set_xmd (copy, g_variant_ref (v1_stream->xmd));
+    modulemd_module_stream_v2_set_xmd (copy, v1_stream->xmd);
 
 
   /* Upgrade the Dependencies */

--- a/modulemd/v2/modulemd-yaml-util.c
+++ b/modulemd/v2/modulemd-yaml-util.c
@@ -957,8 +957,9 @@ modulemd_yaml_emit_variant (yaml_emitter_t *emitter,
       g_set_error (error,
                    MODULEMD_YAML_ERROR,
                    MODULEMD_YAML_ERROR_EMIT,
-                   "Unhandled variant type: \"%s\"",
-                   g_variant_get_type_string (variant));
+                   "Unhandled variant type: \"%s\": %s",
+                   g_variant_get_type_string (variant),
+                   g_variant_print (variant, TRUE));
       return FALSE;
     }
   return TRUE;

--- a/modulemd/v2/tests/test_data/290.yaml
+++ b/modulemd/v2/tests/test_data/290.yaml
@@ -1,0 +1,72 @@
+document: modulemd
+version: 1
+data:
+  name: testmodule
+  stream: master
+  version: 20180205135154
+  context: 9c690d0e
+  summary: A test module in all its beautiful beauty
+  description: This module demonstrates how to write simple modulemd files And can
+    be used for testing the build and release pipeline. ’
+  license:
+    module:
+    - MIT
+  dependencies:
+    buildrequires:
+      platform: f28
+    requires:
+      platform: f28
+  references:
+    community: https://docs.pagure.org/modularity/
+    documentation: https://fedoraproject.org/wiki/Fedora_Packaging_Guidelines_for_Modules
+  xmd:
+    mbs:
+      buildrequires:
+        platform:
+          filtered_rpms: []
+          ref: virtual
+          stream: f28
+          version: '3'
+          context: '00000000'
+      commit: 65a7721ee4eff44d2a63fb8f3a8da6e944ab7f4d
+      requires:
+        platform:
+          filtered_rpms: []
+          ref: virtual
+          stream: f28
+          version: '3'
+      rpms:
+        perl-List-Compare:
+          ref: ac0f3bccca9dcb8465c434ac4c38974bf6205c28
+        perl-Tangerine:
+          ref: 7e96446223f1ad84a26c7cf23d6591cd9f6326c6
+        tangerine:
+          ref: c0f9a7dbd8cf823a2bdc19eeeed20d22b0aa52bf
+      mse: true
+      scmurl: https://src.fedoraproject.org/modules/testmodule.git?#65a7721ee4eff44d2a63fb8f3a8da6e944ab7f4d
+  profiles:
+    default:
+      rpms:
+      - tangerine
+  api:
+    rpms:
+    - perl-Tangerine
+    - tangerine
+  components:
+    rpms:
+      perl-List-Compare:
+        rationale: A dependency of tangerine.
+        repository: https://src.fedoraproject.org/rpms/perl-List-Compare
+        ref: master
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-List-Compare
+      tangerine:
+        rationale: Provides API for this module.
+        buildorder: 10
+        repository: https://src.fedoraproject.org/rpms/tangerine
+        ref: master
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/tangerine
+      perl-Tangerine:
+        rationale: Provides API for this module and is a dependency of tangerine.
+        repository: https://src.fedoraproject.org/rpms/perl-Tangerine
+        ref: master
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/perl-Tangerine


### PR DESCRIPTION
Fix memory issues with XMD handling

This cleans up the usage of g_variant_ref_sink() and re-syncs the
StreamV1 and StreamV2 to both make a proper deep copy of the XMD
when setting it.

The overrides weren't creating the GVariant arrays and dictionaries
quite correctly. Also, the set_xmd() function had the input marked
as (transfer full), which was incorrect and causing refcounting
issues.

Fixes https://github.com/fedora-modularity/libmodulemd/issues/290

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>