### PR TITLE
Doc link fixes

### DIFF
--- a/modulemd/v1/include/modulemd-1.0/modulemd-component-rpm.h
+++ b/modulemd/v1/include/modulemd-1.0/modulemd-component-rpm.h
@@ -51,9 +51,9 @@ modulemd_component_rpm_new (void);
 
 /**
  * modulemd_component_rpm_set_arches:
- * @arches: (nullable): a #ModuleSimpleSet: A set of architectures on which this RPM
- * package should be available. An empty set means  the package is available
- * on all supported architectures.
+ * @arches: (nullable): a #ModulemdSimpleSet: A set of architectures on which
+ * this RPM package should be available. An empty set means the package is
+ * available on all supported architectures.
  *
  * Since: 1.0
  */
@@ -163,9 +163,9 @@ modulemd_component_rpm_dup_cache (ModulemdComponentRpm *self);
 
 /**
  * modulemd_component_rpm_set_multilib:
- * @multilib: (nullable): a #ModuleSimpleSet: A set of architectures on which this RPM
- * package should be available as multilib. An empty set means the package is
- * not available as multilib on any architecture.
+ * @multilib: (nullable): a #ModulemdSimpleSet: A set of architectures on which
+ * this RPM package should be available as multilib. An empty set means the
+ * package is not available as multilib on any architecture.
  *
  * Since: 1.0
  */

