### PR TITLE
Documentation updates

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-component-rpm.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-component-rpm.h
@@ -22,7 +22,7 @@ G_BEGIN_DECLS
  * SECTION: modulemd-component-rpm
  * @title: Modulemd.ComponentRpm
  * @stability: stable
- * @short_description: A rpm component that goes into a module stream.
+ * @short_description: An rpm component that goes into a module stream.
  */
 #define MODULEMD_TYPE_COMPONENT_RPM (modulemd_component_rpm_get_type ())
 
@@ -51,7 +51,10 @@ modulemd_component_rpm_new (const gchar *key);
  * @self: This #ModulemdComponentRpm object.
  * @arch: An architecture on which this package should be available.
  *
- * Restrict the list of architectures on which this RPM will be available. It may be called any number of times to indicate support on additional architectures. Use `reset_arches()` to return to "all architectures".
+ * Restrict the list of architectures on which this RPM will be available. It
+ * may be called any number of times to indicate support on additional
+ * architectures. Use modulemd_component_rpm_reset_arches() to return to "all
+ * architectures".
  *
  * Since: 2.0
  */
@@ -89,7 +92,9 @@ modulemd_component_rpm_get_arches_as_strv (ModulemdComponentRpm *self);
  * @self: This #ModulemdComponentRpm object.
  * @arch: An architecture on which this package should be multilib.
  *
