### PR TITLE
Fix transfer type for Module.search_streams()

### DIFF
--- a/modulemd/common/tests/test-dirty.py
+++ b/modulemd/common/tests/test-dirty.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import git
+import subprocess
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -29,6 +30,8 @@ repo = git.Repo(script_dir,
 if (repo.is_dirty()):
     print("Autoformatter was not run before submitting. Please run "
           "`ninja test`, amend the commit and resubmit this pull request.")
+    res = subprocess.run(['git', 'diff'], capture_output=True, text=True)
+    print(res.stdout, file=sys.stderr)
     sys.exit(os.EX_USAGE)
 
 sys.exit(os.EX_OK)

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -231,6 +231,7 @@ test_v2_python_scripts = files(
     'v2/tests/ModulemdTests/defaultsv1.py',
     'v2/tests/ModulemdTests/dependencies.py',
     'v2/tests/ModulemdTests/merger.py',
+    'v2/tests/ModulemdTests/module.py',
     'v2/tests/ModulemdTests/moduleindex.py',
     'v2/tests/ModulemdTests/modulestream.py',
     'v2/tests/ModulemdTests/profile.py',

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module.h
@@ -131,8 +131,8 @@ modulemd_module_get_stream_by_NSVC (ModulemdModule *self,
  * @arch: (nullable): The processor architecture of the stream to retrieve. If
  * NULL, the architecture is not included in the search.
  *
- * Returns: (transfer full) (element-type ModulemdModuleStream): The list of
- * stream objects matching the requested parameters. This function cannot
+ * Returns: (transfer container) (element-type ModulemdModuleStream): The list
+ * of stream objects matching the requested parameters. This function cannot
  * fail, but it may return a zero-length list if no matches were found. The
  * returned streams will be in a predictable order, sorted first by stream
  * name, then by version (highest to lowest), then by context and finally by

--- a/modulemd/v2/meson.build
+++ b/modulemd/v2/meson.build
@@ -392,6 +392,22 @@ test ('dependencies_python2_release', python2,
       env : py_test_release_env,
       args : dependencies_python_script)
 
+# -- Test Modulemd.Module (Python) -- #
+module_python_script = files('tests/ModulemdTests/module.py')
+test ('module_python3_debug', python3,
+      env : py_test_env,
+      args : module_python_script)
+test ('module_python3_release', python3,
+      env : py_test_release_env,
+      args : module_python_script)
+
+test ('module_python2_debug', python2,
+      env : py_test_env,
+      args : module_python_script)
+test ('module_python2_release', python2,
+      env : py_test_release_env,
+      args : module_python_script)
+
 # -- Test Modulemd.ModuleIndex (Python) -- #
 moduleindex_python_script = files('tests/ModulemdTests/moduleindex.py')
 test ('moduleindex_python3_debug', python3,
@@ -401,7 +417,6 @@ test ('moduleindex_python3_release', python3,
       env : py_test_release_env,
       args : moduleindex_python_script)
 
-moduleindex_python_script = files('tests/ModulemdTests/moduleindex.py')
 test ('moduleindex_python2_debug', python2,
       env : py_test_env,
       args : moduleindex_python_script)

--- a/modulemd/v2/tests/ModulemdTests/module.py
+++ b/modulemd/v2/tests/ModulemdTests/module.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+
+# This file is part of libmodulemd
+# Copyright (C) 2017-2018 Stephen Gallagher
+#
+# Fedora-License-Identifier: MIT
+# SPDX-2.0-License-Identifier: MIT
+# SPDX-3.0-License-Identifier: MIT
+#
+# This program is free software.
+# For more information on the license, see COPYING.
+# For more information on free software, see
+# <https://www.gnu.org/philosophy/free-sw.en.html>.
+
+from os import path
+import sys
+try:
+    import unittest
+    import gi
+    gi.require_version('Modulemd', '2.0')
+    from gi.repository import Modulemd
+    from gi.repository.Modulemd import ModuleIndex
+    from gi.repository import GLib
+except ImportError:
+    # Return error 77 to skip this test on platforms without the necessary
+    # python modules
+    sys.exit(77)
+
+from base import TestBase
+
+
+class TestModule(TestBase):
+
+    def test_search_streams(self):
+        idx = Modulemd.ModuleIndex.new()
+        idx.update_from_file(path.join(self.source_root,
+                                       "modulemd/v2/tests/test_data/f29.yaml"),
+                             True)
+        module = idx.get_module('nodejs')
+
+        self.assertEquals(len(module.search_streams('8', 0)), 1)
+        self.assertEquals(len(module.search_streams('10', 0)), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Technically this is an API-breaking change, but no one is using it
yet and it was always expected to be managed this way.

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/308

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>