--- a/modulemd/v1/include/modulemd-1.0/modulemd-modulestream.h
+++ b/modulemd/v1/include/modulemd-1.0/modulemd-modulestream.h
@@ -365,8 +365,8 @@ modulemd_modulestream_peek_community (ModulemdModuleStream *self);
 
 /**
  * modulemd_modulestream_set_content_licenses:
- * @licenses: (nullable) (transfer none): A #ModuleSimpleSet: The licenses under
- * which the components of this module are released.
+ * @licenses: (nullable) (transfer none): A #ModulemdSimpleSet: The licenses
+ * under which the components of this module are released.
  *
  * Sets the content_licenses property.
  *
@@ -744,8 +744,8 @@ modulemd_modulestream_peek_module_components (ModulemdModuleStream *self);
 
 /**
  * modulemd_modulestream_set_module_licenses:
- * @licenses: (transfer none) (nullable): A #ModuleSimpleSet: The licenses under
- * which the components of this module are released.
+ * @licenses: (transfer none) (nullable): A #ModulemdSimpleSet: The licenses
+ * under which the components of this module are released.
  *
  * Sets the module_licenses property.
  *
@@ -940,8 +940,8 @@ modulemd_modulestream_peek_requires (ModulemdModuleStream *self);
 
 /**
  * modulemd_modulestream_set_rpm_api:
- * @apis: (transfer none) (nullable): A #ModuleSimpleSet: The set of binary RPM
- * packages that form the public API for this module.
+ * @apis: (transfer none) (nullable): A #ModulemdSimpleSet: The set of binary
+ * RPM packages that form the public API for this module.
  *
  * Sets the rpm_api property.
  *
@@ -984,9 +984,9 @@ modulemd_modulestream_peek_rpm_api (ModulemdModuleStream *self);
 
 /**
  * modulemd_modulestream_set_rpm_artifacts:
- * @artifacts: (transfer none) (nullable): A #ModuleSimpleSet: The set of binary
- * RPM packages that are contained in this module. Generally populated by the
- * module build service.
+ * @artifacts: (transfer none) (nullable): A #ModulemdSimpleSet: The set of
+ * binary RPM packages that are contained in this module. Generally populated
+ * by the module build service.
  *
  * Sets the rpm_artifacts property.
  *
@@ -1095,7 +1095,7 @@ modulemd_modulestream_peek_rpm_components (ModulemdModuleStream *self);
 
 /**
  * modulemd_modulestream_set_rpm_filter:
- * @filter: (transfer none) (nullable): A #ModuleSimpleSet: The set of binary
+ * @filter: (transfer none) (nullable): A #ModulemdSimpleSet: The set of binary
  * RPM packages that are explicitly filtered out of this module.
  *
  * Sets the rpm_artifacts property.

--- a/modulemd/v1/include/modulemd-1.0/modulemd-profile.h
+++ b/modulemd/v1/include/modulemd-1.0/modulemd-profile.h
@@ -175,7 +175,8 @@ modulemd_profile_dup_name (ModulemdProfile *self);
 
 /**
  * modulemd_profile_set_rpms:
- * @rpms: (nullable): A #ModuleSimpleSet: The rpms to be installed by this profile.
+ * @rpms: (nullable): A #ModulemdSimpleSet: The rpms to be installed by this
+ * profile.
  *
  * Assigns the set of RPMs that will be installed when this profile is
  * activated.

--- a/modulemd/v1/modulemd-module.c
+++ b/modulemd/v1/modulemd-module.c
@@ -372,8 +372,8 @@ modulemd_module_dup_community (ModulemdModule *self)
 
 /**
  * modulemd_module_set_content_licenses:
- * @licenses: (nullable): A #ModuleSimpleSet: The licenses under which the components of
- * this module are released.
+ * @licenses: (nullable): A #ModulemdSimpleSet: The licenses under which the
+ * components of this module are released.
  *
  * Sets the content_licenses property.
  *
@@ -1005,8 +1005,8 @@ modulemd_module_dup_module_components (ModulemdModule *self)
 
 /**
  * modulemd_module_set_module_licenses:
- * @licenses: (nullable): A #ModuleSimpleSet: The licenses under which the components of
- * this module are released.
+ * @licenses: (nullable): A #ModulemdSimpleSet: The licenses under which the
+ * components of this module are released.
  *
  * Sets the module_licenses property.
  *
@@ -1344,8 +1344,8 @@ modulemd_module_dup_requires (ModulemdModule *self)
 
 /**
  * modulemd_module_set_rpm_api:
- * @apis: (nullable): A #ModuleSimpleSet: The set of binary RPM packages that form the
- * public API for this module.
+ * @apis: (nullable): A #ModulemdSimpleSet: The set of binary RPM packages that
+ * form the public API for this module.
  *
  * Sets the rpm_api property.
  *
@@ -1420,8 +1420,9 @@ modulemd_module_dup_rpm_api (ModulemdModule *self)
 
 /**
  * modulemd_module_set_rpm_artifacts:
- * @artifacts: (nullable): A #ModuleSimpleSet: The set of binary RPM packages that are
- * contained in this module. Generally populated by the module build service.
+ * @artifacts: (nullable): A #ModulemdSimpleSet: The set of binary RPM packages
+ * that are contained in this module. Generally populated by the module build
+ * service.
  *
  * Sets the rpm_artifacts property.
  *
@@ -1726,8 +1727,8 @@ modulemd_module_dup_rpm_components (ModulemdModule *self)
 
 /**
  * modulemd_module_set_rpm_filter:
- * @filter: (nullable): A #ModuleSimpleSet: The set of binary RPM packages that are
- * explicitly filtered out of this module.
+ * @filter: (nullable): A #ModulemdSimpleSet: The set of binary RPM packages
+ * that are explicitly filtered out of this module.
  *
  * Sets the rpm_artifacts property.
  *

--- a/modulemd/v2/include/modulemd-2.0/modulemd-buildopts.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-buildopts.h
@@ -32,7 +32,8 @@ G_DECLARE_FINAL_TYPE (
 /**
  * modulemd_buildopts_new:
  *
- * Returns: (transfer full): A newly-allocated #ModuleBuildopts. This object must be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModulemdBuildopts. This object
+ * must be freed with g_object_unref().
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd-defaults.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-defaults.h
@@ -29,6 +29,7 @@ G_BEGIN_DECLS
 /**
  * ModulemdDefaultsVersionEnum:
  * @MD_DEFAULTS_VERSION_ERROR: Represents an error handling mdversion.
+ * @MD_DEFAULTS_VERSION_UNSET: Represents an unset mdversion.
  * @MD_DEFAULTS_VERSION_ONE: Represents v1 of the #ModulemdDefaults metadata
  * format.
  * @MD_DEFAULTS_VERSION_LATEST: Represents the highest-supported version of the

--- a/modulemd/v2/include/modulemd-2.0/modulemd-defaults.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-defaults.h
@@ -29,10 +29,10 @@ G_BEGIN_DECLS
 /**
  * ModulemdDefaultsVersionEnum:
  * @MD_DEFAULTS_VERSION_ERROR: Represents an error handling mdversion.
- * @MD_DEFAULTS_VERSION_ONE: Represents v1 of the #Modulemd.Defaults metadata
+ * @MD_DEFAULTS_VERSION_ONE: Represents v1 of the #ModulemdDefaults metadata
  * format.
  * @MD_DEFAULTS_VERSION_LATEST: Represents the highest-supported version of the
- * #Modulemd.Defaults metadata format.
+ * #ModulemdDefaults metadata format.
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd-dependencies.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-dependencies.h
@@ -32,7 +32,8 @@ G_DECLARE_FINAL_TYPE (
 /**
  * modulemd_dependencies_new:
  *
- * Returns: (transfer full): A newly-allocated #ModuleDependencies. This object must be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModulemdDependencies. This
+ * object must be freed with g_object_unref().
  *
  * Since: 2.0
  */
