### PR TITLE
Add ModuleIndexMerger.resolve_ext()

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index-merger.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index-merger.h
@@ -161,6 +161,10 @@ modulemd_module_index_merger_associate_index (ModulemdModuleIndexMerger *self,
  * #ModulemdModuleIndexMerger is undefined. The only valid action on it after
  * that point is g_object_unref().
  *
+ * This function is equivalent to calling
+ * modulemd_module_index_merger_resolve_ext() with
+ * `strict_default_streams=FALSE`.
+ *
  * Returns: (transfer full): A newly-allocated #ModulemdModuleIndex containing
  * the merged results. If this function encounters an unresolvable merge
  * conflict, it will return NULL and set @error appropriately.
@@ -170,5 +174,34 @@ modulemd_module_index_merger_associate_index (ModulemdModuleIndexMerger *self,
 ModulemdModuleIndex *
 modulemd_module_index_merger_resolve (ModulemdModuleIndexMerger *self,
                                       GError **error);
+
+
+/**
+ * modulemd_module_index_merger_resolve_ext:
+ * @self: (in): This #ModulemdModuleIndexMerger object.
+ * @strict_default_streams: (in): If TRUE, merging two #ModulemdDefaults with
+ * conflicting default streams will raise an error. If FALSE, the module will
+ * have its default stream blocked.
+ * @error: (out): A #GError containing the reason for a failure to resolve the
+ * merges.
+ *
+ * Merges all added #ModulemdModuleIndex objects according to their priority.
+ * The logic of this merge is described in the Description of
+ * #ModulemdModuleIndexMerger.
+ *
+ * Once this function has been called, the internal state of the
+ * #ModulemdModuleIndexMerger is undefined. The only valid action on it after
+ * that point is g_object_unref().
+ *
+ * Returns: (transfer full): A newly-allocated #ModulemdModuleIndex containing
+ * the merged results. If this function encounters an unresolvable merge
+ * conflict, it will return NULL and set @error appropriately.
+ *
+ * Since: 2.6
+ */
+ModulemdModuleIndex *
+modulemd_module_index_merger_resolve_ext (ModulemdModuleIndexMerger *self,
+                                          gboolean strict_default_streams,
+                                          GError **error);
 
 G_END_DECLS

--- a/modulemd/v2/include/private/modulemd-defaults-private.h
+++ b/modulemd/v2/include/private/modulemd-defaults-private.h
@@ -38,6 +38,8 @@ modulemd_defaults_set_module_name (ModulemdDefaults *self,
  * modulemd_defaults_merge:
  * @from: (in): A #ModulemdDefaults object to merge from
  * @into: (in): A #ModulemdDefaults object being merged into
+ * @strict_default_streams: (in): Whether a stream conflict should throw an
+ * error or just unset the default stream.
  * @error: (out): A #GError containing the reason for an unresolvable merge
  * conflict
  *
@@ -52,6 +54,7 @@ modulemd_defaults_set_module_name (ModulemdDefaults *self,
 ModulemdDefaults *
 modulemd_defaults_merge (ModulemdDefaults *from,
                          ModulemdDefaults *into,
+                         gboolean strict_default_streams,
                          GError **error);
 
 G_END_DECLS

--- a/modulemd/v2/include/private/modulemd-defaults-v1-private.h
+++ b/modulemd/v2/include/private/modulemd-defaults-v1-private.h
@@ -74,6 +74,7 @@ ModulemdDefaults *
 modulemd_defaults_v1_merge (const gchar *module_name,
                             ModulemdDefaultsV1 *from,
                             ModulemdDefaultsV1 *into,
+                            gboolean strict_default_streams,
                             GError **error);
 
 G_END_DECLS

--- a/modulemd/v2/include/private/modulemd-module-index-private.h
+++ b/modulemd/v2/include/private/modulemd-module-index-private.h
@@ -72,6 +72,9 @@ modulemd_module_index_update_from_parser (ModulemdModuleIndex *self,
  * argument specifies whether the contents of @from will supersede those from
  * @into. For specifics of how this works, see the Description section for
  * #ModulemdModuleIndexMerger.
+ * @strict_default_streams: (in): When merging #ModulemdDefaults, treat
+ * conflicting stream defaults as an error if this is True. Otherwise, on a
+ * conflict, the default stream will be unset.
  * @error: (out): If the merge fails, this will return a #GError explaining the
  * reason for it.
  *
@@ -84,6 +87,7 @@ gboolean
 modulemd_module_index_merge (ModulemdModuleIndex *from,
                              ModulemdModuleIndex *into,
                              gboolean override,
+                             gboolean strict_default_streams,
                              GError **error);
 
 G_END_DECLS

--- a/modulemd/v2/modulemd-defaults-v1.c
+++ b/modulemd/v2/modulemd-defaults-v1.c
@@ -1204,6 +1204,7 @@ ModulemdDefaults *
 modulemd_defaults_v1_merge (const gchar *module_name,
                             ModulemdDefaultsV1 *from,
                             ModulemdDefaultsV1 *into,
+                            gboolean strict_default_streams,
                             GError **error)
 {
   g_autoptr (ModulemdDefaultsV1) merged = NULL;
@@ -1246,6 +1247,17 @@ modulemd_defaults_v1_merge (const gchar *module_name,
           g_info ("Module stream mismatch in merge: %s != %s",
                   into->default_stream,
                   from->default_stream);
+          if (strict_default_streams)
+            {
+              g_set_error (error,
+                           MODULEMD_ERROR,
+                           MODULEMD_ERROR_VALIDATE,
+                           "Default stream mismatch in module %s: %s != %s",
+                           module_name,
+                           into->default_stream,
+                           from->default_stream);
+              return NULL;
+            }
           modulemd_defaults_v1_set_default_stream (
             merged, DEFAULT_MERGE_CONFLICT, NULL);
         }

--- a/modulemd/v2/modulemd-defaults.c
+++ b/modulemd/v2/modulemd-defaults.c
@@ -391,6 +391,7 @@ modulemd_defaults_init (ModulemdDefaults *self)
 ModulemdDefaults *
 modulemd_defaults_merge (ModulemdDefaults *from,
                          ModulemdDefaults *into,
+                         gboolean strict_default_streams,
                          GError **error)
 {
   g_autoptr (ModulemdDefaults) merged_defaults = NULL;
@@ -446,6 +447,7 @@ modulemd_defaults_merge (ModulemdDefaults *from,
   merged_defaults = modulemd_defaults_v1_merge (module_name,
                                                 MODULEMD_DEFAULTS_V1 (from),
                                                 MODULEMD_DEFAULTS_V1 (into),
+                                                strict_default_streams,
                                                 &nested_error);
   if (!merged_defaults)
     {

--- a/modulemd/v2/modulemd-module-index-merger.c
+++ b/modulemd/v2/modulemd-module-index-merger.c
@@ -171,6 +171,14 @@ ModulemdModuleIndex *
 modulemd_module_index_merger_resolve (ModulemdModuleIndexMerger *self,
                                       GError **error)
 {
+  return modulemd_module_index_merger_resolve_ext (self, FALSE, error);
+}
+
+ModulemdModuleIndex *
+modulemd_module_index_merger_resolve_ext (ModulemdModuleIndexMerger *self,
+                                          gboolean strict_default_streams,
+                                          GError **error)
+{
   MODULEMD_INIT_TRACE ();
   g_autoptr (ModulemdModuleIndex) thislevel = NULL;
   g_autoptr (ModulemdModuleIndex) final = NULL;
@@ -200,6 +208,7 @@ modulemd_module_index_merger_resolve (ModulemdModuleIndexMerger *self,
           if (!modulemd_module_index_merge (g_ptr_array_index (indexes, j),
                                             thislevel,
                                             FALSE,
+                                            strict_default_streams,
                                             &nested_error))
             {
               g_propagate_error (error, g_steal_pointer (&nested_error));
@@ -209,7 +218,8 @@ modulemd_module_index_merger_resolve (ModulemdModuleIndexMerger *self,
 
 
       /* Merge 'thislevel' into 'final' with override=True */
-      if (!modulemd_module_index_merge (thislevel, final, TRUE, &nested_error))
+      if (!modulemd_module_index_merge (
+            thislevel, final, TRUE, strict_default_streams, &nested_error))
         {
           g_propagate_error (error, g_steal_pointer (&nested_error));
           return NULL;

--- a/modulemd/v2/modulemd-module-index.c
+++ b/modulemd/v2/modulemd-module-index.c
@@ -908,6 +908,7 @@ gboolean
 modulemd_module_index_merge (ModulemdModuleIndex *from,
                              ModulemdModuleIndex *into,
                              gboolean override,
+                             gboolean strict_default_streams,
                              GError **error)
 {
   MODULEMD_INIT_TRACE ();
@@ -996,8 +997,8 @@ modulemd_module_index_merge (ModulemdModuleIndex *from,
         }
       else
         {
-          merged_defaults =
-            modulemd_defaults_merge (defaults, into_defaults, &nested_error);
+          merged_defaults = modulemd_defaults_merge (
+            defaults, into_defaults, strict_default_streams, &nested_error);
           if (!merged_defaults)
             {
               g_propagate_error (error, g_steal_pointer (&nested_error));

--- a/modulemd/v2/tests/ModulemdTests/merger.py
+++ b/modulemd/v2/tests/ModulemdTests/merger.py
@@ -210,6 +210,27 @@ class TestModuleIndexMerger(TestBase):
     def test_merger_with_modified(self):
         pass
 
+    def test_strict_default_streams(self):
+        merger = Modulemd.ModuleIndexMerger.new()
+
+        for stream in ("27", "38"):
+            default = """
+---
+document: modulemd-defaults
+version: 1
+data:
+    module: python
+    stream: %s
+...
+""" % (stream)
+
+            index = Modulemd.ModuleIndex()
+            index.update_from_string(default, strict=True)
+            merger.associate_index(index, 0)
+
+        with self.assertRaisesRegexp(gi.repository.GLib.GError, "Default stream mismatch in module python"):
+            merger.resolve_ext(True)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This will allow us to handle default streams strictly when merging. In most end-user
cases, we want default stream conflicts to simply drop the default stream (this is
fail-safe). But when we are creating a repo with defaults, we want to be stricter and
ensure that we aren't producing a repo with inconsistent data.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

cc @lubomir 