### PR TITLE
Return translated profile descriptions

### DIFF
--- a/modulemd/v2/include/private/modulemd-profile-private.h
+++ b/modulemd/v2/include/private/modulemd-profile-private.h
@@ -16,6 +16,7 @@
 #include <glib-object.h>
 #include <yaml.h>
 
+#include "modulemd-module-stream.h"
 #include "modulemd-profile.h"
 
 /**
@@ -77,3 +78,16 @@ modulemd_profile_emit_yaml (ModulemdProfile *self,
  */
 gboolean
 modulemd_profile_equals_wrapper (const void *a, const void *b);
+
+
+/**
+ * modulemd_profile_set_owner:
+ * @self: This #ModulemdProfile
+ * @owner: A #ModulemdModuleStream that will own this profile. Used to look up
+ * translations internally.
+ *
+ * Since: 2.6
+ */
+void
+modulemd_profile_set_owner (ModulemdProfile *self,
+                            ModulemdModuleStream *owner);

--- a/modulemd/v2/modulemd-module-stream-v1.c
+++ b/modulemd/v2/modulemd-module-stream-v1.c
@@ -522,9 +522,12 @@ modulemd_module_stream_v1_add_profile (ModulemdModuleStreamV1 *self,
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
   g_return_if_fail (MODULEMD_IS_PROFILE (profile));
 
+  ModulemdProfile *copied_profile = modulemd_profile_copy (profile);
+  modulemd_profile_set_owner (copied_profile, MODULEMD_MODULE_STREAM (self));
+
   g_hash_table_replace (self->profiles,
                         g_strdup (modulemd_profile_get_name (profile)),
-                        modulemd_profile_copy (profile));
+                        copied_profile);
 }
 
 

--- a/modulemd/v2/modulemd-module-stream-v2.c
+++ b/modulemd/v2/modulemd-module-stream-v2.c
@@ -653,9 +653,12 @@ modulemd_module_stream_v2_add_profile (ModulemdModuleStreamV2 *self,
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
   g_return_if_fail (MODULEMD_IS_PROFILE (profile));
 
+  ModulemdProfile *copied_profile = modulemd_profile_copy (profile);
+  modulemd_profile_set_owner (copied_profile, MODULEMD_MODULE_STREAM (self));
+
   g_hash_table_replace (self->profiles,
                         g_strdup (modulemd_profile_get_name (profile)),
-                        modulemd_profile_copy (profile));
+                        copied_profile);
 }
 
 


### PR DESCRIPTION
This causes profiles to be associated with their owning ModuleStream
when they are added to it so they can look up the appropriate
translations for their description.

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/321

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>