### PR TITLE
Add Module.search_streams()

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module.h
@@ -121,6 +121,34 @@ modulemd_module_get_stream_by_NSVC (ModulemdModule *self,
 
 
 /**
+ * modulemd_module_search_streams:
+ * @self: This #ModulemdModule object
+ * @stream_name: The name of the stream to retrieve
+ * @version: The version of the stream to retrieve. If set to zero,
+ * the version is not included in the search.
+ * @context: (nullable): The context of the stream to retrieve. If NULL, the
+ * context is not included in the search.
+ * @arch: (nullable): The processor architecture of the stream to retrieve. If
+ * NULL, the architecture is not included in the search.
+ *
+ * Returns: (transfer full) (element-type ModulemdModuleStream): The list of
+ * stream objects matching the requested parameters. This function cannot
+ * fail, but it may return a zero-length list if no matches were found. The
+ * returned streams will be in a predictable order, sorted first by stream
+ * name, then by version (highest to lowest), then by context and finally by
+ * architecture.
+ *
+ * Since: 2.5
+ */
+GPtrArray *
+modulemd_module_search_streams (ModulemdModule *self,
+                                const gchar *stream_name,
+                                const guint64 version,
+                                const gchar *context,
+                                const gchar *arch);
+
+
+/**
  * modulemd_module_get_stream_by_NSVCA:
  * @self: This #ModulemdModule object
  * @stream_name: The name of the stream to retrieve

--- a/modulemd/v2/modulemd-module.c
+++ b/modulemd/v2/modulemd-module.c
@@ -394,11 +394,36 @@ modulemd_module_get_all_streams (ModulemdModule *self)
 static gint
 compare_streams (gconstpointer a, gconstpointer b)
 {
+  int cmp = 0;
+  guint64 a_ver, b_ver;
   ModulemdModuleStream *a_ = *(ModulemdModuleStream **)a;
   ModulemdModuleStream *b_ = *(ModulemdModuleStream **)b;
 
-  return modulemd_module_stream_get_version (b_) -
-         modulemd_module_stream_get_version (a_);
+  /* Sort alphabetically by stream name */
+  cmp = g_strcmp0 (modulemd_module_stream_get_stream_name (a_),
+                   modulemd_module_stream_get_stream_name (b_));
+  if (cmp != 0)
+    return cmp;
+
+  /* Sort by the version, highest first */
+  a_ver = modulemd_module_stream_get_version (a_);
+  b_ver = modulemd_module_stream_get_version (b_);
+  if (b_ver > a_ver)
+    return 1;
+  if (a_ver > b_ver)
+    return -1;
+
+  /* Sort alphabetically by context */
+  cmp = g_strcmp0 (modulemd_module_stream_get_context (a_),
+                   modulemd_module_stream_get_context (b_));
+  if (cmp != 0)
+    return cmp;
+
+  /* Sort alphabetically by architecture */
+  cmp = g_strcmp0 (modulemd_module_stream_get_arch (a_),
+                   modulemd_module_stream_get_arch (b_));
+
+  return cmp;
 }
 
 


### PR DESCRIPTION
Adds the ability to return a list of streams matching one or more SVCA search criteria.

Also refactors Module.get_streams_by_stream_name() and Module.get_stream_by_NSVCA() to use this function internally.

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/297

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>
