### PR TITLE
 Add gtk-doc descriptions for ModulemdModuleStream object properties

### DIFF
--- a/modulemd/v2/meson.build
+++ b/modulemd/v2/meson.build
@@ -707,6 +707,10 @@ gnome.gtkdoc(
     install_dir: 'modulemd-2.0',
     src_dir : './modulemd/v2',
     main_xml : 'modulemd-v2-docs.xml',
+    gobject_typesfile : join_paths(meson.current_build_dir(), 'modulemd-2.0.types'),
+    dependencies : [
+        modulemd_v2_dep,
+    ],
     install : true,
 )
 

--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -1065,6 +1065,11 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
   /* get_mdversion() must be implemented by the child class */
   klass->get_mdversion = NULL;
 
+  /**
+   * ModulemdModuleStream:mdversion:
+   *
+   * The metadata version of this #ModulemdModuleStream object.
+   */
   properties[PROP_MDVERSION] = g_param_spec_uint64 (
     "mdversion",
     "Metadata Version",
@@ -1074,6 +1079,11 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     0,
     G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
+  /**
+   * ModulemdModuleStream:module-name:
+   *
+   * The name of the module providing this stream.
+   */
   properties[PROP_MODULE_NAME] = g_param_spec_string (
     "module-name",
     "Module Name",
@@ -1081,6 +1091,11 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT_ONLY);
 
+  /**
+   * ModulemdModuleStream:stream-name:
+   *
+   * The name of this module stream.
+   */
   properties[PROP_STREAM_NAME] = g_param_spec_string (
     "stream-name",
     "Stream Name",
@@ -1088,6 +1103,11 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT_ONLY);
 
+  /**
+   * ModulemdModuleStream:version:
+   *
+   * The version of this module stream.
+   */
   properties[PROP_VERSION] = g_param_spec_uint64 (
     "version",
     "Module Stream Version",
@@ -1097,6 +1117,13 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     0,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
 
+  /**
+   * ModulemdModuleStream:context:
+   *
+   * The context of this module stream. Distinguishes between streams with
+   * the same version but different dependencies due to module stream
+   * expansion.
+   */
   properties[PROP_CONTEXT] = g_param_spec_string (
     "context",
     "Module Stream Context",
@@ -1106,6 +1133,11 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
 
+  /**
+   * ModulemdModuleStream:arch:
+   *
+   * The processor architecture of this module stream.
+   */
   properties[PROP_ARCH] = g_param_spec_string (
     "arch",
     "Module Stream Architetcture",


### PR DESCRIPTION
This is the first installment of several PRs to resolve issue #315, starting with `ModulemdModuleStream` mentioned in that issue.

The tricky part was figuring out what it took to persuade `gtk-doc` to including the descriptions for the properties in the generated documentation.