### PR TITLE
ModulemdModuleStream property documentation fixes

### DIFF
--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -1140,7 +1140,7 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
    */
   properties[PROP_ARCH] = g_param_spec_string (
     "arch",
-    "Module Stream Architetcture",
+    "Module Stream Architecture",
     "The processor architecture of this module stream.",
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);

--- a/modulemd/v2/modulemd-module-stream.c
+++ b/modulemd/v2/modulemd-module-stream.c
@@ -1065,11 +1065,6 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
   /* get_mdversion() must be implemented by the child class */
   klass->get_mdversion = NULL;
 
-  /**
-   * ModulemdModuleStream:mdversion:
-   *
-   * The metadata version of this #ModulemdModuleStream object.
-   */
   properties[PROP_MDVERSION] = g_param_spec_uint64 (
     "mdversion",
     "Metadata Version",
@@ -1079,11 +1074,6 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     0,
     G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
-  /**
-   * ModulemdModuleStream:module-name:
-   *
-   * The name of the module providing this stream.
-   */
   properties[PROP_MODULE_NAME] = g_param_spec_string (
     "module-name",
     "Module Name",
@@ -1091,11 +1081,6 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT_ONLY);
 
-  /**
-   * ModulemdModuleStream:stream-name:
-   *
-   * The name of this module stream.
-   */
   properties[PROP_STREAM_NAME] = g_param_spec_string (
     "stream-name",
     "Stream Name",
@@ -1103,11 +1088,6 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT_ONLY);
 
-  /**
-   * ModulemdModuleStream:version:
-   *
-   * The version of this module stream.
-   */
   properties[PROP_VERSION] = g_param_spec_uint64 (
     "version",
     "Module Stream Version",
@@ -1117,13 +1097,6 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     0,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
 
-  /**
-   * ModulemdModuleStream:context:
-   *
-   * The context of this module stream. Distinguishes between streams with
-   * the same version but different dependencies due to module stream
-   * expansion.
-   */
   properties[PROP_CONTEXT] = g_param_spec_string (
     "context",
     "Module Stream Context",
@@ -1133,11 +1106,6 @@ modulemd_module_stream_class_init (ModulemdModuleStreamClass *klass)
     NULL,
     G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT);
 
-  /**
-   * ModulemdModuleStream:arch:
-   *
-   * The processor architecture of this module stream.
-   */
   properties[PROP_ARCH] = g_param_spec_string (
     "arch",
     "Module Stream Architecture",


### PR DESCRIPTION
As it turns out, the update to `meson.build` made by commit b8bcf46 was sufficient to enable `gtk-doc` to _automatically_ generate documentation for _all_ GObject properties from the descriptions extracted during the object scan--without the need to add documentation comment blocks in the code!

Thus, the property descriptions added for `ModulemdModuleStream` by commit 76aecdf were totally unnecessary and that redundancy is removed by this commit.

Note, however, that property documentation comment blocks can be added in the code to override the automatically generated descriptions should that be necessary in the future.

This PR also corrects a typo in the `ModulemdModuleStream.arch` property nick name.