### PR TITLE
Check full stream equality when deduplicating

### DIFF
--- a/modulemd/v2/modulemd-module-stream-v1.c
+++ b/modulemd/v2/modulemd-module-stream-v1.c
@@ -1075,7 +1075,7 @@ modulemd_module_stream_v1_equals (ModulemdModuleStream *self_1,
   if (v1_self_1->xmd == NULL || v1_self_2->xmd == NULL)
     return FALSE;
 
-  if (g_variant_equal (v1_self_1->xmd, v1_self_2->xmd) != 0)
+  if (!g_variant_equal (v1_self_1->xmd, v1_self_2->xmd))
     return FALSE;
 
   return TRUE;

--- a/modulemd/v2/modulemd-module-stream-v2.c
+++ b/modulemd/v2/modulemd-module-stream-v2.c
@@ -231,7 +231,7 @@ modulemd_module_stream_v2_equals (ModulemdModuleStream *self_1,
   if (v2_self_1->xmd == NULL || v2_self_2->xmd == NULL)
     return FALSE;
 
-  if (g_variant_equal (v2_self_1->xmd, v2_self_2->xmd) != 0)
+  if (!g_variant_equal (v2_self_1->xmd, v2_self_2->xmd))
     return FALSE;
 
   return TRUE;

--- a/modulemd/v2/modulemd-module.c
+++ b/modulemd/v2/modulemd-module.c
@@ -329,10 +329,17 @@ modulemd_module_add_stream (ModulemdModule *self,
        * favor of the new one.
        */
 
-      /* TODO: Do a full equality check on the two ModuleStreams once
-       * https://github.com/fedora-modularity/libmodulemd/issues/186 is
-       * fixed.
-       */
+      if (!modulemd_module_stream_equals (old, stream))
+        {
+          /* The two streams have matching NSVCA, but differ in content */
+          g_set_error (error,
+                       MODULEMD_ERROR,
+                       MODULEMD_ERROR_VALIDATE,
+                       "Encountered two streams with matching NSVCA %s but "
+                       "differing content",
+                       modulemd_module_stream_get_NSVCA_as_string (stream));
+          return MD_MODULESTREAM_VERSION_ERROR;
+        }
 
       /* First, drop the existing stream */
       g_ptr_array_remove (self->streams, old);

--- a/modulemd/v2/tests/test-modulemd-merger.c
+++ b/modulemd/v2/tests/test-modulemd-merger.c
@@ -90,8 +90,8 @@ merger_test_deduplicate (CommonMmdTestFixture *fixture,
 
   /* Resolve the merge, which should deduplicate all entries */
   merged_index = modulemd_module_index_merger_resolve (merger, &error);
+  g_assert_no_error (error);
   g_assert_nonnull (merged_index);
-  g_assert_null (error);
 
   deduplicated = modulemd_module_index_dump_to_string (merged_index, &error);
   g_assert_nonnull (deduplicated);


### PR DESCRIPTION
Previously, we assumed that any two streams having the same NSVCA
were identical. Now we can actually test for full equality before
dropping one while deduplicating. Note that this will result in a
hard failure if they aren't identical, because this means that the
enabled repositories are providing conflicting data.

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/188

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

@Conan-Kudo Can I get your opinion on whether it's acceptable to treat this as a hard failure? In the unlikely event that two repositories (or the same repository) are providing two `modulemd` documents with the same NSVCA but different content elsewhere, I don't think there's any fail-safe way to pick one over another, so I think our only option is to return an error.

Also includes a dependent fix being tracked and reviewed in https://github.com/fedora-modularity/libmodulemd/pull/303