- * Add an architectures on which this RPM will be multilib. It may be called any number of times. Use `reset_multilib_arches()` to return to "no architectures".
+ * Add an architectures on which this RPM will be multilib. It may be called
+ * any number of times. Use modulemd_component_rpm_reset_multilib_arches() to
+ * return to "no architectures".
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index-merger.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index-merger.h
@@ -110,7 +110,7 @@ G_DECLARE_FINAL_TYPE (ModulemdModuleIndexMerger,
  * Returns: (transfer full): A newly-allocated Modulemd.ModuleIndexMerger
  * object.
  *
- * Since:2.0
+ * Since: 2.0
  */
 ModulemdModuleIndexMerger *
 modulemd_module_index_merger_new (void);

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
@@ -360,7 +360,7 @@ modulemd_module_index_remove_module (ModulemdModuleIndex *self,
  * between streams of the same version. If this upgrade cannot be performed,
  * the function will return @error set appropriately.
  *
- * Returns: TRUE if the #ModulemdModuleStream was added succesfully. If the
+ * Returns: TRUE if the #ModulemdModuleStream was added successfully. If the
  * stream already existed in the index, it will be replaced by the new one. On
  * failure, returns FALSE and sets @error appropriately.
  *
@@ -379,7 +379,7 @@ modulemd_module_index_add_module_stream (ModulemdModuleIndex *self,
  * @error: (out): A #GError containing the reason the #ModulemdDefaults object
  * could not be added or NULL if the function succeeded.
  *
- * Returns: TRUE if the #ModulemdDefaults was added succesfully. If the defaults
+ * Returns: TRUE if the #ModulemdDefaults was added successfully. If the defaults
  * already existed in the index, it will be replaced by the new one. On failure,
  * returns FALSE and sets error approriately.
  *
@@ -421,7 +421,7 @@ modulemd_module_index_get_default_streams_as_hash_table (
  * @error: (out): A #GError containing the reason the #ModulemdTranslation
  * object could not be added or NULL if the function succeeded.
  *
- * Returns: TRUE if the #ModulemdTranslation was added succesfully. If the
+ * Returns: TRUE if the #ModulemdTranslation was added successfully. If the
  * translation already existed in the index, it will be replaced by the new one.
  * On failure, returns FALSE and sets error appropriately.
  *

--- a/modulemd/v2/include/private/modulemd-buildopts-private.h
+++ b/modulemd/v2/include/private/modulemd-buildopts-private.h
@@ -47,7 +47,7 @@ modulemd_buildopts_parse_yaml (yaml_parser_t *parser,
                                GError **error);
 
 /**
- * modulemd_buildopts_emitter_yaml:
+ * modulemd_buildopts_emit_yaml:
  * @self: This #ModulemdBuildopts
  * @emitter: (inout): A libyaml emitter object positioned where a Buildopts
  * belongs in the YAML document.

--- a/modulemd/v2/include/private/modulemd-component-module-private.h
+++ b/modulemd/v2/include/private/modulemd-component-module-private.h
@@ -23,7 +23,7 @@
  * @title: Modulemd.ComponentModule (Private)
  * @stability: Private
  * @short_description: #ModulemdComponentModule methods that should be used only
- * by internal consumers
+ * by internal consumers.
  */
 
 /**
@@ -36,7 +36,7 @@
  * @error: (out): A #GError that will return the reason for parsing error.
  *
  * Returns: (transfer full): A newly-allocated #ModulemdComponentModule object
- * read from the YAML. NULL if a parse error occured and sets @error
+ * read from the YAML. NULL if a parse error occurred and sets @error
  * appropriately.
  *
  * Since: 2.0
@@ -55,7 +55,7 @@ modulemd_component_module_parse_yaml (yaml_parser_t *parser,
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission error.
  *
- * Returns: TRUE if the module component was emitted succesfully. FALSE and sets
+ * Returns: TRUE if the module component was emitted successfully. FALSE and sets
  * @error appropriately if the YAML could not be emitted.
  *
  * Since: 2.0

--- a/modulemd/v2/include/private/modulemd-component-private.h
+++ b/modulemd/v2/include/private/modulemd-component-private.h
@@ -23,7 +23,7 @@
  * @title: Modulemd.Component (Private)
  * @stability: Private
  * @short_description: #ModulemdComponent methods that should be used only
- * by internal consumers
+ * by internal consumers.
  */
 
 
@@ -50,7 +50,7 @@ modulemd_component_parse_buildafter (ModulemdComponent *self,
  * "buildonly" key in a #ModulemdComponent section of a YAML document.
  * @error: (out): A #GError that will return the reason for a parse failure.
  *
- * Returns: TRUE if the buildafter list could be parsed successfully.
+ * Returns: TRUE if the buildonly list could be parsed successfully.
  *
  * Since: 2.2
  */
@@ -63,7 +63,7 @@ modulemd_component_parse_buildonly (ModulemdComponent *self,
  * modulemd_component_has_buildafter:
  * @self: This #ModulemdComponent
  *
- * Returns: Whether one or more buildafter entries have been added to this
+ * Returns: TRUE if one or more buildafter entries have been added to this
  * component.
  *
  * Since: 2.2
@@ -92,7 +92,7 @@ modulemd_component_get_buildafter_internal (ModulemdComponent *self);
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission error.
  *
- * Returns: TRUE if the component header was emitted succesfully. FALSE and sets
+ * Returns: TRUE if the component header was emitted successfully. FALSE and sets
  * @error appropriately if the YAML could not be emitted.
  *
  * Since: 2.0
@@ -110,8 +110,9 @@ modulemd_component_emit_yaml_start (ModulemdComponent *self,
  * document.
  * @error: (out): A #GError that will return the reason for an emission error.
  *
- * Returns: TRUE if the component buildorder was emitted succesfully. FALSE and
- * sets @error appropriately if the YAML could not be emitted.
+ * Returns: TRUE if the component buildorder, buildafter and/or buildonly
+ * item(s) were emitted successfully. FALSE and sets @error appropriately if
+ * the YAML could not be emitted.
  *
  * Since: 2.2
  */
@@ -125,7 +126,7 @@ modulemd_component_emit_yaml_build_common (ModulemdComponent *self,
  * @a: A void pointer
  * @b: A void pointer
  *
- * Returns: TRUE, if both the pointers are equal. FALSE, otherwise
+ * Returns: TRUE, if both the pointers are equal. FALSE, otherwise.
  *
  * Since: 2.5
  */

--- a/modulemd/v2/include/private/modulemd-component-rpm-private.h
+++ b/modulemd/v2/include/private/modulemd-component-rpm-private.h
@@ -23,7 +23,7 @@
  * @title: Modulemd.ComponentRpm (Private)
  * @stability: Private
  * @short_description: #ModulemdComponentRpm methods that should be used only
- * by internal consumers
+ * by internal consumers.
  */
 
 /**
@@ -36,7 +36,7 @@
  * @error: (out): A #GError that will return the reason for parsing error.
  *
  * Returns: (transfer full): A newly-allocated #ModulemdComponentRpm object
- * read from the YAML. NULL if a parse error occured and sets @error
+ * read from the YAML. NULL if a parse error occurred and sets @error
  * appropriately.
  *
  * Since: 2.0
@@ -55,7 +55,7 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission error.
  *
- * Returns: TRUE if the rpm component was emitted succesfully. FALSE and sets
+ * Returns: TRUE if the rpm component was emitted successfully. FALSE and sets
  * @error appropriately if the YAML could not be emitted.
  *
  * Since: 2.0

--- a/modulemd/v2/include/private/modulemd-defaults-private.h
+++ b/modulemd/v2/include/private/modulemd-defaults-private.h
@@ -30,6 +30,13 @@ G_BEGIN_DECLS
 #define DEFAULT_PLACEHOLDER "__DEFAULT_PLACEHOLDER__"
 
 
+/**
+ * modulemd_defaults_set_module_name:
+ * @self: (in): This #ModulemdDefaults object
+ * @module_name: The module name this object represents
+ *
+ * Since: 2.x
+ */
 void
 modulemd_defaults_set_module_name (ModulemdDefaults *self,
                                    const gchar *module_name);
@@ -45,7 +52,9 @@ modulemd_defaults_set_module_name (ModulemdDefaults *self,
  * #ModulemdModuleIndexMerger for details on the merge algorithm used.
  *
  * Returns: (transfer full): A newly-allocated #ModulemdDefaults containing the
- * merged values of @from and @into.
+ * merged values of @from and @into. If this function encounters an
+ * unresolvable merge conflict, it will return NULL and set @error
+ * appropriately.
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/private/modulemd-defaults-private.h
+++ b/modulemd/v2/include/private/modulemd-defaults-private.h
@@ -35,7 +35,7 @@ G_BEGIN_DECLS
  * @self: (in): This #ModulemdDefaults object
  * @module_name: The module name this object represents
  *
- * Since: 2.x
+ * Since: 2.0
  */
 void
 modulemd_defaults_set_module_name (ModulemdDefaults *self,

--- a/modulemd/v2/include/private/modulemd-defaults-v1-private.h
+++ b/modulemd/v2/include/private/modulemd-defaults-v1-private.h
@@ -70,6 +70,25 @@ modulemd_defaults_v1_emit_yaml (ModulemdDefaultsV1 *self,
                                 GError **error);
 
 
+/**
+ * modulemd_defaults_v1_merge:
+ * @module_name: (in): The name of the module for which defaults are being merged.
+ * @from: (in): A #ModulemdDefaultsV1 object to merge from
+ * @into: (in): A #ModulemdDefaultsV1 object being merged into
+ * @error: (out): A #GError containing the reason for an unresolvable merge
+ * conflict
+ *
+ * Performs a merge of two #ModulemdDefaultsV1 objects representing the
+ * defaults for a single module name. See the documentation for
+ * #ModulemdModuleIndexMerger for details on the merge algorithm used.
+ *
+ * Returns: (transfer full): A newly-allocated #ModulemdDefaultsV1 containing
+ * the merged values of @from and @into. If this function encounters an
+ * unresolvable merge conflict, it will return NULL and set @error
+ * appropriately.
+ *
+ * Since: 2.x
+ */
 ModulemdDefaults *
 modulemd_defaults_v1_merge (const gchar *module_name,
                             ModulemdDefaultsV1 *from,

--- a/modulemd/v2/include/private/modulemd-defaults-v1-private.h
+++ b/modulemd/v2/include/private/modulemd-defaults-v1-private.h
@@ -87,7 +87,7 @@ modulemd_defaults_v1_emit_yaml (ModulemdDefaultsV1 *self,
  * unresolvable merge conflict, it will return NULL and set @error
  * appropriately.
  *
- * Since: 2.x
+ * Since: 2.0
  */
 ModulemdDefaults *
 modulemd_defaults_v1_merge (const gchar *module_name,

--- a/modulemd/v2/include/private/modulemd-rpm-map-entry-private.h
+++ b/modulemd/v2/include/private/modulemd-rpm-map-entry-private.h
@@ -19,7 +19,7 @@
  * @title: Modulemd.RpmMapEntry (Private)
  * @stability: Private
  * @short_description: #ModulemdRpmMapEntry methods that should be used only
- * by internal consumers
+ * by internal consumers.
  */
 
 /**
@@ -31,7 +31,7 @@
  * @error: (out): A #GError that will return the reason for parsing error.
  *
  * Returns: (transfer full): A newly-allocated #ModulemdComponentRpm object
- * read from the YAML. NULL if a parse error occured and sets @error
+ * read from the YAML. NULL if a parse error occurred and sets @error
  * appropriately.
  * Since: 2.2
  */

--- a/modulemd/v2/include/private/modulemd-yaml.h
+++ b/modulemd/v2/include/private/modulemd-yaml.h
@@ -251,7 +251,7 @@ mmd_emitter_scalar (yaml_emitter_t *emitter,
  * @list: A list that will be emitted to the YAML emitter.
  * @error: (out): A #GError that will return the reason for an emitting error.
  *
- * Returns: A boolean whether emitting the sequence was succesful.
+ * Returns: A boolean whether emitting the sequence was successful.
  *
  * Since: 2.0
  */
@@ -285,7 +285,7 @@ modulemd_yaml_parse_date (yaml_parser_t *parser, GError **error);
  * @error: (out): A #GError that will return the reason for a parsing or validation error.
  *
  * Returns: (transfer full): A newly-allocated gchar * representing the parsed value.
- * NULL if a parse error occured and sets @error appropriately.
+ * NULL if a parse error occurred and sets @error appropriately.
  *
  * Since: 2.0
  */
@@ -301,7 +301,7 @@ modulemd_yaml_parse_string (yaml_parser_t *parser, GError **error);
  * validation error.
  *
  * Returns: A boolean representing the parsed value. Returns FALSE if a parse
- * error occured and sets @error appropriately.
+ * error occurred and sets @error appropriately.
  *
  * Since: 2.2
  */
@@ -317,7 +317,7 @@ modulemd_yaml_parse_bool (yaml_parser_t *parser, GError **error);
  * validation error.
  *
  * Returns: (transfer full): A 64-bit signed integer representing the parsed
- * value. Returns 0 if a parse error occured and sets @error appropriately.
+ * value. Returns 0 if a parse error occurred and sets @error appropriately.
  *
  * Since: 2.0
  */
@@ -333,7 +333,7 @@ modulemd_yaml_parse_int64 (yaml_parser_t *parser, GError **error);
  * validation error.
  *
  * Returns: (transfer full): A 64-bit unsigned integer representing the parsed
- * value. Returns 0 if a parse error occured and sets @error appropriately.
+ * value. Returns 0 if a parse error occurred and sets @error appropriately.
  *
  * Since: 2.0
  */
@@ -348,7 +348,7 @@ modulemd_yaml_parse_uint64 (yaml_parser_t *parser, GError **error);
  *
  * Returns: (transfer full): A newly-allocated GHashtTable * representing the parsed value.
  * All parsed sequence entries are added as keys in the hashtable.
- * NULL if a parse error occured and sets @error appropriately.
+ * NULL if a parse error occurred and sets @error appropriately.
  *
  * Since: 2.0
  */
@@ -372,7 +372,7 @@ modulemd_yaml_parse_string_set (yaml_parser_t *parser, GError **error);
  *
  * Returns: (transfer full): A newly-allocated GHashtTable * representing the
  * parsed values. All parsed sequence entries are added as keys in the
- * hashtable. NULL if a parse error occured and sets @error appropriately.
+ * hashtable. NULL if a parse error occurred and sets @error appropriately.
  *
  * Since: 2.0
  */
@@ -394,7 +394,7 @@ modulemd_yaml_parse_string_set_from_map (yaml_parser_t *parser,
  * data.dependencies in ModuleStreamV1.
  *
  * Returns: (transfer full): A newly-allocated GHashtTable * representing the
- * parsed values. NULL if a parse error occured and sets @error appropriately.
+ * parsed values. NULL if a parse error occurred and sets @error appropriately.
  *
  * Since: 2.0
  */
@@ -449,7 +449,7 @@ modulemd_yaml_emit_document_headers (yaml_emitter_t *emitter,
  * array or dictionary.
  * @error: (out): A #GError that will return the reason for failing to emit.
  *
- * Returns: TRUE if the variant emitted succesfully. FALSE if an error was
+ * Returns: TRUE if the variant emitted successfully. FALSE if an error was
  * encountered and sets @error appropriately.
  *
  * Since: 2.0


### PR DESCRIPTION
This is an initial batch of documentation updates for private functions requested by #317. However, it also includes corrections for numerous minor spelling, grammar, style, and punctuation errors throughout.

I haven't yet identified when `modulemd_defaults_set_module_name()` and `modulemd_defaults_v1_merge()` first appeared, so I put in `Since: 2.x` as a place holder.

Feel free to merge this now if you are so inclined, or wait until I have made further progress going through the private functions.