### PR TITLE
Add ModuleIndex.get_default_streams()

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
@@ -392,6 +392,29 @@ modulemd_module_index_add_defaults (ModulemdModuleIndex *self,
 
 
 /**
+ * modulemd_module_index_get_default_streams_as_hash_table: (rename-to modulemd_module_index_get_default_streams)
+ * @self: (in): This #ModulemdModuleIndex
+ * @intent: (in) (nullable): The name of the system intent whose default stream
+ * will be retrieved. If left NULL or the specified intent has no separate
+ * default, it will return the generic default stream for this module.
+ *
+ * Get a dictionary of all modules in the index that have a default stream.
+ *
+ * This function cannot fail, but may return an empty (non-NULL) GHashTable.
+ *
+ * Returns: (transfer container) (element-type utf8 utf8): A #GHashTable with
+ * the module name as the key and the default stream as the value for all
+ * modules with a default stream in the index. Modules without a default stream
+ * will not appear in this table.
+ *
+ * Since: 2.5
+ */
+GHashTable *
+modulemd_module_index_get_default_streams_as_hash_table (
+  ModulemdModuleIndex *self, const gchar *intent);
+
+
+/**
  * modulemd_module_index_add_translation:
  * @self: This #ModulemdModuleIndex
  * @translation: The #ModulemdTranslation object to add to the index.

--- a/modulemd/v2/include/private/gi-binding-renames.h
+++ b/modulemd/v2/include/private/gi-binding-renames.h
@@ -259,6 +259,14 @@ GStrv
 modulemd_module_index_get_module_names (ModulemdModuleIndex *self);
 
 /**
+ * modulemd_module_index_get_default_streams: (skip)
+ */
+GHashTable *
+modulemd_module_index_get_default_streams (ModulemdModuleIndex *self,
+                                           const gchar *intent);
+
+
+/**
  * modulemd_rpm_map_entry_get_nevra: (skip)
  */
 gchar *

--- a/modulemd/v2/tests/ModulemdTests/moduleindex.py
+++ b/modulemd/v2/tests/ModulemdTests/moduleindex.py
@@ -99,6 +99,23 @@ profiles:
             "obligatory lorem ipsum dolor sit amet goes right here.")
         self.assertEqual(stream.get_description("en_GB"), "An example module.")
 
+    def test_get_default_streams(self):
+        idx = Modulemd.ModuleIndex.new()
+        idx.update_from_file(path.join(self.source_root,
+                                       "modulemd/v2/tests/test_data/f29.yaml"),
+                             True)
+
+        default_streams = idx.get_default_streams()
+        self.assertIsNotNone(default_streams)
+
+        self.assertIn("dwm", default_streams.keys())
+        self.assertEquals("6.1", default_streams["dwm"])
+
+        self.assertIn("stratis", default_streams.keys())
+        self.assertEquals("1", default_streams["stratis"])
+
+        self.assertNotIn("nodejs", default_streams.keys())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This function adds an easy way to get the set of modules that have default
streams.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

CC: @puiterwijk @smooge