@@ -88,7 +89,7 @@ modulemd_dependencies_add_buildtime_stream (ModulemdDependencies *self,
 
 /**
  * modulemd_dependencies_set_empty_buildtime_dependencies_for_module:
- * @self: This #ModuleDependencies
+ * @self: This #ModulemdDependencies
  * @module_name: The name of the module to add dependencies on.
  *
  * Adds a module and inserts an empty list for it as buildtime dependency.
@@ -102,9 +103,9 @@ modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
 
 /**
  * modulemd_dependencies_clear_buildtime_dependencies:
- * @self: This #ModuleDependencies
+ * @self: This #ModulemdDependencies
  *
- * Remove all buildtime dependencies from this @ModulemdDependencies object
+ * Remove all buildtime dependencies from this #ModulemdDependencies object
  *
  * Since 2.5
  */
@@ -158,7 +159,7 @@ modulemd_dependencies_add_runtime_stream (ModulemdDependencies *self,
 
 /**
  * modulemd_dependencies_set_empty_runtime_dependencies_for_module:
- * @self: This #ModuleDependencies
+ * @self: This #ModulemdDependencies
  * @module_name: The name of the module to add dependencies on.
  *
  * Adds a module and inserts an empty list for it as runtime dependency.
@@ -172,9 +173,9 @@ modulemd_dependencies_set_empty_runtime_dependencies_for_module (
 
 /**
  * modulemd_dependencies_clear_runtime_dependencies:
- * @self: This #ModuleDependencies
+ * @self: This #ModulemdDependencies
  *
- * Remove all runtime dependencies from this @ModulemdDependencies object
+ * Remove all runtime dependencies from this #ModulemdDependencies object
  *
  * Since 2.5
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index-merger.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index-merger.h
@@ -119,8 +119,8 @@ modulemd_module_index_merger_new (void);
 /**
  * modulemd_module_index_merger_associate_index:
  * @self: (in): This #ModulemdModuleIndexMerger object.
- * @index: (in) (transfer none): A #ModuleIndex, usually constructed by reading
- * the module metadata from a repository with
+ * @index: (in) (transfer none): A #ModulemdModuleIndex, usually constructed by
+ * reading the module metadata from a repository with
  * modulemd_module_index_update_from_file(),
  * modulemd_module_index_update_from_string(), or
  * `modulemd_module_index_update_from_stream()`. This function take a reference

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
@@ -354,14 +354,14 @@ modulemd_module_index_remove_module (ModulemdModuleIndex *self,
  * @error: (out): A #GError containing the reason the #ModulemdModuleStream
  * object could not be added or NULL if the function succeeded.
  *
- * Add a #ModuleStream to the #ModuleIndex. While being added, the
- * #ModuleStream will be upgraded to MD_MODULESTREAM_VERSION_LATEST to ensure
- * that merges done with #ModulemdModuleIndexMerger will always occur between
- * streams of the same version. If this upgrade cannot be performed, the
- * function will return @error set appropriately.
+ * Add a #ModulemdModuleStream to the #ModulemdModuleIndex. While being added,
+ * the #ModulemdModuleStream will be upgraded to MD_MODULESTREAM_VERSION_LATEST
+ * to ensure that merges done with #ModulemdModuleIndexMerger will always occur
+ * between streams of the same version. If this upgrade cannot be performed,
+ * the function will return @error set appropriately.
  *
- * Returns: TRUE if the #ModulemdModule was added succesfully. If the stream
- * already existed in the index, it will be replaced by the new one. On
+ * Returns: TRUE if the #ModulemdModuleStream was added succesfully. If the
+ * stream already existed in the index, it will be replaced by the new one. On
  * failure, returns FALSE and sets @error appropriately.
  *
  * Since: 2.0

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v1.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v1.h
@@ -89,7 +89,7 @@ modulemd_module_stream_v1_get_arch (ModulemdModuleStreamV1 *self);
 /**
  * modulemd_module_stream_v1_set_buildopts:
  * @self: (in): This #ModulemdModuleStreamV1 object.
- * @buildopts: (in) (transfer none): A #ModulemdBuildOpts object describing
+ * @buildopts: (in) (transfer none): A #ModulemdBuildopts object describing
  * build options that apply globally to components in this module.
  *
  * Set build options for this module's components.

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
@@ -90,7 +90,7 @@ modulemd_module_stream_v2_get_arch (ModulemdModuleStreamV2 *self);
 /**
  * modulemd_module_stream_v2_set_buildopts:
  * @self: (in): This #ModulemdModuleStreamV2 object.
- * @buildopts: (in) (transfer none): A #ModulemdBuildOpts object describing
+ * @buildopts: (in) (transfer none): A #ModulemdBuildopts object describing
  * build options that apply globally to components in this module.
  *
  * Set build options for this module's components.

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream.h
@@ -31,6 +31,9 @@ G_BEGIN_DECLS
 
 /**
  * ModulemdModuleStreamVersionEnum:
+ * @MD_MODULESTREAM_VERSION_ERROR: Represents an error handling module stream
+ * version.
+ * @MD_MODULESTREAM_VERSION_UNSET: Represents an unset module stream version.
  * @MD_MODULESTREAM_VERSION_ONE: Represents v1 of the #ModulemdModuleStream
  * metadata format.
  * @MD_MODULESTREAM_VERSION_TWO: Represents v2 of the #ModulemdModuleStream

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream.h
@@ -31,12 +31,12 @@ G_BEGIN_DECLS
 
 /**
  * ModulemdModuleStreamVersionEnum:
- * @MD_MODULESTREAM_VERSION_ONE: Represents v1 of the #Modulemd.ModuleStream
+ * @MD_MODULESTREAM_VERSION_ONE: Represents v1 of the #ModulemdModuleStream
  * metadata format.
- * @MD_MODULESTREAM_VERSION_TWO: Represents v2 of the #Modulemd.ModuleStream
+ * @MD_MODULESTREAM_VERSION_TWO: Represents v2 of the #ModulemdModuleStream
  * metadata format.
  * @MD_MODULESTREAM_VERSION_LATEST: Represents the highest-supported version of
- * the #Modulemd.ModuleStream metadata format.
+ * the #ModulemdModuleStream metadata format.
  *
  * Since: 2.0
  */
@@ -91,7 +91,7 @@ struct _ModulemdModuleStreamClass
 
 /**
  * modulemd_module_stream_new:
- * @mdversion: (in): The metadata version of ModuleStream to create.
+ * @mdversion: (in): The metadata version of #ModulemdModuleStream to create.
  * @module_name: (in) (nullable): The name of the module.
  * @module_stream: (in) (nullable): The name of this stream. Optional.
  *
@@ -369,7 +369,8 @@ modulemd_module_stream_get_context (ModulemdModuleStream *self);
  * modulemd_module_stream_set_arch:
  * @self: (in): This #ModulemdModuleStream.
  * @arch: (in) (nullable): Module architecture.
- * Indicates to which processor architecture this ModulemdModuleStream applies.
+ * Indicates to which processor architecture this #ModulemdModuleStream
+ * applies.
  *
  * Since: 2.2
  */
@@ -383,7 +384,8 @@ modulemd_module_stream_set_arch (ModulemdModuleStream *self,
  * @self: (in): This #ModulemdModuleStream.
  *
  * Returns: (transfer none): Module architecture.
- * Indicates to which processor architecture this ModulemdModuleStream applies.
+ * Indicates to which processor architecture this #ModulemdModuleStream
+ * applies.
  *
  * Since: 2.2
  */
@@ -396,7 +398,7 @@ modulemd_module_stream_get_arch (ModulemdModuleStream *self);
  * @self: (in): This #ModulemdModuleStream.
  *
  * Retrieves a representation of the module name, stream name, version and
- * context of this #ModuleStream in the form
+ * context of this #ModulemdModuleStream in the form
  * `module_name:stream_name:version:context`. Note that this excludes the
  * architecture of the module stream and as such is not guaranteed to be unique
  * within a repository.

--- a/modulemd/v2/include/modulemd-2.0/modulemd-profile.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-profile.h
@@ -47,8 +47,8 @@ modulemd_profile_equals (ModulemdProfile *self_1, ModulemdProfile *self_2);
  * modulemd_profile_new:
  * @name: (not nullable): The name of this profile.
  *
- * Returns: (transfer full): A newly-allocated #ModuleProfile. This object must
- * be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModulemdProfile. This object
+ * must be freed with g_object_unref().
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd-rpm-map-entry.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-rpm-map-entry.h
@@ -69,7 +69,7 @@ modulemd_rpm_map_entry_copy (ModulemdRpmMapEntry *self);
 
 /**
  * modulemd_rpm_map_entry_equals:
- * @self: A #ModuleRpmMapEntry
+ * @self: A #ModulemdRpmMapEntry
  * @other: Another #ModulemdRpmMapEntry
  *
  * Returns: TRUE if the two entries contain equivalent data. FALSE if they

--- a/modulemd/v2/include/modulemd-2.0/modulemd-translation-entry.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-translation-entry.h
@@ -130,7 +130,7 @@ modulemd_translation_entry_get_description (ModulemdTranslationEntry *self);
 
 /**
  * modulemd_translation_entry_get_profiles_as_strv: (rename-to modulemd_translation_entry_get_profiles)
- * @self: This #ModuleTranslationEntry
+ * @self: This #ModulemdTranslationEntry
  *
  * Get a list of profiles that have descriptions.
  *
@@ -145,7 +145,7 @@ modulemd_translation_entry_get_profiles_as_strv (
 
 /**
  * modulemd_translation_entry_set_profile_description:
- * @self: This #ModuleTranslationEntry
+ * @self: This #ModulemdTranslationEntry
  * @profile_name: The name of the profile.
  * @profile_description: (nullable): The translated description of the profile.
  *
@@ -162,7 +162,7 @@ modulemd_translation_entry_set_profile_description (
 
 /**
  * module_translation_entry_get_profile_description:
- * @self: This #ModuleTranslationEntry
+ * @self: This #ModulemdTranslationEntry
  * @profile_name: The name of the profile whose description is being translated.
  *
  * Returns: (transfer none): The description for the specified profile.

--- a/modulemd/v2/include/modulemd-2.0/modulemd-translation.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-translation.h
@@ -37,7 +37,8 @@ G_DECLARE_FINAL_TYPE (
  * @module_stream: The name of the module stream to which these translations apply.
  * @modified: The last modified time represented as a 64-bit integer (such as 201807011200)
  *
- * Returns: (transfer full): A newly-allocated #ModuleTranslation. This object must be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModulemdTranslation. This
+ * object must be freed with g_object_unref().
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd.h
@@ -112,9 +112,9 @@ G_BEGIN_DECLS
  * complete successfully. Additionally, it should be noted that the combined
  * metadata in any #ModulemdModuleIndex will have all of its component parts
  * upgraded to match the highest version of those objects seen. So for example
- * if the repodata has a mix of v1 and v2 #ModuleStream objects, the index will
- * contain only v2 objects (with the v1 objects automatically upgraded
- * internally).
+ * if the repodata has a mix of v1 and v2 #ModulemdModuleStream objects, the
+ * index will contain only v2 objects (with the v1 objects automatically
+ * upgraded internally).
  *
  * At this point, we can start operating on the retrieved data. This guide will
  * give only a brief overview of the most common operations. See the API
@@ -176,8 +176,8 @@ G_BEGIN_DECLS
  * syntactically and referentially.
  *
  * Also available is `Modulemd.ModuleStreamVersionEnum.LATEST` which will
- * always represent the highest-supported ModuleStream version. This may change
- * at any time.
+ * always represent the highest-supported version of the
+ * #ModulemdModuleStream metadata format. This may change at any time.
  */
 
 

--- a/modulemd/v2/include/private/modulemd-buildopts-private.h
+++ b/modulemd/v2/include/private/modulemd-buildopts-private.h
@@ -22,7 +22,7 @@
  * SECTION: modulemd-buildopts-private
  * @title: Modulemd.Buildopts (Private)
  * @stability: Private
- * @short_description: #Modulemd.Buildopts methods that should be used only
+ * @short_description: #ModulemdBuildopts methods that should be used only
  * by internal consumers.
  */
 

--- a/modulemd/v2/include/private/modulemd-component-module-private.h
+++ b/modulemd/v2/include/private/modulemd-component-module-private.h
@@ -22,7 +22,7 @@
  * SECTION: modulemd-component-module-private
  * @title: Modulemd.ComponentModule (Private)
  * @stability: Private
- * @short_description: #Modulemd.ComponentModule methods that should be used only
+ * @short_description: #ModulemdComponentModule methods that should be used only
  * by internal consumers
  */
 

--- a/modulemd/v2/include/private/modulemd-component-private.h
+++ b/modulemd/v2/include/private/modulemd-component-private.h
@@ -30,7 +30,7 @@
 /**
  * modulemd_component_parse_buildafter:
  * @self: This #ModulemdComponent
- * @emitter: (inout): A libyaml emitter object positioned just after the
+ * @parser: (inout): A libyaml parser object positioned just after the
  * "buildafter" key in a #ModulemdComponent section of a YAML document.
  * @error: (out): A #GError that will return the reason for a parse failure.
  *
@@ -46,7 +46,7 @@ modulemd_component_parse_buildafter (ModulemdComponent *self,
 /**
  * modulemd_component_parse_buildonly:
  * @self: This #ModulemdComponent
- * @emitter: (inout): A libyaml emitter object positioned just after the
+ * @parser: (inout): A libyaml parser object positioned just after the
  * "buildonly" key in a #ModulemdComponent section of a YAML document.
  * @error: (out): A #GError that will return the reason for a parse failure.
  *

--- a/modulemd/v2/include/private/modulemd-component-private.h
+++ b/modulemd/v2/include/private/modulemd-component-private.h
@@ -22,7 +22,7 @@
  * SECTION: modulemd-component-private
  * @title: Modulemd.Component (Private)
  * @stability: Private
- * @short_description: #Modulemd.Component methods that should be used only
+ * @short_description: #ModulemdComponent methods that should be used only
  * by internal consumers
  */
 

--- a/modulemd/v2/include/private/modulemd-component-rpm-private.h
+++ b/modulemd/v2/include/private/modulemd-component-rpm-private.h
@@ -22,7 +22,7 @@
  * SECTION: modulemd-component-rpm-private
  * @title: Modulemd.ComponentRpm (Private)
  * @stability: Private
- * @short_description: #Modulemd.ComponentRpm methods that should be used only
+ * @short_description: #ModulemdComponentRpm methods that should be used only
  * by internal consumers
  */
 

--- a/modulemd/v2/include/private/modulemd-defaults-v1-private.h
+++ b/modulemd/v2/include/private/modulemd-defaults-v1-private.h
@@ -24,7 +24,7 @@ G_BEGIN_DECLS
  * SECTION: modulemd-defaults-v1-private
  * @title: Modulemd.DefaultsV1 (Private)
  * @stability: private
- * @short_description: #ModulemdDefault methods that should only be used by
+ * @short_description: #ModulemdDefaults methods that should only be used by
  * internal consumers.
  */
 

--- a/modulemd/v2/include/private/modulemd-dependencies-private.h
+++ b/modulemd/v2/include/private/modulemd-dependencies-private.h
@@ -22,7 +22,7 @@
  * SECTION: modulemd-dependencies-private
  * @title: Modulemd.Dependencies (Private)
  * @stability: Private
- * @short_description: #Modulemd.Dependencies methods that should be used only
+ * @short_description: #ModulemdDependencies methods that should be used only
  * by internal consumers.
  */
 

--- a/modulemd/v2/include/private/modulemd-module-index-private.h
+++ b/modulemd/v2/include/private/modulemd-module-index-private.h
@@ -71,7 +71,7 @@ modulemd_module_index_update_from_parser (ModulemdModuleIndex *self,
  * @override: (in): In the event that the contents cannot be merged, this
  * argument specifies whether the contents of @from will supersede those from
  * @into. For specifics of how this works, see the Description section for
- * #ModulemdIndexMerger.
+ * #ModulemdModuleIndexMerger.
  * @error: (out): If the merge fails, this will return a #GError explaining the
  * reason for it.
  *

--- a/modulemd/v2/include/private/modulemd-profile-private.h
+++ b/modulemd/v2/include/private/modulemd-profile-private.h
@@ -22,7 +22,7 @@
  * SECTION: modulemd-profile-private
  * @title: Modulemd.Profile (Private)
  * @stability: Private
- * @short_description: #Modulemd.Profile methods that should be used only
+ * @short_description: #ModulemdProfile methods that should be used only
  * by internal consumers.
  */
 

--- a/modulemd/v2/include/private/modulemd-rpm-map-entry-private.h
+++ b/modulemd/v2/include/private/modulemd-rpm-map-entry-private.h
@@ -18,7 +18,7 @@
  * SECTION: modulemd-rpm-map-entry-private
  * @title: Modulemd.RpmMapEntry (Private)
  * @stability: Private
- * @short_description: #Modulemd.RpmMapEntry methods that should be used only
+ * @short_description: #ModulemdRpmMapEntry methods that should be used only
  * by internal consumers
  */
 

--- a/modulemd/v2/include/private/modulemd-service-level-private.h
+++ b/modulemd/v2/include/private/modulemd-service-level-private.h
@@ -22,7 +22,7 @@
  * SECTION: modulemd-service-level-private
  * @title: Modulemd.ServiceLevel (Private)
  * @stability: Private
- * @short_description: #Modulemd.ServiceLevel methods that should be used only
+ * @short_description: #ModulemdServiceLevel methods that should be used only
  * by internal consumers.
  */
 

--- a/modulemd/v2/include/private/modulemd-subdocument-info-private.h
+++ b/modulemd/v2/include/private/modulemd-subdocument-info-private.h
@@ -23,7 +23,7 @@
  * SECTION: modulemd-subdocument-info-private
  * @title: Modulemd.SubdocumentInfo (Private)
  * @stability: Private
- * @short_description: #Modulemd.SubdocumentInfo methods that should be used only
+ * @short_description: #ModulemdSubdocumentInfo methods that should be used only
  * by internal consumers.
  */
 

--- a/modulemd/v2/include/private/modulemd-translation-entry-private.h
+++ b/modulemd/v2/include/private/modulemd-translation-entry-private.h
@@ -22,7 +22,7 @@
  * SECTION: modulemd-translation-entry-private
  * @title: Modulemd.TranslationEntry (Private)
  * @stability: Private
- * @short_description: #Modulemd.TranslationEntry methods that should be used only
+ * @short_description: #ModulemdTranslationEntry methods that should be used only
  * by internal consumers.
  */
 

--- a/modulemd/v2/include/private/modulemd-translation-private.h
+++ b/modulemd/v2/include/private/modulemd-translation-private.h
@@ -20,10 +20,10 @@
 #include "modulemd-subdocument-info.h"
 
 /**
- * SECTION: modulemd-profile-private
- * @title: Modulemd.Profile (Private)
+ * SECTION: modulemd-translation-private
+ * @title: Modulemd.Translation (Private)
  * @stability: Private
- * @short_description: #Modulemd.Profile methods that should be used only
+ * @short_description: #ModulemdTranslation methods that should be used only
  * by internal consumers.
  */
 


### PR DESCRIPTION
Fixes #301 by correcting typos that resulted in missing link references to various object names, etc.

Also corrects a few mis-documented parameters and adds missing documentation for a few enums.