### PR TITLE
Fix XMD comparison

### DIFF
--- a/modulemd/v2/modulemd-module-stream-v1.c
+++ b/modulemd/v2/modulemd-module-stream-v1.c
@@ -1075,7 +1075,7 @@ modulemd_module_stream_v1_equals (ModulemdModuleStream *self_1,
   if (v1_self_1->xmd == NULL || v1_self_2->xmd == NULL)
     return FALSE;
 
-  if (g_variant_equal (v1_self_1->xmd, v1_self_2->xmd) != 0)
+  if (!g_variant_equal (v1_self_1->xmd, v1_self_2->xmd))
     return FALSE;
 
   return TRUE;

--- a/modulemd/v2/modulemd-module-stream-v2.c
+++ b/modulemd/v2/modulemd-module-stream-v2.c
@@ -231,7 +231,7 @@ modulemd_module_stream_v2_equals (ModulemdModuleStream *self_1,
   if (v2_self_1->xmd == NULL || v2_self_2->xmd == NULL)
     return FALSE;
 
-  if (g_variant_equal (v2_self_1->xmd, v2_self_2->xmd) != 0)
+  if (!g_variant_equal (v2_self_1->xmd, v2_self_2->xmd))
     return FALSE;
 
   return TRUE;


### PR DESCRIPTION
Comparison of the XMDs were accidentally returning the opposite
truth value.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

@OrionStar25 please review. I discovered this while working on https://github.com/fedora-modularity/libmodulemd/issues/188.