### PR TITLE
Documentation updates, round 2

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-buildopts.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-buildopts.h
@@ -32,8 +32,8 @@ G_DECLARE_FINAL_TYPE (
 /**
  * modulemd_buildopts_new:
  *
- * Returns: (transfer full): A newly-allocated #ModulemdBuildopts. This object
- * must be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModulemdBuildopts object. This
+ * object must be freed with g_object_unref().
  *
  * Since: 2.0
  */
@@ -43,10 +43,10 @@ modulemd_buildopts_new (void);
 
 /**
  * modulemd_buildopts_equals:
- * @self_1: A #ModulemdBuildopts
- * @self_2: A #ModulemdBuildopts
+ * @self_1: A #ModulemdBuildopts object.
+ * @self_2: A #ModulemdBuildopts object.
  *
- * Check for equality for 2 ModulemdBuildopts objects.
+ * Check for equality for two #ModulemdBuildopts objects.
  *
  * Returns: TRUE if both objects are equal, FALSE otherwise.
  *
@@ -59,11 +59,12 @@ modulemd_buildopts_equals (ModulemdBuildopts *self_1,
 
 /**
  * modulemd_buildopts_copy:
- * @self: This #ModulemdBuildopts
+ * @self: This #ModulemdBuildopts object.
  *
  * Create a copy of this #ModulemdBuildopts object.
  *
- * Returns: (transfer full): a copied #ModulemdBuildopts object
+ * Returns: (transfer full): A newly-allocated #ModulemdBuildopts object that
+ * is a copy of @self.
  *
  * Since: 2.0
  */
@@ -73,8 +74,9 @@ modulemd_buildopts_copy (ModulemdBuildopts *self);
 
 /**
  * modulemd_buildopts_set_rpm_macros:
- * @self: This #ModulemdBuildopts
- * @rpm_macros: A string containing RPM build macros in the form that they would appear in an RPM macros file on-disk.
+ * @self: This #ModulemdBuildopts object.
+ * @rpm_macros: A string containing RPM build macros in the form that they
+ * would appear in an RPM macros file on-disk.
  *
  * Since: 2.0
  */
@@ -85,9 +87,10 @@ modulemd_buildopts_set_rpm_macros (ModulemdBuildopts *self,
 
 /**
  * modulemd_buildopts_get_rpm_macros:
- * @self: This #ModulemdBuildopts
+ * @self: This #ModulemdBuildopts object.
  *
- * Returns: (transfer none): A string containing RPM build macros in the form that they would appear in an RPM macros file on-disk.
+ * Returns: (transfer none): A string containing RPM build macros in the form
+ * that they would appear in an RPM macros file on-disk.
  *
  * Since: 2.0
  */
@@ -97,7 +100,7 @@ modulemd_buildopts_get_rpm_macros (ModulemdBuildopts *self);
 
 /**
  * modulemd_buildopts_add_rpm_to_whitelist:
- * @self: This #ModulemdBuildopts
+ * @self: This #ModulemdBuildopts object.
  * @rpm: An RPM name to add to the whitelist.
  *
  * Since: 2.0
@@ -109,7 +112,7 @@ modulemd_buildopts_add_rpm_to_whitelist (ModulemdBuildopts *self,
 
 /**
  * modulemd_buildopts_remove_rpm_from_whitelist:
- * @self: This #ModulemdBuildopts
+ * @self: This #ModulemdBuildopts object.
  * @rpm: An RPM name to remove from the whitelist.
  *
  * Since: 2.0
@@ -121,7 +124,7 @@ modulemd_buildopts_remove_rpm_from_whitelist (ModulemdBuildopts *self,
 
 /**
  * modulemd_buildopts_clear_rpm_whitelist:
- * @self: This #ModulemdBuildopts
+ * @self: This #ModulemdBuildopts object.
  *
  * Remove all RPMs from the whitelist.
  *
@@ -133,7 +136,7 @@ modulemd_buildopts_clear_rpm_whitelist (ModulemdBuildopts *self);
 
 /**
  * modulemd_buildopts_get_rpm_whitelist_as_strv: (rename-to modulemd_buildopts_get_rpm_whitelist)
- * @self: This #ModulemdBuildopts
+ * @self: This #ModulemdBuildopts object.
  *
  * Returns: (transfer full): An ordered #GStrv list of all RPMs in the whitelist.
  *

--- a/modulemd/v2/include/modulemd-2.0/modulemd-component-module.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-component-module.h
@@ -60,7 +60,7 @@ modulemd_component_module_set_ref (ModulemdComponentModule *self,
 
 /**
  * modulemd_component_module_get_ref:
- * @self: This #ModulemdComponentModule object
+ * @self: This #ModulemdComponentModule object.
  *
  * Returns: (transfer none): The commit ID in the SCM repository.
  *
@@ -72,7 +72,7 @@ modulemd_component_module_get_ref (ModulemdComponentModule *self);
 
 /**
  * modulemd_component_module_set_repository:
- * @self: This #ModulemdComponentModule object
+ * @self: This #ModulemdComponentModule object.
  * @repository: (in) (nullable): The URI of the SCM repository.
  *
  * Since: 2.0
@@ -84,7 +84,7 @@ modulemd_component_module_set_repository (ModulemdComponentModule *self,
 
 /**
  * modulemd_component_module_get_repository:
- * @self: This #ModulemdComponentModule object
+ * @self: This #ModulemdComponentModule object.
  *
  * Returns: (transfer none): The URI of the SCM repository.
  *

--- a/modulemd/v2/include/modulemd-2.0/modulemd-component-rpm.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-component-rpm.h
@@ -79,7 +79,8 @@ modulemd_component_rpm_reset_arches (ModulemdComponentRpm *self);
  * modulemd_component_rpm_get_arches_as_strv: (rename-to modulemd_component_rpm_get_arches)
  * @self: This #ModulemdComponentRpm object.
  *
- * Returns: (transfer full): A list of architectures on which this RPM should be available.
+ * Returns: (transfer full): A #GStrv list of architectures on which this RPM
+ * should be available.
  *
  * Since: 2.0
  */
@@ -92,7 +93,7 @@ modulemd_component_rpm_get_arches_as_strv (ModulemdComponentRpm *self);
  * @self: This #ModulemdComponentRpm object.
  * @arch: An architecture on which this package should be multilib.
  *
- * Add an architectures on which this RPM will be multilib. It may be called
+ * Add an architecture on which this RPM will be multilib. It may be called
  * any number of times. Use modulemd_component_rpm_reset_multilib_arches() to
  * return to "no architectures".
  *
@@ -119,7 +120,8 @@ modulemd_component_rpm_reset_multilib_arches (ModulemdComponentRpm *self);
  * modulemd_component_rpm_get_multilib_arches_as_strv: (rename-to modulemd_component_rpm_get_multilib_arches)
  * @self: This #ModulemdComponentRpm object.
  *
- * Returns: (transfer full): A list of architectures on which multilib should be available.
+ * Returns: (transfer full): A #GStrv list of architectures on which multilib
+ * should be available.
  *
  * Since: 2.0
  */
@@ -165,7 +167,7 @@ modulemd_component_rpm_set_ref (ModulemdComponentRpm *self, const gchar *ref);
 
 /**
  * modulemd_component_rpm_get_ref:
- * @self: This #ModulemdComponentRpm object
+ * @self: This #ModulemdComponentRpm object.
  *
  * Returns: (transfer none): The commit ID in the SCM repository.
  *
@@ -177,7 +179,7 @@ modulemd_component_rpm_get_ref (ModulemdComponentRpm *self);
 
 /**
  * modulemd_component_rpm_set_repository:
- * @self: This #ModulemdComponentRpm object
+ * @self: This #ModulemdComponentRpm object.
  * @repository: (in) (nullable): The URI of the SCM repository.
  *
  * Since: 2.0
@@ -189,7 +191,7 @@ modulemd_component_rpm_set_repository (ModulemdComponentRpm *self,
 
 /**
  * modulemd_component_rpm_get_repository:
- * @self: This #ModulemdComponentRpm object
+ * @self: This #ModulemdComponentRpm object.
  *
  * Returns: (transfer none): The URI of the SCM repository.
  *

--- a/modulemd/v2/include/modulemd-2.0/modulemd-component.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-component.h
@@ -45,10 +45,10 @@ struct _ModulemdComponentClass
 
 /**
  * modulemd_component_equals:
- * @self_1: A #ModulemdComponent object
- * @self_2: A #ModulemdComponent object
+ * @self_1: A #ModulemdComponent object.
+ * @self_2: A #ModulemdComponent object.
  *
- * Returns: TRUE, if both the objects are equal. FALSE, otherwise
+ * Returns: TRUE, if both the objects are equal. FALSE, otherwise.
  *
  * Since: 2.3
  */
@@ -59,12 +59,12 @@ modulemd_component_equals (ModulemdComponent *self_1,
 
 /**
  * modulemd_component_copy:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  * @key: (in) (nullable): An optional new key for the copied component which is
  * used as the lookup key when this component is attached to a
  * #ModulemdModuleStream.
  *
- * Returns: (transfer full): A newly-allocated copy of @self
+ * Returns: (transfer full): A newly-allocated copy of @self.
  *
  * Since: 2.0
  */
@@ -74,7 +74,7 @@ modulemd_component_copy (ModulemdComponent *self, const gchar *key);
 
 /**
  * modulemd_component_validate:
- * @self: (in): This #ModulemdComponent.
+ * @self: (in): This #ModulemdComponent object.
  * @error: (out): A #GError that will return the reason for a validation error.
  *
  * Verifies that all stored values are internally consistent and that the
@@ -92,7 +92,7 @@ modulemd_component_validate (ModulemdComponent *self, GError **error);
 
 /**
  * modulemd_component_add_buildafter:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  * @key: (in): A key representing another component in the
  * #ModulemdModuleStream components map.
  *
@@ -106,7 +106,7 @@ modulemd_component_add_buildafter (ModulemdComponent *self, const gchar *key);
 
 /**
  * modulemd_component_clear_buildafter:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  *
  * Remove all buildafter entries for this component.
  *
@@ -118,7 +118,7 @@ modulemd_component_clear_buildafter (ModulemdComponent *self);
 
 /**
  * modulemd_component_get_buildafter_as_strv: (rename-to modulemd_component_get_buildafter)
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  *
  * Returns: (transfer full): The set of component keys that this component
  * depends upon.
@@ -131,7 +131,7 @@ modulemd_component_get_buildafter_as_strv (ModulemdComponent *self);
 
 /**
  * modulemd_component_set_buildonly:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  * @buildonly: Whether this component is used only for building this module. If
  * set to TRUE, the build system should add any artifacts produced by this
  * component to the data.filters section of the output modulemd.
@@ -144,7 +144,7 @@ modulemd_component_set_buildonly (ModulemdComponent *self, gboolean buildonly);
 
 /**
  * modulemd_component_get_buildonly:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  *
  * Returns: TRUE if this component is used only for building this module.
  *
@@ -156,7 +156,7 @@ modulemd_component_get_buildonly (ModulemdComponent *self);
 
 /**
  * modulemd_component_set_buildorder:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  * @buildorder: The order this component should be built relative to others.
  *
  * Since: 2.0
@@ -167,9 +167,9 @@ modulemd_component_set_buildorder (ModulemdComponent *self, gint64 buildorder);
 
 /**
  * modulemd_component_get_buildorder:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  *
- * Returns: The value of the buildorder
+ * Returns: The value of the buildorder.
  *
  * Since: 2.0
  */
@@ -196,7 +196,7 @@ modulemd_component_set_name (ModulemdComponent *self, const gchar *name);
 
 /**
  * modulemd_component_get_name:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  *
  * Returns: (transfer none): The name of the component. Note that this may be
  * different from the key used to save this component to a
@@ -211,7 +211,7 @@ modulemd_component_get_name (ModulemdComponent *self);
 
 /**
  * modulemd_component_get_key:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  *
  * Returns: (transfer none): The name of the key used to attach this component
  * to a #ModulemdModuleStream.
@@ -224,7 +224,7 @@ modulemd_component_get_key (ModulemdComponent *self);
 
 /**
  * modulemd_component_set_rationale:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  * @rationale: (in) (nullable): The reason that this component is part of the
  * stream.
  *
@@ -237,7 +237,7 @@ modulemd_component_set_rationale (ModulemdComponent *self,
 
 /**
  * modulemd_component_get_rationale:
- * @self: This #ModulemdComponent object
+ * @self: This #ModulemdComponent object.
  *
  * Returns: (transfer none): The rationale.
  *

--- a/modulemd/v2/include/modulemd-2.0/modulemd-defaults-v1.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-defaults-v1.h
@@ -88,8 +88,8 @@ modulemd_defaults_v1_get_default_stream (ModulemdDefaultsV1 *self,
  * separate defaults for this module, it will return the generic stream
  * profiles.
  *
- * Returns: (transfer full): A sorted list of unique stream names for which
- * default profiles have been assigned.
+ * Returns: (transfer full): A sorted #GStrv list of unique stream names for
+ * which default profiles have been assigned.
  *
  * Since: 2.0
  */
@@ -124,8 +124,8 @@ modulemd_defaults_v1_add_default_profile_for_stream (ModulemdDefaultsV1 *self,
 /**
  * modulemd_defaults_v1_set_empty_default_profiles_for_stream:
  * @self: (in): This #ModulemdDefaultsV1 object.
- * @stream_name: (in): The name of the module stream to which to add this
- * default profile.
+ * @stream_name: (in): The name of the module stream for which to empty
+ * default profiles.
  * @intent: (in) (nullable): The name of the system intent from which to clear
  * the profile defaults for this stream.
  *
@@ -141,8 +141,8 @@ modulemd_defaults_v1_set_empty_default_profiles_for_stream (
 /**
  * modulemd_defaults_v1_remove_default_profiles_for_stream:
  * @self: (in): This #ModulemdDefaultsV1 object.
- * @stream_name: (in): The name of the module stream to which to add this
- * default profile.
+ * @stream_name: (in): The name of the module stream from which to remove
+ * default profiles.
  * @intent: (in) (nullable): The name of the system intent from which to remove
  * the profile defaults for this stream.
  *
@@ -164,9 +164,9 @@ modulemd_defaults_v1_remove_default_profiles_for_stream (
  * @intent: (in) (nullable): The name of the system intent from which to
  * retrieve the profile defaults for this stream.
  *
- * Returns: (transfer full): A sorted list of unique profiles to be installed
- * by default for this stream. NULL, if this stream_name is not present in the
- * defaults.
+ * Returns: (transfer full): A sorted #GStrv list of unique profiles to be
+ * installed by default for this stream. NULL, if this stream_name is not
+ * present in the defaults.
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd-defaults.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-defaults.h
@@ -74,12 +74,12 @@ struct _ModulemdDefaultsClass
 
 /**
  * modulemd_defaults_new:
- * @version: The version of the defaults metadata to create
- * @module_name: The name of the module to which these defaults apply
+ * @version: The version of the defaults metadata to create.
+ * @module_name: The name of the module to which these defaults apply.
  *
  * Create a new #ModulemdDefaults.
  *
- * Returns: (transfer full): a newly created #ModulemdDefaults subtype of the
+ * Returns: (transfer full): A newly created #ModulemdDefaults subtype of the
  * requested version.
  *
  * Since: 2.0
@@ -90,9 +90,9 @@ modulemd_defaults_new (guint64 version, const gchar *module_name);
 
 /**
  * modulemd_defaults_copy:
- * @self: (in): This #ModulemdDefaults object
+ * @self: (in): This #ModulemdDefaults object.
  *
- * Returns: (transfer full): A newly-allocated copy of @self
+ * Returns: (transfer full): A newly-allocated copy of @self.
  *
  * Since: 2.0
  */
@@ -102,7 +102,7 @@ modulemd_defaults_copy (ModulemdDefaults *self);
 
 /**
  * modulemd_defaults_validate:
- * @self: (in): This #ModulemdDefaults object
+ * @self: (in): This #ModulemdDefaults object.
  * @error: (out):  A #GError that will return the reason for a validation error.
  *
  * Returns: TRUE if validation passed, FALSE and sets @error appropriately if
@@ -119,7 +119,7 @@ modulemd_defaults_validate (ModulemdDefaults *self, GError **error);
  * @self_1: (in): A #ModulemdDefaults object
  * @self_2: (in): A #ModulemdDefaults object
  *
- * Returns: TRUE if both self_1 and self_2 contain equal values, FALSE if they differed.
+ * Returns: TRUE if both @self_1 and @self_2 contain equal values, FALSE if they differed.
  *
  * Since: 2.2
  */
@@ -129,7 +129,7 @@ modulemd_defaults_equals (ModulemdDefaults *self_1, ModulemdDefaults *self_2);
 
 /**
  * modulemd_defaults_upgrade:
- * @self: (in): This #ModulemdDefaults object
+ * @self: (in): This #ModulemdDefaults object.
  * @mdversion: (in): The version to upgrade to.
  * @error: (out):  A #GError that will return the reason for an upgrade error.
  *
@@ -147,7 +147,7 @@ modulemd_defaults_upgrade (ModulemdDefaults *self,
 
 /**
  * modulemd_defaults_get_module_name:
- * @self: (in): This #ModulemdDefaults object
+ * @self: (in): This #ModulemdDefaults object.
  *
  * Returns: (transfer none): The name of the module to which these defaults
  * apply.
@@ -160,7 +160,7 @@ modulemd_defaults_get_module_name (ModulemdDefaults *self);
 
 /**
  * modulemd_defaults_get_mdversion:
- * @self: (in): This #ModulemdDefaults object
+ * @self: (in): This #ModulemdDefaults object.
  *
  * Returns: The metadata version of this defaults object.
  *
@@ -172,7 +172,7 @@ modulemd_defaults_get_mdversion (ModulemdDefaults *self);
 
 /**
  * modulemd_defaults_set_modified:
- * @self: (in): This #ModulemdDefaults object
+ * @self: (in): This #ModulemdDefaults object.
  * @modified: (in): The last modified time represented as a 64-bit integer
  * (such as 201807011200)
  *
@@ -184,7 +184,7 @@ modulemd_defaults_set_modified (ModulemdDefaults *self, guint64 modified);
 
 /**
  * modulemd_defaults_get_modified:
- * @self: (in): This #ModulemdDefaults object
+ * @self: (in): This #ModulemdDefaults object.
  *
  * Returns: The last modified time represented as a 64-bit integer
  * (such as 201807011200)

--- a/modulemd/v2/include/modulemd-2.0/modulemd-dependencies.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-dependencies.h
@@ -32,8 +32,8 @@ G_DECLARE_FINAL_TYPE (
 /**
  * modulemd_dependencies_new:
  *
- * Returns: (transfer full): A newly-allocated #ModulemdDependencies. This
- * object must be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModulemdDependencies object.
+ * This object must be freed with g_object_unref().
  *
  * Since: 2.0
  */
@@ -43,10 +43,10 @@ modulemd_dependencies_new (void);
 
 /**
  * modulemd_dependencies_equals:
- * @self_1: A #ModulemdDependencies
- * @self_2: A #ModulemdDependencies
+ * @self_1: A #ModulemdDependencies object.
+ * @self_2: A #ModulemdDependencies object.
  *
- * Check if self_1 and self_2 are equal objects
+ * Check if @self_1 and @self_2 are equal objects.
  *
  * Returns: TRUE, if the're equal. FALSE, otherwise.
  *
@@ -59,11 +59,11 @@ modulemd_dependencies_equals (ModulemdDependencies *self_1,
 
 /**
  * modulemd_dependencies_copy:
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  *
  * Create a copy of this #ModulemdDependencies object.
  *
- * Returns: (transfer full): a copied #ModulemdDependencies object
+ * Returns: (transfer full): The copied #ModulemdDependencies object.
  *
  * Since: 2.0
  */
@@ -73,11 +73,14 @@ modulemd_dependencies_copy (ModulemdDependencies *self);
 
 /**
  * modulemd_dependencies_add_buildtime_stream:
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  * @module_name: The name of the module to depend on.
  * @module_stream: The name of the module stream to depend on.
  *
- * Add a single stream of a module that is required to build another dependent module. The matrix of streams and module names will be calculated by the build-system. If the provided module name is already present, the streams will be added (with deduplication).
+ * Add a single stream of a module that is required to build another dependent
+ * module. The matrix of streams and module names will be calculated by the
+ * build-system. If the provided module name is already present, the streams
+ * will be added (with deduplication).
  *
  * Since: 2.0
  */
@@ -89,7 +92,7 @@ modulemd_dependencies_add_buildtime_stream (ModulemdDependencies *self,
 
 /**
  * modulemd_dependencies_set_empty_buildtime_dependencies_for_module:
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  * @module_name: The name of the module to add dependencies on.
  *
  * Adds a module and inserts an empty list for it as buildtime dependency.
@@ -103,11 +106,11 @@ modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
 
 /**
  * modulemd_dependencies_clear_buildtime_dependencies:
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  *
- * Remove all buildtime dependencies from this #ModulemdDependencies object
+ * Remove all buildtime dependencies from this #ModulemdDependencies object.
  *
- * Since 2.5
+ * Since: 2.5
  */
 void
 modulemd_dependencies_clear_buildtime_dependencies (
@@ -116,9 +119,10 @@ modulemd_dependencies_clear_buildtime_dependencies (
 
 /**
  * modulemd_dependencies_get_buildtime_modules_as_strv: (rename-to modulemd_dependencies_get_buildtime_modules)
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  *
- * Returns: (transfer full): An ordered list of module names of build-time dependencies.
+ * Returns: (transfer full): An ordered #GStrv list of module names of
+ * build-time dependencies.
  *
  * Since: 2.0
  */
@@ -129,10 +133,12 @@ modulemd_dependencies_get_buildtime_modules_as_strv (
 
 /**
  * modulemd_dependencies_get_buildtime_streams_as_strv: (rename-to modulemd_dependencies_get_buildtime_streams)
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  * @module: The name of the module.
  *
- * Returns: (transfer full) (nullable): An ordered list of module streams associated with the specified module that are required at build-time.
+ * Returns: (transfer full) (nullable): An ordered #GStrv list of module
+ * streams associated with the specified module that are required at
+ * build-time.
  *
  * Since: 2.0
  */
@@ -143,11 +149,14 @@ modulemd_dependencies_get_buildtime_streams_as_strv (
 
 /**
  * modulemd_dependencies_add_runtime_stream:
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  * @module_name: The name of the module to depend on.
  * @module_stream: The name of the module stream to depend on.
  *
- * Adds a module and its stream that is required at runtime by a dependent module. The matrix of streams and module names will be calculated by the build-system. If the listed provided module name is already present, the streams will be added (with deduplication).
+ * Adds a module and its stream that is required at runtime by a dependent
+ * module. The matrix of streams and module names will be calculated by the
+ * build-system. If the listed provided module name is already present, the
+ * streams will be added (with deduplication).
  *
  * Since: 2.0
  */
@@ -159,7 +168,7 @@ modulemd_dependencies_add_runtime_stream (ModulemdDependencies *self,
 
 /**
  * modulemd_dependencies_set_empty_runtime_dependencies_for_module:
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  * @module_name: The name of the module to add dependencies on.
  *
  * Adds a module and inserts an empty list for it as runtime dependency.
@@ -173,11 +182,11 @@ modulemd_dependencies_set_empty_runtime_dependencies_for_module (
 
 /**
  * modulemd_dependencies_clear_runtime_dependencies:
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  *
- * Remove all runtime dependencies from this #ModulemdDependencies object
+ * Remove all runtime dependencies from this #ModulemdDependencies object.
  *
- * Since 2.5
+ * Since: 2.5
  */
 void
 modulemd_dependencies_clear_runtime_dependencies (ModulemdDependencies *self);
@@ -185,9 +194,10 @@ modulemd_dependencies_clear_runtime_dependencies (ModulemdDependencies *self);
 
 /**
  * modulemd_dependencies_get_runtime_modules_as_strv: (rename-to modulemd_dependencies_get_runtime_modules)
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  *
- * Returns: (transfer full): An ordered list of module names of run-time dependencies.
+ * Returns: (transfer full): An ordered #GStrv list of module names of run-time
+ * dependencies.
  *
  * Since: 2.0
  */
@@ -197,10 +207,11 @@ modulemd_dependencies_get_runtime_modules_as_strv (ModulemdDependencies *self);
 
 /**
  * modulemd_dependencies_get_runtime_streams_as_strv: (rename-to modulemd_dependencies_get_runtime_streams)
- * @self: This #ModulemdDependencies
+ * @self: This #ModulemdDependencies object.
  * @module: The name of the module.
  *
- * Returns: (transfer full) (nullable): An ordered list of module streams associated with the specified module that are required at run-time.
+ * Returns: (transfer full) (nullable): An ordered #GStrv list of module streams
+ * associated with the specified module that are required at run-time.
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index-merger.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index-merger.h
@@ -107,7 +107,7 @@ G_DECLARE_FINAL_TYPE (ModulemdModuleIndexMerger,
 /**
  * modulemd_module_index_merger_new:
  *
- * Returns: (transfer full): A newly-allocated Modulemd.ModuleIndexMerger
+ * Returns: (transfer full): A newly-allocated #ModulemdModuleIndexMerger
  * object.
  *
  * Since: 2.0
@@ -165,9 +165,9 @@ modulemd_module_index_merger_associate_index (ModulemdModuleIndexMerger *self,
  * modulemd_module_index_merger_resolve_ext() with
  * `strict_default_streams=FALSE`.
  *
- * Returns: (transfer full): A newly-allocated #ModulemdModuleIndex containing
- * the merged results. If this function encounters an unresolvable merge
- * conflict, it will return NULL and set @error appropriately.
+ * Returns: (transfer full): A newly-allocated #ModulemdModuleIndex object
+ * containing the merged results. If this function encounters an unresolvable
+ * merge conflict, it will return NULL and set @error appropriately.
  *
  * Since: 2.0
  */
@@ -193,9 +193,9 @@ modulemd_module_index_merger_resolve (ModulemdModuleIndexMerger *self,
  * #ModulemdModuleIndexMerger is undefined. The only valid action on it after
  * that point is g_object_unref().
  *
- * Returns: (transfer full): A newly-allocated #ModulemdModuleIndex containing
- * the merged results. If this function encounters an unresolvable merge
- * conflict, it will return NULL and set @error appropriately.
+ * Returns: (transfer full): A newly-allocated #ModulemdModuleIndex object
+ * containing the merged results. If this function encounters an unresolvable
+ * merge conflict, it will return NULL and set @error appropriately.
  *
  * Since: 2.6
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-index.h
@@ -139,7 +139,7 @@ modulemd_module_index_new (void);
 
 /**
  * modulemd_module_index_update_from_file:
- * @self: This #ModulemdModuleIndex object
+ * @self: This #ModulemdModuleIndex object.
  * @yaml_file: (in): A YAML file containing the module metadata and other
  * related information such as default streams.
  * @strict: (in): Whether the parser should return failure if it encounters an
@@ -147,10 +147,10 @@ modulemd_module_index_new (void);
  * @failures: (out) (element-type ModulemdSubdocumentInfo) (transfer container):
  * An array containing any subdocuments from the YAML file that failed to parse.
  * See #ModulemdSubdocumentInfo for more details.
- * @error: (out): A GError containing additional information if this function
+ * @error: (out): A #GError containing additional information if this function
  * fails in a way that prevents program continuation.
  *
- * Returns: TRUE if the update was successful. Returns FALSE and sets failures
+ * Returns: TRUE if the update was successful. Returns FALSE and sets @failures
  * approriately if any of the YAML subdocuments were invalid or sets @error if
  * there was a fatal parse error.
  *
@@ -166,7 +166,7 @@ modulemd_module_index_update_from_file (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_update_from_string:
- * @self: This #ModulemdModuleIndex object
+ * @self: This #ModulemdModuleIndex object.
  * @yaml_string: (in): A YAML string containing the module metadata and other
  * related information such as default streams.
  * @strict: (in): Whether the parser should return failure if it encounters an
@@ -174,10 +174,10 @@ modulemd_module_index_update_from_file (ModulemdModuleIndex *self,
  * @failures: (out) (element-type ModulemdSubdocumentInfo) (transfer container):
  * An array containing any subdocuments from the YAML file that failed to parse.
  * See #ModulemdSubdocumentInfo for more details.
- * @error: (out): A GError containing additional information if this function
+ * @error: (out): A #GError containing additional information if this function
  * fails in a way that prevents program continuation.
  *
- * Returns: TRUE if the update was successful. Returns FALSE and sets failures
+ * Returns: TRUE if the update was successful. Returns FALSE and sets @failures
  * approriately if any of the YAML subdocuments were invalid or sets @error if
  * there was a fatal parse error.
  *
@@ -193,7 +193,7 @@ modulemd_module_index_update_from_string (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_update_from_stream: (skip)
- * @self: This #ModulemdModuleIndex object
+ * @self: This #ModulemdModuleIndex object.
  * @yaml_stream: (in): A YAML stream containing the module metadata and other
  * related information such as default streams.
  * @strict: (in): Whether the parser should return failure if it encounters an
@@ -201,10 +201,10 @@ modulemd_module_index_update_from_string (ModulemdModuleIndex *self,
  * @failures: (out) (element-type ModulemdSubdocumentInfo) (transfer container):
  * An array containing any subdocuments from the YAML file that failed to parse.
  * See #ModulemdSubdocumentInfo for more details.
- * @error: (out): A GError containing additional information if this function
+ * @error: (out): A #GError containing additional information if this function
  * fails in a way that prevents program continuation.
  *
- * Returns: TRUE if the update was successful. Returns FALSE and sets failures
+ * Returns: TRUE if the update was successful. Returns FALSE and sets @failures
  * approriately if any of the YAML subdocuments were invalid or sets @error if
  * there was a fatal parse error.
  *
@@ -220,7 +220,7 @@ modulemd_module_index_update_from_stream (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_update_from_custom: (skip)
- * @self: This #ModulemdModuleIndex object
+ * @self: This #ModulemdModuleIndex object.
  * @custom_read_fn: (in): A #ModulemdReadHandler
  * @custom_pvt_data: (inout): The private data needed by the #ModulemdReadHandler
  * @strict: (in): Whether the parser should return failure if it encounters an
@@ -228,7 +228,7 @@ modulemd_module_index_update_from_stream (ModulemdModuleIndex *self,
  * @failures: (out) (element-type ModulemdSubdocumentInfo) (transfer container):
  * An array containing any subdocuments from the YAML file that failed to parse.
  * See #ModulemdSubdocumentInfo for more details.
- * @error: (out): A GError containing additional information if this function
+ * @error: (out): A #GError containing additional information if this function
  * fails in a way that prevents program continuation.
  *
  * Returns: TRUE if the update was successful. Returns FALSE and sets @failures
@@ -248,12 +248,12 @@ modulemd_module_index_update_from_custom (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_dump_to_string:
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  * @error: (out): A #GError containing the reason the function failed, NULL if
  * the function succeeded.
  *
  * Returns: (transfer full): A YAML representation of the index as a string. In
- * the event of an error, sets error appropriately and returns NULL.
+ * the event of an error, sets @error appropriately and returns NULL.
  *
  * Since: 2.0
  */
@@ -263,13 +263,13 @@ modulemd_module_index_dump_to_string (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_dump_to_stream: (skip)
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  * @yaml_stream: (in): A stream to write the module metadata and other related
  * information to.
  * @error: (out): A #GError containing the reason the function failed, NULL if
  * the function succeeded.
  *
- * Returns: TRUE if written successfully, FALSE and sets error appropriately in
+ * Returns: TRUE if written successfully, FALSE and sets @error appropriately in
  * the event of an error.
  *
  * Since: 2.0
@@ -282,14 +282,14 @@ modulemd_module_index_dump_to_stream (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_dump_to_custom: (skip)
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  * @custom_write_fn: (in): A #ModulemdWriteHandler
  * @custom_pvt_data: (inout): The private data needed by the
  * #ModulemdWriteHandler
  * @error: (out): A #GError containing the reason the function failed, NULL if
  * the function succeeded
  *
- * Returns: TRUE if written successfully, FALSE and sets error appropriately in
+ * Returns: TRUE if written successfully, FALSE and sets @error appropriately in
  * the event of an error.
  *
  * Since: 2.3
@@ -303,7 +303,7 @@ modulemd_module_index_dump_to_custom (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_get_module_names_as_strv: (rename-to modulemd_module_index_get_module_names)
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  *
  * Returns: (transfer full): An ordered list of string keys in this index.
  *
@@ -315,7 +315,7 @@ modulemd_module_index_get_module_names_as_strv (ModulemdModuleIndex *self);
 
 /**
  * modulemd_module_index_get_module:
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  * @module_name: The module name to look up in the index.
  *
  * Returns: (transfer none): The #ModulemdModule object matching the provided
@@ -330,7 +330,7 @@ modulemd_module_index_get_module (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_remove_module:
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  * @module_name: The name of the module to remove from the index.
  *
  * Remove a module, including all of its streams, its defaults and its
@@ -348,14 +348,14 @@ modulemd_module_index_remove_module (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_add_module_stream:
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  * @stream: The #ModulemdModuleStream to add to the index. The stream added
  * must have a module name and stream name set on it or it will be rejected.
  * @error: (out): A #GError containing the reason the #ModulemdModuleStream
  * object could not be added or NULL if the function succeeded.
  *
  * Add a #ModulemdModuleStream to the #ModulemdModuleIndex. While being added,
- * the #ModulemdModuleStream will be upgraded to MD_MODULESTREAM_VERSION_LATEST
+ * the #ModulemdModuleStream will be upgraded to %MD_MODULESTREAM_VERSION_LATEST
  * to ensure that merges done with #ModulemdModuleIndexMerger will always occur
  * between streams of the same version. If this upgrade cannot be performed,
  * the function will return @error set appropriately.
@@ -374,14 +374,14 @@ modulemd_module_index_add_module_stream (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_add_defaults:
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  * @defaults: The #ModulemdDefaults object to add to the index.
  * @error: (out): A #GError containing the reason the #ModulemdDefaults object
  * could not be added or NULL if the function succeeded.
  *
  * Returns: TRUE if the #ModulemdDefaults was added successfully. If the defaults
  * already existed in the index, it will be replaced by the new one. On failure,
- * returns FALSE and sets error approriately.
+ * returns FALSE and sets @error approriately.
  *
  * Since: 2.0
  */
@@ -393,14 +393,14 @@ modulemd_module_index_add_defaults (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_get_default_streams_as_hash_table: (rename-to modulemd_module_index_get_default_streams)
- * @self: (in): This #ModulemdModuleIndex
+ * @self: (in): This #ModulemdModuleIndex object.
  * @intent: (in) (nullable): The name of the system intent whose default stream
  * will be retrieved. If left NULL or the specified intent has no separate
  * default, it will return the generic default stream for this module.
  *
  * Get a dictionary of all modules in the index that have a default stream.
  *
- * This function cannot fail, but may return an empty (non-NULL) GHashTable.
+ * This function cannot fail, but may return an empty (non-NULL) #GHashTable.
  *
  * Returns: (transfer container) (element-type utf8 utf8): A #GHashTable with
  * the module name as the key and the default stream as the value for all
@@ -416,14 +416,14 @@ modulemd_module_index_get_default_streams_as_hash_table (
 
 /**
  * modulemd_module_index_add_translation:
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  * @translation: The #ModulemdTranslation object to add to the index.
  * @error: (out): A #GError containing the reason the #ModulemdTranslation
  * object could not be added or NULL if the function succeeded.
  *
  * Returns: TRUE if the #ModulemdTranslation was added successfully. If the
  * translation already existed in the index, it will be replaced by the new one.
- * On failure, returns FALSE and sets error appropriately.
+ * On failure, returns FALSE and sets @error appropriately.
  *
  * Since: 2.0
  */
@@ -434,7 +434,7 @@ modulemd_module_index_add_translation (ModulemdModuleIndex *self,
 
 /**
  * modulemd_module_index_get_defaults_mdversion:
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  *
  * Returns: The metadata version of #ModulemdDefaults in use for this index.
  *
@@ -446,7 +446,7 @@ modulemd_module_index_get_defaults_mdversion (ModulemdModuleIndex *self);
 
 /**
  * modulemd_module_index_get_stream_mdversion:
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  *
  * Returns: The metadata version of #ModulemdModuleStream in use for this
  * index.
@@ -459,7 +459,7 @@ modulemd_module_index_get_stream_mdversion (ModulemdModuleIndex *self);
 
 /**
  * modulemd_module_index_upgrade_streams:
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  * @mdversion: The #ModulemdModuleStream metadata version to upgrade to.
  * @error: (out): A #GError that contains information on why the index could
  * not be upgraded in the event of an error.
@@ -478,7 +478,7 @@ modulemd_module_index_upgrade_streams (
 
 /**
  * modulemd_module_index_upgrade_defaults:
- * @self: This #ModulemdModuleIndex
+ * @self: This #ModulemdModuleIndex object.
  * @mdversion: The #ModulemdDefaults metadata version to upgrade to.
  * @error: (out): A #GError that contains information on why the index could
  * not be upgraded in the event of an error.

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v1.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v1.h
@@ -155,13 +155,15 @@ modulemd_module_stream_v1_set_description (ModulemdModuleStreamV1 *self,
 
 /**
  * modulemd_module_stream_v1_get_description:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
  * @locale: (in) (nullable): The name of the locale to use when translating
  * the string. If NULL, it will determine the locale with a system call to
- * setlocale(LC_MESSAGES, NULL) and return the that. If the caller wants the
- * untranslated string, they should pass "C" for the locale.
+ * `setlocale(LC_MESSAGES, NULL)` and return that. If the caller wants the
+ * untranslated string, they should pass `"C"` for the locale.
  *
  * Returns: (transfer none): The module description, translated to the
- * requested locale if available.
+ * requested locale if available. Translation information is managed by the
+ * #ModulemdTranslation and #ModulemdTranslationEntry objects.
  *
  * Since: 2.0
  */
@@ -212,13 +214,15 @@ modulemd_module_stream_v1_set_summary (ModulemdModuleStreamV1 *self,
 
 /**
  * modulemd_module_stream_v1_get_summary:
+ * @self: (in): This #ModulemdModuleStreamV1 object.
  * @locale: (in) (nullable): The name of the locale to use when translating
  * the string. If NULL, it will determine the locale with a system call to
- * setlocale(LC_MESSAGES, NULL) and return the that. If the caller wants the
- * untranslated string, they should pass "C" for the locale.
+ * `setlocale(LC_MESSAGES, NULL)` and return that. If the caller wants the
+ * untranslated string, they should pass `"C"` for the locale.
  *
  * Returns: (transfer none): The module summary, translated to the requested
- * locale if available.
+ * locale if available. Translation information is managed by the
+ * #ModulemdTranslation and #ModulemdTranslationEntry objects.
  *
  * Since: 2.0
  */
@@ -330,8 +334,8 @@ modulemd_module_stream_v1_clear_rpm_components (ModulemdModuleStreamV1 *self);
  * modulemd_module_stream_v1_get_module_component_names_as_strv: (rename-to modulemd_module_stream_v1_get_module_component_names)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of module component names included
- * in this stream.
+ * Returns: (transfer full): An ordered #GStrv list of module component names
+ * included in this stream.
  *
  * Since: 2.0
  */
@@ -343,8 +347,8 @@ modulemd_module_stream_v1_get_module_component_names_as_strv (
  * modulemd_module_stream_v1_get_rpm_component_names_as_strv: (rename-to modulemd_module_stream_v1_get_rpm_component_names)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of RPM component names included
- * in this stream.
+ * Returns: (transfer full): An ordered #GStrv list of RPM component names
+ * included in this stream.
  *
  * Since: 2.0
  */
@@ -358,7 +362,7 @@ modulemd_module_stream_v1_get_rpm_component_names_as_strv (
  * @self: (in): This #ModulemdModuleStreamV1 object.
  * @component_name: (in): The name of the component to retrieve.
  *
- * Returns: (transfer none): The module component matching @component name if
+ * Returns: (transfer none): The module component matching @component_name if
  * it exists, else NULL.
  *
  * Since: 2.0
@@ -373,7 +377,7 @@ modulemd_module_stream_v1_get_module_component (ModulemdModuleStreamV1 *self,
  * @self: (in): This #ModulemdModuleStreamV1 object.
  * @component_name: (in): The name of the component to retrieve.
  *
- * Returns: (transfer none): The RPM component matching @component name if it
+ * Returns: (transfer none): The RPM component matching @component_name if it
  * exists, else NULL.
  *
  * Since: 2.0
@@ -463,8 +467,8 @@ modulemd_module_stream_v1_clear_module_licenses (ModulemdModuleStreamV1 *self);
  * modulemd_module_stream_v1_get_content_licenses_as_strv: (rename-to modulemd_module_stream_v1_get_content_licenses)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of licenses under which one or
- * more components of this module stream are released.
+ * Returns: (transfer full): An ordered #GStrv list of licenses under which one
+ * or more components of this module stream are released.
  *
  * Since: 2.0
  */
@@ -477,8 +481,8 @@ modulemd_module_stream_v1_get_content_licenses_as_strv (
  * modulemd_module_stream_v1_get_module_licenses_as_strv: (rename-to modulemd_module_stream_v1_get_module_licenses)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of licenses under which this
- * module stream is released.
+ * Returns: (transfer full): An ordered #GStrv list of licenses under which
+ * this module stream is released.
  *
  * Since: 2.0
  */
@@ -505,7 +509,7 @@ modulemd_module_stream_v1_add_profile (ModulemdModuleStreamV1 *self,
  * modulemd_module_stream_v1_clear_profiles:
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Removes all profiles from this module stream.
+ * Remove all profiles from this module stream.
  *
  * Since: 2.0
  */
@@ -517,8 +521,8 @@ modulemd_module_stream_v1_clear_profiles (ModulemdModuleStreamV1 *self);
  * modulemd_module_stream_v1_get_profile_names_as_strv: (rename-to modulemd_module_stream_v1_get_profile_names)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of profile names associated with
- * this module stream.
+ * Returns: (transfer full): An ordered #GStrv list of profile names associated
+ * with this module stream.
  *
  * Since: 2.0
  */
@@ -583,8 +587,8 @@ modulemd_module_stream_v1_clear_rpm_api (ModulemdModuleStreamV1 *self);
  * modulemd_module_stream_v1_get_rpm_api_as_strv: (rename-to modulemd_module_stream_v1_get_rpm_api)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of binary RPM names that forms
- * the public API of this module stream.
+ * Returns: (transfer full): An ordered #GStrv list of binary RPM names that
+ * forms the public API of this module stream.
  *
  * Since: 2.0
  */
@@ -620,7 +624,7 @@ modulemd_module_stream_v1_remove_rpm_artifact (ModulemdModuleStreamV1 *self,
  * modulemd_module_stream_v1_clear_rpm_artifacts:
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Remove all RPM NEVRs from the list of artifacts
+ * Remove all RPM NEVRs from the list of artifacts.
  *
  * Since: 2.5
  */
@@ -632,8 +636,8 @@ modulemd_module_stream_v1_clear_rpm_artifacts (ModulemdModuleStreamV1 *self);
  * modulemd_module_stream_v1_get_rpm_artifacts_as_strv: (rename-to modulemd_module_stream_v1_get_rpm_artifacts)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of RPM NEVRs are included in this
- * module stream.
+ * Returns: (transfer full): An ordered #GStrv list of RPM NEVRs are included
+ * in this module stream.
  *
  * Since: 2.0
  */
@@ -682,8 +686,8 @@ modulemd_module_stream_v1_clear_rpm_filters (ModulemdModuleStreamV1 *self);
  * modulemd_module_stream_v1_get_rpm_filters_as_strv: (rename-to modulemd_module_stream_v1_get_rpm_filters)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of binary RPM names that are
- * filtered out of this module stream.
+ * Returns: (transfer full): An ordered #GStrv list of binary RPM names that
+ * are filtered out of this module stream.
  *
  * Since: 2.0
  */
@@ -710,7 +714,7 @@ modulemd_module_stream_v1_add_servicelevel (
  * modulemd_module_stream_v1_clear_servicelevels:
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Removes all servicelevels from this module stream.
+ * Remove all servicelevels from this module stream.
  *
  * Since: 2.0
  */
@@ -722,8 +726,8 @@ modulemd_module_stream_v1_clear_servicelevels (ModulemdModuleStreamV1 *self);
  * modulemd_module_stream_v1_get_servicelevel_names_as_strv: (rename-to modulemd_module_stream_v1_get_servicelevel_names)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of servicelevel names associated with
- * this module stream.
+ * Returns: (transfer full): An ordered #GStrv list of servicelevel names
+ * associated with this module stream.
  *
  * Since: 2.0
  */
@@ -753,7 +757,7 @@ modulemd_module_stream_v1_get_servicelevel (ModulemdModuleStreamV1 *self,
  * @eol: (in): The end-of-life date for the "rawhide" service level.
  *
  * Comptibility function with early iterations of modulemd v1. This function is
- * a wrapper for Modulemd.ModuleStreamV1.add_servicelevel("rawhide", eol).
+ * a wrapper for `modulemd_module_stream_v1_add_servicelevel("rawhide", eol)`.
  *
  * Since: 2.0
  * Deprecated: 2.0
@@ -768,7 +772,7 @@ modulemd_module_stream_v1_set_eol (ModulemdModuleStreamV1 *self, GDate *eol);
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
  * Compatibility function with early iterations of modulemd v1. This function
- * is a wrapper for Modulemd.ModuleStreamV1.get_servicelevel("rawhide").
+ * is a wrapper for `modulemd_module_stream_v1_get_servicelevel("rawhide")`.
  *
  * Returns: (transfer none): The end-of-life date for the "rawhide" service
  * level.
@@ -872,8 +876,8 @@ modulemd_module_stream_v1_clear_runtime_requirements (
  * modulemd_module_stream_v1_get_buildtime_modules_as_strv: (rename-to modulemd_module_stream_v1_get_buildtime_modules)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of module names that this module
- * depends on at build-time.
+ * Returns: (transfer full): An ordered #GStrv list of module names that this
+ * module depends on at build-time.
  *
  * Since: 2.0
  */
@@ -886,8 +890,8 @@ modulemd_module_stream_v1_get_buildtime_modules_as_strv (
  * modulemd_module_stream_v1_get_runtime_modules_as_strv: (rename-to modulemd_module_stream_v1_get_runtime_modules)
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer full): An ordered list of module names that this module
- * depends on at runtime.
+ * Returns: (transfer full): An ordered #GStrv list of module names that this
+ * module depends on at runtime.
  *
  * Since: 2.0
  */
@@ -949,7 +953,7 @@ modulemd_module_stream_v1_set_xmd (ModulemdModuleStreamV1 *self,
  * modulemd_module_stream_v1_get_xmd:
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Returns: (transfer none): The extensible metadata block as a GVariant.
+ * Returns: (transfer none): The extensible metadata block as a #GVariant.
  */
 GVariant *
 modulemd_module_stream_v1_get_xmd (ModulemdModuleStreamV1 *self);

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream-v2.h
@@ -159,11 +159,12 @@ modulemd_module_stream_v2_set_description (ModulemdModuleStreamV2 *self,
  * @self: (in): This #ModulemdModuleStreamV2 object.
  * @locale: (in) (nullable): The name of the locale to use when translating
  * the string. If NULL, it will determine the locale with a system call to
- * setlocale(LC_MESSAGES, NULL) and return the that. If the caller wants the
- * untranslated string, they should pass "C" for the locale.
+ * `setlocale(LC_MESSAGES, NULL)` and return that. If the caller wants the
+ * untranslated string, they should pass `"C"` for the locale.
  *
  * Returns: (transfer none): The module description, translated to the
- * requested locale if available.
+ * requested locale if available. Translation information is managed by the
+ * #ModulemdTranslation and #ModulemdTranslationEntry objects.
  *
  * Since: 2.0
  */
@@ -217,11 +218,12 @@ modulemd_module_stream_v2_set_summary (ModulemdModuleStreamV2 *self,
  * @self: (in): This #ModulemdModuleStreamV2 object.
  * @locale: (in) (nullable): The name of the locale to use when translating
  * the string. If NULL, it will determine the locale with a system call to
- * setlocale(LC_MESSAGES, NULL) and return the that. If the caller wants the
- * untranslated string, they should pass "C" for the locale.
+ * `setlocale(LC_MESSAGES, NULL)` and return that. If the caller wants the
+ * untranslated string, they should pass `"C"` for the locale.
  *
  * Returns: (transfer none): The module summary, translated to the requested
- * locale if available.
+ * locale if available. Translation information is managed by the
+ * #ModulemdTranslation and #ModulemdTranslationEntry objects.
  *
  * Since: 2.0
  */
@@ -329,8 +331,8 @@ modulemd_module_stream_v2_clear_rpm_components (ModulemdModuleStreamV2 *self);
  * modulemd_module_stream_v2_get_module_component_names_as_strv: (rename-to modulemd_module_stream_v2_get_module_component_names)
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Returns: (transfer full): An ordered list of module component names included
- * in this stream.
+ * Returns: (transfer full): An ordered #GStrv list of module component names
+ * included in this stream.
  *
  * Since: 2.0
  */
@@ -342,8 +344,8 @@ modulemd_module_stream_v2_get_module_component_names_as_strv (
  * modulemd_module_stream_v2_get_rpm_component_names_as_strv: (rename-to modulemd_module_stream_v2_get_rpm_component_names)
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Returns: (transfer full): An ordered list of RPM component names included
- * in this stream.
+ * Returns: (transfer full): An ordered #GStrv list of RPM component names
+ * included in this stream.
  *
  * Since: 2.0
  */
@@ -357,7 +359,7 @@ modulemd_module_stream_v2_get_rpm_component_names_as_strv (
  * @self: (in): This #ModulemdModuleStreamV2 object.
  * @component_name: (in): The name of the component to retrieve.
  *
- * Returns: (transfer none): The module component matching @component name if
+ * Returns: (transfer none): The module component matching @component_name if
  * it exists, else NULL.
  *
  * Since: 2.0
@@ -372,7 +374,7 @@ modulemd_module_stream_v2_get_module_component (ModulemdModuleStreamV2 *self,
  * @self: (in): This #ModulemdModuleStreamV2 object.
  * @component_name: (in): The name of the component to retrieve.
  *
- * Returns: (transfer none): The RPM component matching @component name if it
+ * Returns: (transfer none): The RPM component matching @component_name if it
  * exists, else NULL.
  *
  * Since: 2.0
@@ -462,8 +464,8 @@ modulemd_module_stream_v2_clear_module_licenses (ModulemdModuleStreamV2 *self);
  * modulemd_module_stream_v2_get_content_licenses_as_strv: (rename-to modulemd_module_stream_v2_get_content_licenses)
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Returns: (transfer full): An ordered list of licenses under which one or
- * more components of this module stream are released.
+ * Returns: (transfer full): An ordered #GStrv list of licenses under which one
+ * or more components of this module stream are released.
  *
  * Since: 2.0
  */
@@ -476,8 +478,8 @@ modulemd_module_stream_v2_get_content_licenses_as_strv (
  * modulemd_module_stream_v2_get_module_licenses_as_strv: (rename-to modulemd_module_stream_v2_get_module_licenses)
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Returns: (transfer full): An ordered list of licenses under which this
- * module stream is released.
+ * Returns: (transfer full): An ordered #GStrv list of licenses under which
+ * this module stream is released.
  *
  * Since: 2.0
  */
@@ -504,7 +506,7 @@ modulemd_module_stream_v2_add_profile (ModulemdModuleStreamV2 *self,
  * modulemd_module_stream_v2_clear_profiles:
  * @self: (in): This #ModulemdModuleStreamV1 object.
  *
- * Removes all profiles from this module stream.
+ * Remove all profiles from this module stream.
  *
  * Since: 2.0
  */
@@ -516,8 +518,8 @@ modulemd_module_stream_v2_clear_profiles (ModulemdModuleStreamV2 *self);
  * modulemd_module_stream_v2_get_profile_names_as_strv: (rename-to modulemd_module_stream_v2_get_profile_names)
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Returns: (transfer full): An ordered list of profile names associated with
- * this module stream.
+ * Returns: (transfer full): An ordered #GStrv list of profile names associated
+ * with this module stream.
  *
  * Since: 2.0
  */
@@ -582,8 +584,8 @@ modulemd_module_stream_v2_clear_rpm_api (ModulemdModuleStreamV2 *self);
  * modulemd_module_stream_v2_get_rpm_api_as_strv: (rename-to modulemd_module_stream_v2_get_rpm_api)
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Returns: (transfer full): An ordered list of binary RPM names that forms
- * the public API of this module stream.
+ * Returns: (transfer full): An ordered #GStrv list of binary RPM names that
+ * form the public API of this module stream.
  *
  * Since: 2.0
  */
@@ -631,8 +633,8 @@ modulemd_module_stream_v2_clear_rpm_artifacts (ModulemdModuleStreamV2 *self);
  * modulemd_module_stream_v2_get_rpm_artifacts_as_strv: (rename-to modulemd_module_stream_v2_get_rpm_artifacts)
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Returns: (transfer full): An ordered list of RPM NEVRs are included in this
- * module stream.
+ * Returns: (transfer full): An ordered #GStrv list of RPM NEVRs that are
+ * included in this module stream.
  *
  * Since: 2.0
  */
@@ -716,8 +718,8 @@ modulemd_module_stream_v2_clear_rpm_filters (ModulemdModuleStreamV2 *self);
  * modulemd_module_stream_v2_get_rpm_filters_as_strv: (rename-to modulemd_module_stream_v2_get_rpm_filters)
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Returns: (transfer full): An ordered list of binary RPM names that are
- * filtered out of this module stream.
+ * Returns: (transfer full): An ordered #GStrv list of binary RPM names that
+ * are filtered out of this module stream.
  *
  * Since: 2.0
  */
@@ -744,7 +746,7 @@ modulemd_module_stream_v2_add_servicelevel (
  * modulemd_module_stream_v2_clear_servicelevels:
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Removes all servicelevels from this module stream.
+ * Remove all servicelevels from this module stream.
  *
  * Since: 2.0
  */
@@ -756,8 +758,8 @@ modulemd_module_stream_v2_clear_servicelevels (ModulemdModuleStreamV2 *self);
  * modulemd_module_stream_v2_get_servicelevel_names_as_strv: (rename-to modulemd_module_stream_v2_get_servicelevel_names)
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Returns: (transfer full): An ordered list of servicelevel names associated with
- * this module stream.
+ * Returns: (transfer full): An ordered #GStrv list of servicelevel names
+ * associated with this module stream.
  *
  * Since: 2.0
  */
@@ -801,7 +803,7 @@ modulemd_module_stream_v2_add_dependencies (ModulemdModuleStreamV2 *self,
  * modulemd_module_stream_v2_clear_dependencies:
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Empties the list of dependencies for this #ModulemdModuleStream
+ * Empties the list of dependencies for this #ModulemdModuleStream.
  *
  * Since: 2.4
  */
@@ -829,7 +831,7 @@ modulemd_module_stream_v2_remove_dependencies (ModulemdModuleStreamV2 *self,
  * modulemd_module_stream_v2_get_dependencies:
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Return the list of #ModulemdDependencies objects as a GPtrArray
+ * Return the list of #ModulemdDependencies objects as a #GPtrArray.
  *
  * Returns: (transfer none) (element-type ModulemdDependencies): A list of
  * all #ModulemdDependencies objects associated with this module stream.
@@ -861,7 +863,7 @@ modulemd_module_stream_v2_set_xmd (ModulemdModuleStreamV2 *self,
  * modulemd_module_stream_v2_get_xmd:
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *
- * Returns: (transfer none): The extensible metadata block as a GVariant.
+ * Returns: (transfer none): The extensible metadata block as a #GVariant.
  */
 GVariant *
 modulemd_module_stream_v2_get_xmd (ModulemdModuleStreamV2 *self);

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module-stream.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module-stream.h
@@ -207,10 +207,10 @@ modulemd_module_stream_read_stream (FILE *stream,
 
 /**
  * modulemd_module_stream_equals:
- * @self_1: (in): A #ModulemdModuleStream.
- * @self_2: (in): A #ModulemdModuleStream.
+ * @self_1: (in): A #ModulemdModuleStream object.
+ * @self_2: (in): A #ModulemdModuleStream object.
  *
- * Checks if self_1 and self_2 are identical objects.
+ * Checks if @self_1 and @self_2 are identical objects.
  *
  * Returns: TRUE, If both objects are equal. FALSE, otherwise.
  *
@@ -223,7 +223,7 @@ modulemd_module_stream_equals (ModulemdModuleStream *self_1,
 
 /**
  * modulemd_module_stream_copy:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  * @module_name: (in) (nullable): An optional new name for the module of the
  * copied stream.
  * @module_stream: (in) (nullable): An optional new name for the copied stream.
@@ -244,7 +244,7 @@ modulemd_module_stream_copy (ModulemdModuleStream *self,
 
 /**
  * modulemd_module_stream_upgrade:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  * @mdversion: (in): The metadata version to upgrade to. If zero, upgrades to
  * the highest-supported version.
  * @error: (out): A #GError that will return the reason for an upgrade error.
@@ -265,7 +265,7 @@ modulemd_module_stream_upgrade (ModulemdModuleStream *self,
 
 /**
  * modulemd_module_stream_validate:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  * @error: (out): A #GError that will return the reason for a validation error.
  *
  * Verifies that all stored values are internally consistent and that the
@@ -283,7 +283,7 @@ modulemd_module_stream_validate (ModulemdModuleStream *self, GError **error);
 
 /**
  * modulemd_module_stream_get_mdversion:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  *
  * Returns: The metadata version of this #ModulemdModuleStream.
  *
@@ -295,7 +295,7 @@ modulemd_module_stream_get_mdversion (ModulemdModuleStream *self);
 
 /**
  * modulemd_module_stream_get_module_name:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  *
  * Returns: (transfer none): The name of the module.
  *
@@ -307,7 +307,7 @@ modulemd_module_stream_get_module_name (ModulemdModuleStream *self);
 
 /**
  * modulemd_module_stream_get_stream_name:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  *
  * Returns: (transfer none): The name of this stream.
  *
@@ -319,8 +319,8 @@ modulemd_module_stream_get_stream_name (ModulemdModuleStream *self);
 
 /**
  * modulemd_module_stream_set_version:
- * @self: (in): This #ModulemdModuleStream.
- * @version: (in): The version of this #ModulemdModuleStream
+ * @self: (in): This #ModulemdModuleStream object.
+ * @version: (in): The version of this #ModulemdModuleStream.
  *
  * Since: 2.0
  */
@@ -331,7 +331,7 @@ modulemd_module_stream_set_version (ModulemdModuleStream *self,
 
 /**
  * modulemd_module_stream_get_version:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  *
  * Returns: The version of this #ModulemdModuleStream.
  */
@@ -340,7 +340,7 @@ modulemd_module_stream_get_version (ModulemdModuleStream *self);
 
 /**
  * modulemd_module_stream_set_context:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  * @context: (in) (nullable): Module context flag.
  * The context flag serves to distinguish module builds with the same name,
  * stream and version and plays an important role in automatic module stream
@@ -355,7 +355,7 @@ modulemd_module_stream_set_context (ModulemdModuleStream *self,
 
 /**
  * modulemd_module_stream_get_context:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  *
  * Returns: (transfer none): Module context flag.
  * The context flag serves to distinguish module builds with the same name,
@@ -370,7 +370,7 @@ modulemd_module_stream_get_context (ModulemdModuleStream *self);
 
 /**
  * modulemd_module_stream_set_arch:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  * @arch: (in) (nullable): Module architecture.
  * Indicates to which processor architecture this #ModulemdModuleStream
  * applies.
@@ -384,9 +384,9 @@ modulemd_module_stream_set_arch (ModulemdModuleStream *self,
 
 /**
  * modulemd_module_stream_get_arch:
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  *
- * Returns: (transfer none): Module architecture.
+ * Returns: (transfer none): Module architecture object.
  * Indicates to which processor architecture this #ModulemdModuleStream
  * applies.
  *
@@ -398,7 +398,7 @@ modulemd_module_stream_get_arch (ModulemdModuleStream *self);
 
 /**
  * modulemd_module_stream_get_nsvc_as_string: (rename-to modulemd_module_stream_get_nsvc)
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  *
  * Retrieves a representation of the module name, stream name, version and
  * context of this #ModulemdModuleStream in the form
@@ -417,7 +417,7 @@ modulemd_module_stream_get_nsvc_as_string (ModulemdModuleStream *self);
 
 /**
  * modulemd_module_stream_get_NSVCA_as_string: (rename-to modulemd_module_stream_get_NSVCA)
- * @self: (in): This #ModulemdModuleStream.
+ * @self: (in): This #ModulemdModuleStream object.
  *
  * Returns: (transfer full): The NSVCA of this module stream. The returned
  * format is described
@@ -432,9 +432,9 @@ modulemd_module_stream_get_NSVCA_as_string (ModulemdModuleStream *self);
 
 /**
  * modulemd_module_stream_depends_on_stream:
- * @self: (not nullable): This #ModulemdModuleStream.
- * @module_name: (not nullable): A module name
- * @stream_name: (not nullable): The stream of the module
+ * @self: (not nullable): This #ModulemdModuleStream object.
+ * @module_name: (not nullable): A module name.
+ * @stream_name: (not nullable): The stream of the module.
  *
  * Returns: TRUE if any of the #ModulemdDependencies objects associated with
  * this module applies to the provided module name and stream in the runtime
@@ -452,9 +452,9 @@ modulemd_module_stream_depends_on_stream (ModulemdModuleStream *self,
 
 /**
  * modulemd_module_stream_build_depends_on_stream:
- * @self: (not nullable): This #ModulemdModuleStream.
- * @module_name: (not nullable): A module name
- * @stream_name: (not nullable): The stream of the module
+ * @self: (not nullable): This #ModulemdModuleStream object.
+ * @module_name: (not nullable): A module name.
+ * @stream_name: (not nullable): The stream of the module.
  *
  * Returns: TRUE if any of the #ModulemdDependencies objects associated with
  * this module applies to the provided module name and stream in the build-time

--- a/modulemd/v2/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-module.h
@@ -35,9 +35,10 @@ G_DECLARE_FINAL_TYPE (
 
 /**
  * modulemd_module_get_stream_names_as_strv: (rename-to modulemd_module_get_stream_names)
- * @self: This #ModulemdModule
+ * @self: This #ModulemdModule object.
  *
- * Returns: (transfer full): An ordered list of stream names in this module.
+ * Returns: (transfer full): An ordered #GStrv list of stream names in this
+ * module.
  *
  * Since: 2.6
  */
@@ -47,9 +48,9 @@ modulemd_module_get_stream_names_as_strv (ModulemdModule *self);
 
 /**
  * modulemd_module_copy:
- * @self: (in): This #ModulemdModule object
+ * @self: (in): This #ModulemdModule object.
  *
- * Returns: (transfer full): A deep copy of this #ModulemdModule object
+ * Returns: (transfer full): A deep copy of this #ModulemdModule object.
  *
  * Since: 2.0
  */
@@ -59,8 +60,9 @@ modulemd_module_copy (ModulemdModule *self);
 
 /**
  * modulemd_module_validate:
- * @self: (in): This #ModulemdModule object
- * @error: (out): A GError containign the reason the object failed validation. NULL if the validation passed.
+ * @self: (in): This #ModulemdModule object.
+ * @error: (out): A #GError containing the reason the object failed validation.
+ * NULL if the validation passed.
  *
  * Returns: TRUE if validation passed, FALSE and sets @error if failed.
  *
@@ -72,9 +74,9 @@ modulemd_module_validate (ModulemdModule *self, GError **error);
 
 /**
  * modulemd_module_get_module_name:
- * @self: This #ModulemdModule object
+ * @self: This #ModulemdModule object.
  *
- * Returns: (transfer none): The module name
+ * Returns: (transfer none): The module name.
  *
  * Since: 2.0
  */
@@ -84,7 +86,7 @@ modulemd_module_get_module_name (ModulemdModule *self);
 
 /**
  * modulemd_module_get_all_streams:
- * @self: This #ModulemdModule object
+ * @self: This #ModulemdModule object.
  *
  * Returns: (transfer none) (element-type ModulemdModuleStream): A list of all available stream objects associated with
  * this module. There may be multiple streams with the same name and different version and
@@ -98,8 +100,8 @@ modulemd_module_get_all_streams (ModulemdModule *self);
 
 /**
  * modulemd_module_get_streams_by_stream_name_as_list: (rename-to modulemd_module_get_streams_by_stream_name)
- * @self: This #ModulemdModule object
- * @stream_name: The name of the stream to retrieve
+ * @self: This #ModulemdModule object.
+ * @stream_name: The name of the stream to retrieve.
  *
  * Returns: (transfer container) (element-type ModulemdModuleStream): A list of all available stream objects associated with a
  * particular stream name, sorted highest to lowest by the version. The same version may have
@@ -114,10 +116,10 @@ modulemd_module_get_streams_by_stream_name_as_list (ModulemdModule *self,
 
 /**
  * modulemd_module_get_stream_by_NSVC:
- * @self: This #ModulemdModule object
- * @stream_name: The name of the stream to retrieve
- * @version: The version of the stream to retrieve
- * @context: The context of the stream to retrieve
+ * @self: This #ModulemdModule object.
+ * @stream_name: The name of the stream to retrieve.
+ * @version: The version of the stream to retrieve.
+ * @context: The context of the stream to retrieve.
  *
  * Returns: (transfer none): The requested stream object or NULL if no match was found.
  *
@@ -134,8 +136,8 @@ modulemd_module_get_stream_by_NSVC (ModulemdModule *self,
 
 /**
  * modulemd_module_search_streams:
- * @self: This #ModulemdModule object
- * @stream_name: The name of the stream to retrieve
+ * @self: This #ModulemdModule object.
+ * @stream_name: The name of the stream to retrieve.
  * @version: The version of the stream to retrieve. If set to zero,
  * the version is not included in the search.
  * @context: (nullable): The context of the stream to retrieve. If NULL, the
@@ -162,8 +164,8 @@ modulemd_module_search_streams (ModulemdModule *self,
 
 /**
  * modulemd_module_get_stream_by_NSVCA:
- * @self: This #ModulemdModule object
- * @stream_name: The name of the stream to retrieve
+ * @self: This #ModulemdModule object.
+ * @stream_name: The name of the stream to retrieve.
  * @version: The version of the stream to retrieve. If set to zero, the version
  * is not included in the search.
  * @context: (nullable): The context of the stream to retrieve. If NULL, the
@@ -190,8 +192,8 @@ modulemd_module_get_stream_by_NSVCA (ModulemdModule *self,
 
 /**
  * modulemd_module_remove_streams_by_NSVCA:
- * @self: This #ModulemdModule object
- * @stream_name: (not nullable): The name of the stream to remove
+ * @self: This #ModulemdModule object.
+ * @stream_name: (not nullable): The name of the stream to remove.
  * @version: The version of the stream to remove. If set to zero, matches all
  * versions.
  * @context: (nullable): The context of the stream to remove. If NULL, matches
@@ -214,8 +216,8 @@ modulemd_module_remove_streams_by_NSVCA (ModulemdModule *self,
 
 /**
  * modulemd_module_remove_streams_by_name:
- * @self: This #ModulemdModule object
- * @stream_name: (not nullable): The name of the stream to remove
+ * @self: This #ModulemdModule object.
+ * @stream_name: (not nullable): The name of the stream to remove.
  *
  * Remove one or more #ModulemdModuleStream objects from this #ModulemdModule
  * that match the provided stream name.
@@ -228,7 +230,7 @@ modulemd_module_remove_streams_by_NSVCA (ModulemdModule *self,
 
 /**
  * modulemd_module_get_defaults:
- * @self: This #ModulemdModule object
+ * @self: This #ModulemdModule object.
  *
  * Returns: (transfer none): The defaults of this module.
  *

--- a/modulemd/v2/include/modulemd-2.0/modulemd-profile.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-profile.h
@@ -32,10 +32,11 @@ G_DECLARE_FINAL_TYPE (
 
 /**
  * modulemd_profile_equals:
- * @self_1: A #ModulemdProfile
- * @self_2: A #ModulemdProfile
+ * @self_1: A #ModulemdProfile object.
+ * @self_2: A #ModulemdProfile object.
  *
- * Returns: TRUE if all elements of self_1 and self_2 are equal. FALSE, otherwise. 
+ * Returns: TRUE, if all elements of @self_1 and @self_2 are equal. FALSE,
+ * otherwise.
  *
  * Since: 2.2
  */
@@ -47,8 +48,8 @@ modulemd_profile_equals (ModulemdProfile *self_1, ModulemdProfile *self_2);
  * modulemd_profile_new:
  * @name: (not nullable): The name of this profile.
  *
- * Returns: (transfer full): A newly-allocated #ModulemdProfile. This object
- * must be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModulemdProfile object. This
+ * object must be freed with g_object_unref().
  *
  * Since: 2.0
  */
@@ -58,11 +59,11 @@ modulemd_profile_new (const gchar *name);
 
 /**
  * modulemd_profile_copy:
- * @self: This #ModulemdProfile
+ * @self: This #ModulemdProfile object.
  *
  * Create a copy of this #ModulemdProfile object.
  *
- * Returns: (transfer full): a copied #ModulemdProfile object
+ * Returns: (transfer full): The copied #ModulemdProfile object.
  *
  * Since: 2.0
  */
@@ -72,7 +73,7 @@ modulemd_profile_copy (ModulemdProfile *self);
 
 /**
  * modulemd_profile_get_name:
- * @self: This #ModulemdProfile
+ * @self: This #ModulemdProfile object.
  *
  * Returns: (transfer none): The name of this profile.
  *
@@ -84,8 +85,8 @@ modulemd_profile_get_name (ModulemdProfile *self);
 
 /**
  * modulemd_profile_set_description:
- * @self: This #ModulemdProfile
- * @description: (nullable): The description of this profile in the C locale.
+ * @self: This #ModulemdProfile object.
+ * @description: (nullable): The untranslated description of this profile.
  *
  * Since: 2.0
  */
@@ -96,15 +97,16 @@ modulemd_profile_set_description (ModulemdProfile *self,
 
 /**
  * modulemd_profile_get_description:
- * @self: This #ModulemdProfile
+ * @self: This #ModulemdProfile object.
  * @locale: (in) (nullable): The name of the locale to use when translating
  * the string. If NULL, it will determine the locale with a system call to
- * setlocale(LC_MESSAGES, NULL) and return the that. If the caller wants the
- * untranslated string, they should pass "C" for the locale.
+ * `setlocale(LC_MESSAGES, NULL)` and return that. If the caller wants the
+ * untranslated string, they should pass `"C"` for the locale.
  *
  * Returns: (transfer none): The description of this profile translated into
  * the language specified by the locale if it is available, otherwise it
- * returns the C.UTF-8 original.
+ * returns the C.UTF-8 original. Translation information is managed by the
+ * #ModulemdTranslation and #ModulemdTranslationEntry objects.
  *
  * Since: 2.0
  */
@@ -114,7 +116,7 @@ modulemd_profile_get_description (ModulemdProfile *self, const gchar *locale);
 
 /**
  * modulemd_profile_add_rpm:
- * @self: This #ModulemdProfile
+ * @self: This #ModulemdProfile object.
  * @rpm: The name of a binary RPM that should be installed when this profile is
  * selected for installation.
  *
@@ -126,7 +128,7 @@ modulemd_profile_add_rpm (ModulemdProfile *self, const gchar *rpm);
 
 /**
  * modulemd_profile_remove_rpm:
- * @self: This #ModulemdProfile
+ * @self: This #ModulemdProfile object.
  * @rpm: The name of a binary RPM to remove from this profile.
  *
  * Since: 2.0
@@ -137,9 +139,9 @@ modulemd_profile_remove_rpm (ModulemdProfile *self, const gchar *rpm);
 
 /**
  * modulemd_profile_clear_rpms:
- * @self: This #ModulemdProfile
+ * @self: This #ModulemdProfile object.
  *
- * Remove all RPMs from this profile
+ * Remove all RPMs from this profile.
  *
  * Since: 2.5
  */
@@ -149,7 +151,7 @@ modulemd_profile_clear_rpms (ModulemdProfile *self);
 
 /**
  * modulemd_profile_get_rpms_as_strv: (rename-to modulemd_profile_get_rpms)
- * @self: This #ModulemdProfile
+ * @self: This #ModulemdProfile object.
  *
  * Returns: (transfer full): An ordered #GStrv list of binary RPMS that would be
  * installed when this profile is selected for installation.

--- a/modulemd/v2/include/modulemd-2.0/modulemd-rpm-map-entry.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-rpm-map-entry.h
@@ -35,17 +35,17 @@ G_DECLARE_FINAL_TYPE (ModulemdRpmMapEntry,
 
 /**
  * modulemd_rpm_map_entry_new:
- * @name: The name of the package
- * @epoch: The epoch of the package
- * @version: The version of the package
- * @release: The release string of the package
- * @arch: The processor architecture of the package
+ * @name: The name of the package.
+ * @epoch: The epoch of the package.
+ * @version: The version of the package.
+ * @release: The release string of the package.
+ * @arch: The processor architecture of the package.
  *
  * Create a new rpm-map entry. This will contain the decomposed NEVRA of an
  * RPM artifact.
  *
- * Returns: (transfer full): A newly-allocated #ModulemdRpmMapEntry with the
- * provided values.
+ * Returns: (transfer full): A newly-allocated #ModulemdRpmMapEntry object with
+ * the provided values.
  */
 ModulemdRpmMapEntry *
 modulemd_rpm_map_entry_new (const gchar *name,
@@ -57,7 +57,7 @@ modulemd_rpm_map_entry_new (const gchar *name,
 
 /**
  * modulemd_rpm_map_entry_copy:
- * @self: This #ModulemdRpmMapEntry
+ * @self: This #ModulemdRpmMapEntry object.
  *
  * Returns: (transfer full): A deep copy of this #ModulemdRpmMapEntry object.
  *
@@ -69,8 +69,8 @@ modulemd_rpm_map_entry_copy (ModulemdRpmMapEntry *self);
 
 /**
  * modulemd_rpm_map_entry_equals:
- * @self: A #ModulemdRpmMapEntry
- * @other: Another #ModulemdRpmMapEntry
+ * @self: A #ModulemdRpmMapEntry object.
+ * @other: Another #ModulemdRpmMapEntry object.
  *
  * Returns: TRUE if the two entries contain equivalent data. FALSE if they
  * differ.
@@ -84,8 +84,8 @@ modulemd_rpm_map_entry_equals (ModulemdRpmMapEntry *self,
 
 /**
  * modulemd_rpm_map_entry_validate:
- * @self: This #ModulemdRpmMapEntry
- * @error: (out): A GError containign the reason the object failed validation.
+ * @self: This #ModulemdRpmMapEntry object.
+ * @error: (out): A #GError containing the reason the object failed validation.
  * NULL if the validation passed.
  *
  * Since: 2.2
@@ -96,8 +96,8 @@ modulemd_rpm_map_entry_validate (ModulemdRpmMapEntry *self, GError **error);
 
 /**
  * modulemd_rpm_map_entry_set_name:
- * @self: This #ModulemdRpmMapEntry
- * @name: The package name of this RPM
+ * @self: This #ModulemdRpmMapEntry object.
+ * @name: The package name of this RPM.
  *
  * Since: 2.2
  */
@@ -107,9 +107,9 @@ modulemd_rpm_map_entry_set_name (ModulemdRpmMapEntry *self, const gchar *name);
 
 /**
  * modulemd_rpm_map_entry_get_name:
- * @self: This #ModulemdRpmMapEntry
+ * @self: This #ModulemdRpmMapEntry object.
  *
- * Returns: (transfer none): The package name of this RPM
+ * Returns: (transfer none): The package name of this RPM.
  *
  * Since: 2.2
  */
@@ -119,8 +119,8 @@ modulemd_rpm_map_entry_get_name (ModulemdRpmMapEntry *self);
 
 /**
  * modulemd_rpm_map_entry_set_epoch:
- * @self: This #ModulemdRpmMapEntry
- * @epoch: The package epoch of this RPM
+ * @self: This #ModulemdRpmMapEntry object.
+ * @epoch: The package epoch of this RPM.
  *
  * Since: 2.2
  */
@@ -130,9 +130,9 @@ modulemd_rpm_map_entry_set_epoch (ModulemdRpmMapEntry *self, guint64 epoch);
 
 /**
  * modulemd_rpm_map_entry_get_epoch:
- * @self: This #ModulemdRpmMapEntry
+ * @self: This #ModulemdRpmMapEntry object.
  *
- * Returns: The package epoch of this RPM
+ * Returns: The package epoch of this RPM.
  *
  * Since: 2.2
  */
@@ -142,8 +142,8 @@ modulemd_rpm_map_entry_get_epoch (ModulemdRpmMapEntry *self);
 
 /**
  * modulemd_rpm_map_entry_set_version:
- * @self: This #ModulemdRpmMapEntry
- * @version: The package version of this RPM
+ * @self: This #ModulemdRpmMapEntry object.
+ * @version: The package version of this RPM.
  *
  * Since: 2.2
  */
@@ -154,9 +154,9 @@ modulemd_rpm_map_entry_set_version (ModulemdRpmMapEntry *self,
 
 /**
  * modulemd_rpm_map_entry_get_version:
- * @self: This #ModulemdRpmMapEntry
+ * @self: This #ModulemdRpmMapEntry object.
  *
- * Returns: (transfer none): The package version of this RPM
+ * Returns: (transfer none): The package version of this RPM.
  *
  * Since: 2.2
  */
@@ -166,8 +166,8 @@ modulemd_rpm_map_entry_get_version (ModulemdRpmMapEntry *self);
 
 /**
  * modulemd_rpm_map_entry_set_release:
- * @self: This #ModulemdRpmMapEntry
- * @release: The package release string of this RPM
+ * @self: This #ModulemdRpmMapEntry object.
+ * @release: The package release string of this RPM.
  *
  * Since: 2.2
  */
@@ -178,9 +178,9 @@ modulemd_rpm_map_entry_set_release (ModulemdRpmMapEntry *self,
 
 /**
  * modulemd_rpm_map_entry_get_release:
- * @self: This #ModulemdRpmMapEntry
+ * @self: This #ModulemdRpmMapEntry object.
  *
- * Returns: (transfer none): The package release of this RPM
+ * Returns: (transfer none): The package release of this RPM.
  *
  * Since: 2.2
  */
@@ -190,8 +190,8 @@ modulemd_rpm_map_entry_get_release (ModulemdRpmMapEntry *self);
 
 /**
  * modulemd_rpm_map_entry_set_arch:
- * @self: This #ModulemdRpmMapEntry
- * @arch: The package architecture of this RPM
+ * @self: This #ModulemdRpmMapEntry object.
+ * @arch: The package architecture of this RPM.
  *
  * Since: 2.2
  */
@@ -201,9 +201,9 @@ modulemd_rpm_map_entry_set_arch (ModulemdRpmMapEntry *self, const gchar *arch);
 
 /**
  * modulemd_rpm_map_entry_get_arch:
- * @self: This #ModulemdRpmMapEntry
+ * @self: This #ModulemdRpmMapEntry object.
  *
- * Returns: (transfer none): The package architecture of this RPM
+ * Returns: (transfer none): The package architecture of this RPM.
  *
  * Since: 2.2
  */
@@ -213,7 +213,7 @@ modulemd_rpm_map_entry_get_arch (ModulemdRpmMapEntry *self);
 
 /**
  * modulemd_rpm_map_entry_get_nevra_as_string: (rename-to modulemd_rpm_map_entry_get_nevra)
- * @self: This #ModulemdRpmMapEntry
+ * @self: This #ModulemdRpmMapEntry object.
  *
  * Returns: (transfer full): A newly-allocated string containing the complete
  * N-E:V-R.A constructed from the component parts. NULL if any field is

--- a/modulemd/v2/include/modulemd-2.0/modulemd-service-level.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-service-level.h
@@ -36,8 +36,8 @@ G_DECLARE_FINAL_TYPE (ModulemdServiceLevel,
  * modulemd_service_level_new:
  * @name: (not nullable): The name of the service level.
  *
- * Returns: (transfer full): A newly-allocated #ModulemdServiceLevel. This
- * object must be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModulemdServiceLevel object.
+ * This object must be freed with g_object_unref().
  *
  * Since: 2.0
  */
@@ -47,11 +47,11 @@ modulemd_service_level_new (const gchar *name);
 
 /**
  * modulemd_service_level_copy:
- * @self: This #ModulemdServiceLevel
+ * @self: This #ModulemdServiceLevel object.
  *
  * Create a copy of this #ModulemdServiceLevel object.
  *
- * Returns: (transfer full): a copied #ModulemdServiceLevel object
+ * Returns: (transfer full): The copied #ModulemdServiceLevel object.
  *
  * Since: 2.0
  */
@@ -61,7 +61,7 @@ modulemd_service_level_copy (ModulemdServiceLevel *self);
 
 /**
  * modulemd_service_level_get_name:
- * @self: This #ModulemdServiceLevel
+ * @self: This #ModulemdServiceLevel object.
  *
  * Get the name of this service level.
  *
@@ -76,7 +76,7 @@ modulemd_service_level_get_name (ModulemdServiceLevel *self);
 
 /**
  * modulemd_service_level_set_eol:
- * @self: This #ModulemdServiceLevel
+ * @self: This #ModulemdServiceLevel object.
  * @date: (nullable): The date this service level ends.
  *
  * Sets the end date of the service level. If the #GDate passed in is invalid
@@ -90,7 +90,7 @@ modulemd_service_level_set_eol (ModulemdServiceLevel *self, GDate *date);
 
 /**
  * modulemd_service_level_set_eol_ymd:
- * @self: This #ModulemdServiceLevel
+ * @self: This #ModulemdServiceLevel object.
  * @year: The year this service level ends.
  * @month: The month this service level ends.
  * @day: The day of the month this service level ends.
@@ -106,9 +106,9 @@ modulemd_service_level_set_eol_ymd (ModulemdServiceLevel *self,
 
 /**
  * modulemd_service_level_remove_eol:
- * @self: This #ModulemdServiceLevel
+ * @self: This #ModulemdServiceLevel object.
  *
- * Remove the EOL from this Service Level
+ * Remove the EOL from this Service Level.
  *
  * Since: 2.0
  */
@@ -117,7 +117,7 @@ modulemd_service_level_remove_eol (ModulemdServiceLevel *self);
 
 /**
  * modulemd_service_level_get_eol:
- * @self: This #ModulemdServiceLevel
+ * @self: This #ModulemdServiceLevel object.
  *
  * Returns: (transfer none): The end date of the service level as a #GDate.
  *
@@ -128,7 +128,7 @@ modulemd_service_level_get_eol (ModulemdServiceLevel *self);
 
 /**
  * modulemd_service_level_get_eol_as_string:
- * @self: This #ModulemdServiceLevel
+ * @self: This #ModulemdServiceLevel object.
  *
  * Returns: (transfer full) (nullable): The end date of the service level as a
  * string of the form "YYYY-MM-DD" or NULL if the date is unset or invalid.
@@ -140,8 +140,8 @@ modulemd_service_level_get_eol_as_string (ModulemdServiceLevel *self);
 
 /**
  * modulemd_service_level_equals:
- * @self_1: A #ModulemdServiceLevel
- * @self_2: A #ModulemdServiceLevel
+ * @self_1: A #ModulemdServiceLevel object.
+ * @self_2: A #ModulemdServiceLevel object.
  *
  * Returns: TRUE if both the dates are either NULL or valid, FALSE otherwise.
  *

--- a/modulemd/v2/include/modulemd-2.0/modulemd-subdocument-info.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-subdocument-info.h
@@ -35,9 +35,9 @@ G_DECLARE_FINAL_TYPE (ModulemdSubdocumentInfo,
 
 /**
  * modulemd_subdocument_info_get_yaml:
- * @self: This #ModulemdSubdocumentInfo
+ * @self: This #ModulemdSubdocumentInfo object.
  *
- * Returns: (transfer none): The associated YAML subdocument
+ * Returns: (transfer none): The associated YAML subdocument.
  *
  * Since: 2.0
  */
@@ -47,9 +47,10 @@ modulemd_subdocument_info_get_yaml (ModulemdSubdocumentInfo *self);
 
 /**
  * modulemd_subdocument_info_get_gerror:
- * @self: This #ModulemdSubdocumentInfo
+ * @self: This #ModulemdSubdocumentInfo object.
  *
- * Returns: (transfer none): A GError containing an error code and message about why this subdocument failed parsing.
+ * Returns: (transfer none): A #GError containing an error code and message
+ * about why this subdocument failed parsing.
  *
  * Since: 2.0
  */

--- a/modulemd/v2/include/modulemd-2.0/modulemd-translation-entry.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-translation-entry.h
@@ -38,8 +38,8 @@ G_DECLARE_FINAL_TYPE (ModulemdTranslationEntry,
  * @locale: (not nullable): The locale for this translation entry.
  * It must correspond to the format specified by libc locale names.
  *
- * Returns: (transfer full): A newly-allocated #ModulemdTranslationEntry. This
- * object must be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModulemdTranslationEntry
+ * object. This object must be freed with g_object_unref().
  *
  * Since: 2.0
  */
@@ -49,11 +49,11 @@ modulemd_translation_entry_new (const gchar *locale);
 
 /**
  * modulemd_translation_entry_copy:
- * @self: This #ModulemdTranslationEntry
+ * @self: This #ModulemdTranslationEntry object.
  *
  * Create a copy of this #ModulemdTranslationEntry object.
  *
- * Returns: (transfer full): a copied #ModulemdTranslationEntry object
+ * Returns: (transfer full): The copied #ModulemdTranslationEntry object.
  *
  * Since: 2.0
  */
@@ -63,7 +63,7 @@ modulemd_translation_entry_copy (ModulemdTranslationEntry *self);
 
 /**
  * modulemd_translation_entry_get_locale:
- * @self: This #ModulemdTranslationEntry
+ * @self: This #ModulemdTranslationEntry object.
  *
  * Get the locale of this translation entry.
  *
@@ -78,8 +78,9 @@ modulemd_translation_entry_get_locale (ModulemdTranslationEntry *self);
 
 /**
  * modulemd_translation_entry_set_summary:
- * @self: This #ModulemdTranslationEntry
- * @summary: (nullable): The summary of this module translated appropriately for this locale.
+ * @self: This #ModulemdTranslationEntry object.
+ * @summary: (nullable): The summary of this module translated appropriately
+ * for this locale.
  *
  * Since: 2.0
  */
@@ -90,11 +91,12 @@ modulemd_translation_entry_set_summary (ModulemdTranslationEntry *self,
 
 /**
  * modulemd_translation_entry_get_summary:
- * @self: This #ModulemdTranslationEntry
+ * @self: This #ModulemdTranslationEntry object.
  *
  * Get the summary of this translation entry.
  *
- * Returns: (transfer none): The summary of this module stream translated into the language specified by locale.
+ * Returns: (transfer none): The summary of this module stream translated into
+ * the language specified by locale.
  *
  * Since: 2.0
  */
@@ -104,8 +106,9 @@ modulemd_translation_entry_get_summary (ModulemdTranslationEntry *self);
 
 /**
  * modulemd_translation_entry_set_description:
- * @self: This #ModulemdTranslationEntry
- * @description: (nullable): The description of this module stream translated into the language specified by locale.
+ * @self: This #ModulemdTranslationEntry object.
+ * @description: (nullable): The description of this module stream translated
+ * into the language specified by locale.
  *
  * Since: 2.0
  */
@@ -116,11 +119,12 @@ modulemd_translation_entry_set_description (ModulemdTranslationEntry *self,
 
 /**
  * modulemd_translation_entry_get_description:
- * @self: This #ModulemdTranslationEntry
+ * @self: This #ModulemdTranslationEntry object.
  *
  * Get the description of this translation entry.
  *
- * Returns: (transfer none): The description of this module stream translated into the language specified by locale.
+ * Returns: (transfer none): The description of this module stream translated
+ * into the language specified by locale.
  *
  * Since: 2.0
  */
@@ -130,7 +134,7 @@ modulemd_translation_entry_get_description (ModulemdTranslationEntry *self);
 
 /**
  * modulemd_translation_entry_get_profiles_as_strv: (rename-to modulemd_translation_entry_get_profiles)
- * @self: This #ModulemdTranslationEntry
+ * @self: This #ModulemdTranslationEntry object.
  *
  * Get a list of profiles that have descriptions.
  *
@@ -146,11 +150,11 @@ modulemd_translation_entry_get_profiles_as_strv (
 
 /**
  * modulemd_translation_entry_set_profile_description:
- * @self: This #ModulemdTranslationEntry
+ * @self: This #ModulemdTranslationEntry object.
  * @profile_name: The name of the profile.
  * @profile_description: (nullable): The translated description of the profile.
  *
- * Adds a profile name translation
+ * Adds a profile name translation.
  *
  * Since: 2.0
  */
@@ -163,7 +167,7 @@ modulemd_translation_entry_set_profile_description (
 
 /**
  * module_translation_entry_get_profile_description:
- * @self: This #ModulemdTranslationEntry
+ * @self: This #ModulemdTranslationEntry object.
  * @profile_name: The name of the profile whose description is being translated.
  *
  * Returns: (transfer none): The description for the specified profile.

--- a/modulemd/v2/include/modulemd-2.0/modulemd-translation.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-translation.h
@@ -35,10 +35,11 @@ G_DECLARE_FINAL_TYPE (
  * @version: The metadata version of this #ModulemdTranslation.
  * @module_name: The name of the module to which these translations apply.
  * @module_stream: The name of the module stream to which these translations apply.
- * @modified: The last modified time represented as a 64-bit integer (such as 201807011200)
+ * @modified: The last modified time represented as a 64-bit integer (such as
+ * 201807011200).
  *
- * Returns: (transfer full): A newly-allocated #ModulemdTranslation. This
- * object must be freed with g_object_unref().
+ * Returns: (transfer full): A newly-allocated #ModulemdTranslation object.
+ * This object must be freed with g_object_unref().
  *
  * Since: 2.0
  */
@@ -51,11 +52,11 @@ modulemd_translation_new (guint64 version,
 
 /**
  * modulemd_translation_copy:
- * @self: This #ModulemdTranslation
+ * @self: This #ModulemdTranslation object.
  *
  * Create a copy of this #ModulemdTranslation object.
  *
- * Returns: (transfer full): a copied #ModulemdTranslation object
+ * Returns: (transfer full): The copied #ModulemdTranslation object.
  *
  * Since: 2.0
  */
@@ -65,10 +66,13 @@ modulemd_translation_copy (ModulemdTranslation *self);
 
 /**
  * modulemd_translation_validate:
- * @self: This #ModulemdTranslation
+ * @self: This #ModulemdTranslation object.
  * @error: (out): If the object is not valid, it will return the reason.
  *
- * This method ensures that the translation is internally consistent for usage or dumping to YAML. It will be run implicitly prior to emitting YAML. This is not a complete linter, merely a sanity check that the values are not impossible.
+ * This method ensures that the translation is internally consistent for usage
+ * or dumping to YAML. It will be run implicitly prior to emitting YAML. This
+ * is not a complete linter, merely a sanity check that the values are not
+ * impossible.
  *
  * Since: 2.0
  */
@@ -78,8 +82,9 @@ modulemd_translation_validate (ModulemdTranslation *self, GError **error);
 
 /**
  * modulemd_translation_set_modified:
- * @self: This #ModulemdTranslation
- * @modified: The last modified time represented as a 64-bit integer (such as 201807011200)
+ * @self: This #ModulemdTranslation object.
+ * @modified: The last modified time represented as a 64-bit integer (such as
+ * 201807011200).
  *
  * Since: 2.0
  */
@@ -90,9 +95,10 @@ modulemd_translation_set_modified (ModulemdTranslation *self,
 
 /**
  * modulemd_translation_get_locales_as_strv: (rename-to modulemd_translation_get_locales)
- * @self: This #ModulemdTranslation
+ * @self: This #ModulemdTranslation object.
  *
- * Returns: (transfer full): An ordered list of locales known to this Modulemd.Translation.
+ * Returns: (transfer full): An ordered #GStrv list of locales known to this
+ * #ModulemdTranslation.
  *
  * Since: 2.0
  */
@@ -102,7 +108,7 @@ modulemd_translation_get_locales_as_strv (ModulemdTranslation *self);
 
 /**
  * modulemd_translation_set_translation_entry:
- * @self: This #ModulemdTranslation
+ * @self: This #ModulemdTranslation object.
  * @translation_entry: A set of translations of this module stream for a particular locale.
  *
  * Since: 2.0
@@ -114,7 +120,7 @@ modulemd_translation_set_translation_entry (
 
 /**
  * modulemd_translation_get_translation_entry:
- * @self: This #ModulemdTranslation
+ * @self: This #ModulemdTranslation object.
  * @locale: The locale of the translation to retrieve.
  *
  * Returns: (transfer none): The translation entry for the requested locale, or NULL if the locale was unknown.

--- a/modulemd/v2/include/private/modulemd-buildopts-private.h
+++ b/modulemd/v2/include/private/modulemd-buildopts-private.h
@@ -48,7 +48,7 @@ modulemd_buildopts_parse_yaml (yaml_parser_t *parser,
 
 /**
  * modulemd_buildopts_emit_yaml:
- * @self: This #ModulemdBuildopts
+ * @self: This #ModulemdBuildopts object.
  * @emitter: (inout): A libyaml emitter object positioned where a Buildopts
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission or

--- a/modulemd/v2/include/private/modulemd-component-module-private.h
+++ b/modulemd/v2/include/private/modulemd-component-module-private.h
@@ -50,7 +50,7 @@ modulemd_component_module_parse_yaml (yaml_parser_t *parser,
 
 /**
  * modulemd_component_module_emit_yaml:
- * @self: This #ModulemdComponentModule
+ * @self: This #ModulemdComponentModule object.
  * @emitter: (inout): A libyaml emitter object positioned where Module Component
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission error.

--- a/modulemd/v2/include/private/modulemd-component-private.h
+++ b/modulemd/v2/include/private/modulemd-component-private.h
@@ -29,9 +29,9 @@
 
 /**
  * modulemd_component_parse_buildafter:
- * @self: This #ModulemdComponent
+ * @self: This #ModulemdComponent object.
  * @parser: (inout): A libyaml parser object positioned just after the
- * "buildafter" key in a #ModulemdComponent section of a YAML document.
+ * "buildafter" key in a Component section of a YAML document.
  * @error: (out): A #GError that will return the reason for a parse failure.
  *
  * Returns: TRUE if the buildafter list could be parsed successfully.
@@ -45,9 +45,9 @@ modulemd_component_parse_buildafter (ModulemdComponent *self,
 
 /**
  * modulemd_component_parse_buildonly:
- * @self: This #ModulemdComponent
+ * @self: This #ModulemdComponent object.
  * @parser: (inout): A libyaml parser object positioned just after the
- * "buildonly" key in a #ModulemdComponent section of a YAML document.
+ * "buildonly" key in a Component section of a YAML document.
  * @error: (out): A #GError that will return the reason for a parse failure.
  *
  * Returns: TRUE if the buildonly list could be parsed successfully.
@@ -61,7 +61,7 @@ modulemd_component_parse_buildonly (ModulemdComponent *self,
 
 /**
  * modulemd_component_has_buildafter:
- * @self: This #ModulemdComponent
+ * @self: This #ModulemdComponent object.
  *
  * Returns: TRUE if one or more buildafter entries have been added to this
  * component.
@@ -74,7 +74,7 @@ modulemd_component_has_buildafter (ModulemdComponent *self);
 
 /**
  * modulemd_component_get_buildafter_internal:
- * @self: This #ModulemdComponentModule
+ * @self: This #ModulemdComponent object.
  *
  * Returns: The internal hash table representing the set of buildafter
  * dependencies.
@@ -87,7 +87,7 @@ modulemd_component_get_buildafter_internal (ModulemdComponent *self);
 
 /**
  * modulemd_component_emit_yaml_start:
- * @self: This #ModulemdComponent
+ * @self: This #ModulemdComponent object.
  * @emitter: (inout): A libyaml emitter object positioned where Component start
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission error.
@@ -104,7 +104,7 @@ modulemd_component_emit_yaml_start (ModulemdComponent *self,
 
 /**
  * modulemd_component_emit_yaml_build_common:
- * @self: This #ModulemdComponent
+ * @self: This #ModulemdComponent object.
  * @emitter: (inout): A libyaml emitter object positioned where a Component's
  * buildorder, buildafter and/or buildonly item(s) should appear in the YAML
  * document.
@@ -126,7 +126,7 @@ modulemd_component_emit_yaml_build_common (ModulemdComponent *self,
  * @a: A void pointer
  * @b: A void pointer
  *
- * Returns: TRUE, if both the pointers are equal. FALSE, otherwise.
+ * Returns: TRUE, if both pointers are pointers to #ModulemdComponent objects and both objects are equal. FALSE, otherwise.
  *
  * Since: 2.5
  */

--- a/modulemd/v2/include/private/modulemd-component-rpm-private.h
+++ b/modulemd/v2/include/private/modulemd-component-rpm-private.h
@@ -50,7 +50,7 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
 
 /**
  * modulemd_component_rpm_emit_yaml:
- * @self: This #ModulemdComponentRpm
+ * @self: This #ModulemdComponentRpm object.
  * @emitter: (inout): A libyaml emitter object positioned where Rpm Component
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission error.

--- a/modulemd/v2/include/private/modulemd-defaults-private.h
+++ b/modulemd/v2/include/private/modulemd-defaults-private.h
@@ -32,8 +32,8 @@ G_BEGIN_DECLS
 
 /**
  * modulemd_defaults_set_module_name:
- * @self: (in): This #ModulemdDefaults object
- * @module_name: The module name this object represents
+ * @self: (in): This #ModulemdDefaults object.
+ * @module_name: The module name this object represents.
  *
  * Since: 2.0
  */
@@ -43,19 +43,19 @@ modulemd_defaults_set_module_name (ModulemdDefaults *self,
 
 /**
  * modulemd_defaults_merge:
- * @from: (in): A #ModulemdDefaults object to merge from
- * @into: (in): A #ModulemdDefaults object being merged into
+ * @from: (in): A #ModulemdDefaults object to merge from.
+ * @into: (in): A #ModulemdDefaults object being merged into.
  * @strict_default_streams: (in): Whether a stream conflict should throw an
  * error or just unset the default stream.
  * @error: (out): A #GError containing the reason for an unresolvable merge
- * conflict
+ * conflict.
  *
  * Performs a merge of two #ModulemdDefaults objects. See the documentation for
  * #ModulemdModuleIndexMerger for details on the merge algorithm used.
  *
- * Returns: (transfer full): A newly-allocated #ModulemdDefaults containing the
- * merged values of @from and @into. If this function encounters an
- * unresolvable merge conflict, it will return NULL and set @error
+ * Returns: (transfer full): A newly-allocated #ModulemdDefaults object
+ * containing the merged values of @from and @into. If this function encounters
+ * an unresolvable merge conflict, it will return NULL and set @error
  * appropriately.
  *
  * Since: 2.0

--- a/modulemd/v2/include/private/modulemd-defaults-v1-private.h
+++ b/modulemd/v2/include/private/modulemd-defaults-v1-private.h
@@ -53,7 +53,7 @@ modulemd_defaults_v1_parse_yaml (ModulemdSubdocumentInfo *subdoc,
 
 /**
  * modulemd_defaults_v1_emit_yaml:
- * @self: This #ModulemdDefaultsV1
+ * @self: This #ModulemdDefaultsV1 object.
  * @emitter: (inout): A libyaml emitter object positioned where a Defaults (v1)
  * data section belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission or
@@ -73,18 +73,20 @@ modulemd_defaults_v1_emit_yaml (ModulemdDefaultsV1 *self,
 /**
  * modulemd_defaults_v1_merge:
  * @module_name: (in): The name of the module for which defaults are being merged.
- * @from: (in): A #ModulemdDefaultsV1 object to merge from
- * @into: (in): A #ModulemdDefaultsV1 object being merged into
+ * @from: (in): A #ModulemdDefaultsV1 object to merge from.
+ * @into: (in): A #ModulemdDefaultsV1 object being merged into.
+ * @strict_default_streams: (in): Whether a stream conflict should throw an
+ * error or just unset the default stream.
  * @error: (out): A #GError containing the reason for an unresolvable merge
- * conflict
+ * conflict.
  *
  * Performs a merge of two #ModulemdDefaultsV1 objects representing the
  * defaults for a single module name. See the documentation for
  * #ModulemdModuleIndexMerger for details on the merge algorithm used.
  *
- * Returns: (transfer full): A newly-allocated #ModulemdDefaultsV1 containing
- * the merged values of @from and @into. If this function encounters an
- * unresolvable merge conflict, it will return NULL and set @error
+ * Returns: (transfer full): A newly-allocated #ModulemdDefaultsV1 object
+ * containing the merged values of @from and @into. If this function encounters
+ * an unresolvable merge conflict, it will return NULL and set @error
  * appropriately.
  *
  * Since: 2.0

--- a/modulemd/v2/include/private/modulemd-dependencies-private.h
+++ b/modulemd/v2/include/private/modulemd-dependencies-private.h
@@ -46,9 +46,10 @@ modulemd_dependencies_parse_yaml (yaml_parser_t *parser,
                                   gboolean strict,
                                   GError **error);
 
+
 /**
- * modulemd_dependenciesemitter_yaml:
- * @self: This #ModulemdDependencies
+ * modulemd_dependencies_emit_yaml:
+ * @self: This #ModulemdDependencies object.
  * @emitter: (inout): A libyaml emitter object positioned where a dependencies instance
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission or
@@ -65,14 +66,55 @@ modulemd_dependencies_emit_yaml (ModulemdDependencies *self,
                                  GError **error);
 
 
+/**
+ * modulemd_dependencies_validate:
+ * @self: This #ModulemdDependencies object.
+ * @error: (out): A #GError containing the reason the object failed validation.
+ * NULL if the validation passed.
+ *
+ * Returns: TRUE if validation passed. FALSE and sets @error if failed.
+ *
+ * This method runs a sanity check that the runtime (requires) and buildtime
+ * (buildrequires) dependencies are internally consistent.
+ *
+ * Since: 2.0
+ */
 gboolean
 modulemd_dependencies_validate (ModulemdDependencies *self, GError **error);
 
 
+/**
+ * modulemd_dependencies_requires_module_and_stream:
+ * @self: This #ModulemdDependencies object.
+ * @module_name: (in): The name of the module to be checked.
+ * @stream_name: (in): The name of the stream to be checked.
+ *
+ * Returns: TRUE if the specified runtime dependency is present. FALSE if not.
+ *
+ * This method checks if the runtime dependencies for this object include the
+ * specified module stream.
+ *
+ * Since: 2.2
+ */
 gboolean
 modulemd_dependencies_requires_module_and_stream (ModulemdDependencies *self,
                                                   const gchar *module_name,
                                                   const gchar *stream_name);
+
+
+/**
+ * modulemd_dependencies_buildrequires_module_and_stream:
+ * @self: This #ModulemdDependencies object.
+ * @module_name: (in): The name of the module to be checked.
+ * @stream_name: (in): The name of the stream to be checked.
+ *
+ * Returns: TRUE if the specified buildtime dependency is present. FALSE if not.
+ *
+ * This method checks if the buildtime dependencies for this object include the
+ * specified module stream.
+ *
+ * Since: 2.2
+ */
 gboolean
 modulemd_dependencies_buildrequires_module_and_stream (
   ModulemdDependencies *self,

--- a/modulemd/v2/include/private/modulemd-module-index-private.h
+++ b/modulemd/v2/include/private/modulemd-module-index-private.h
@@ -30,7 +30,7 @@ G_BEGIN_DECLS
 
 /**
  * modulemd_module_index_update_from_parser:
- * @self: (in): This #ModulemdModuleIndex object
+ * @self: (in): This #ModulemdModuleIndex object.
  * @parser: (inout): An initialized YAML parser that has not yet processed any
  * events.
  * @strict: (in): Whether the parser should return failure if it encounters an
@@ -44,7 +44,7 @@ G_BEGIN_DECLS
  * See #ModulemdSubdocumentInfo for more details. If the array is NULL, it will
  * be allocated by this function. If it is non-NULL, this function will append
  * to it.
- * @error: (out): A GError containing additional information if this function
+ * @error: (out): A #GError containing additional information if this function
  * fails in a way that prevents program continuation.
  *
  * Returns: TRUE if the update was successful. Returns FALSE and sets failures

--- a/modulemd/v2/include/private/modulemd-module-private.h
+++ b/modulemd/v2/include/private/modulemd-module-private.h
@@ -33,9 +33,9 @@ G_BEGIN_DECLS
 
 /**
  * modulemd_module_new:
- * @module_name: (in) (not nullable): The name of the module
+ * @module_name: (in) (not nullable): The name of the module.
  *
- * Returns: (transfer full): A newly-allocated #ModulemdModule
+ * Returns: (transfer full): A newly-allocated #ModulemdModule object.
  *
  * Since: 2.0
  */
@@ -45,7 +45,7 @@ modulemd_module_new (const gchar *module_name);
 
 /**
  * modulemd_module_set_defaults:
- * @self: (in): This #ModulemdModule object
+ * @self: (in): This #ModulemdModule object.
  * @defaults: (in): A #ModulemdDefaults object to associate with this
  * #ModulemdModule. If the module_name in the #ModulemdDefaults object does not
  * match this module, it will be rejected.
@@ -62,9 +62,9 @@ modulemd_module_new (const gchar *module_name);
  * error.
  *
  * Returns: The mdversion of the defaults that were added. Returns
- * MD_DEFAULTS_VERSION_ERROR and sets @error if the default name didn't match
+ * %MD_DEFAULTS_VERSION_ERROR and sets @error if the default name didn't match
  * or the Defaults object couldn't be upgraded successfully to
- * the @index_mdversion. Returns MD_DEFAULTS_VERSION_UNSET if @defaults was
+ * the @index_mdversion. Returns %MD_DEFAULTS_VERSION_UNSET if @defaults was
  * NULL.
  *
  * Since: 2.0
@@ -77,8 +77,8 @@ modulemd_module_set_defaults (ModulemdModule *self,
 
 
 /**
- * modulemd_module_associate_translation:
- * @self: This #ModulemdModule object
+ * modulemd_module_add_translation:
+ * @self: This #ModulemdModule object.
  * @translation: (in): A #ModulemdTranslation object which is copied into the
  * #ModulemdModule object.
  *
@@ -91,7 +91,7 @@ modulemd_module_add_translation (ModulemdModule *self,
 
 /**
  * modulemd_module_get_translated_streams:
- * @self: This #ModulemdModule object
+ * @self: This #ModulemdModule object.
  *
  * Returns: (transfer container): A list of streams for which translations have
  * been added, sorted by stream name.
@@ -103,8 +103,8 @@ modulemd_module_get_translated_streams (ModulemdModule *self);
 
 
 /**
- * modulemd_module_get_translations:
- * @self: This #ModulemdModule object
+ * modulemd_module_get_translation:
+ * @self: This #ModulemdModule object.
  * @stream: The stream to look up translations for.
  *
  * Returns: (transfer none): The set of translations attached to streams.
@@ -117,7 +117,7 @@ modulemd_module_get_translation (ModulemdModule *self, const gchar *stream);
 
 /**
  * modulemd_module_add_stream:
- * @self: This #ModulemdModule object
+ * @self: This #ModulemdModule object.
  * @stream: A #ModulemdModuleStream object to associate with this
  * #ModulemdModule. A stream added to a #ModulemdModule must have a module
  * name and stream name set on it or it will be rejected. If the module name
@@ -135,10 +135,10 @@ modulemd_module_get_translation (ModulemdModule *self, const gchar *stream);
  * appropriate error.
  *
  * Returns: The mdversion of the stream that was added. Returns
- * MD_MODULE_STREAM_VERSION_ERROR and sets @error if the module name didn't
+ * %MD_MODULE_STREAM_VERSION_ERROR and sets @error if the module name didn't
  * match, the module and stream names were unset or the stream object couldn't
  * be upgraded successfully to the @index_mdversion. Returns
- * MD_MODULE_STREAM_VERSION_UNSET if @stream was NULL.
+ * %MD_MODULE_STREAM_VERSION_UNSET if @stream was NULL.
  *
  * Since: 2.0
  */
@@ -151,8 +151,8 @@ modulemd_module_add_stream (ModulemdModule *self,
 
 /**
  * modulemd_module_upgrade_streams:
- * @self: This #ModulemdModule object
- * @mdversion: The metadata version to upgrade to
+ * @self: This #ModulemdModule object.
+ * @mdversion: The metadata version to upgrade to.
  * @error: (out): A #GError containing the reason a stream failed to upgrade.
  *
  * Returns: TRUE if all upgrades completed successfully. FALSE and sets @error

--- a/modulemd/v2/include/private/modulemd-module-stream-private.h
+++ b/modulemd/v2/include/private/modulemd-module-stream-private.h
@@ -33,25 +33,80 @@ G_BEGIN_DECLS
  */
 
 
+/**
+ * modulemd_module_stream_set_module_name:
+ * @self: (in): This #ModulemdModuleStream object.
+ * @module_name: The module name this object represents.
+ *
+ * Since: 2.0
+ */
 void
 modulemd_module_stream_set_module_name (ModulemdModuleStream *self,
                                         const gchar *module_name);
 
+/**
+ * modulemd_module_stream_set_stream_name:
+ * @self: (in): This #ModulemdModuleStream object.
+ * @stream_name: The stream name this object represents.
+ *
+ * Since: 2.0
+ */
 void
 modulemd_module_stream_set_stream_name (ModulemdModuleStream *self,
                                         const gchar *stream_name);
 
+/**
+ * modulemd_module_stream_associate_translation:
+ * @self: (in): This #ModulemdModuleStream object.
+ * @translation: (in): The #ModulemdTranslation information to associate with
+ * this object.
+ *
+ * Since: 2.0
+ */
 void
 modulemd_module_stream_associate_translation (
   ModulemdModuleStream *self, ModulemdTranslation *translation);
 
+/**
+ * modulemd_module_stream_get_translation:
+ * @self: (in): This #ModulemdModuleStream object.
+ *
+ * Returns: The #ModulemdTranslation information to associated with this object.
+ *
+ * Since: 2.0
+ */
 ModulemdTranslation *
 modulemd_module_stream_get_translation (ModulemdModuleStream *self);
 
+/**
+ * modulemd_module_stream_get_translation_entry:
+ * @self: (in): This #ModulemdModuleStream object.
+ * @locale: The locale of the translation to retrieve.
+ *
+ * Returns: (transfer none): The module stream #ModulemdTranslationEntry for
+ * the requested locale, or NULL if the locale was unknown.
+ *
+ * Since: 2.0
+ */
 ModulemdTranslationEntry *
 modulemd_module_stream_get_translation_entry (ModulemdModuleStream *self,
                                               const gchar *locale);
 
+/**
+ * modulemd_module_stream_validate_components:
+ * @components: (in): A #GHashTable of #ModulemdComponent objects.
+ * @error: (out): A #GError that will return the reason for a validation error.
+ *
+ * Verifies that each of the #ModulemdComponent objects in @components
+ * validates correctly via modulemd_component_validate(), verifies that any
+ * buildafter components are also present in @components, and verifies that
+ * buildorder and buildafter aren't mixed.
+ *
+ * Returns: TRUE if the component objects passed validation. FALSE and sets
+ * @error appropriately if validation fails.
+ *
+ * Since: 2.0
+ */
 gboolean
 modulemd_module_stream_validate_components (GHashTable *components,
                                             GError **error);
@@ -120,6 +175,23 @@ modulemd_module_stream_validate_components (GHashTable *components,
     }                                                                         \
   while (0)
 
+/**
+ * modulemd_module_stream_emit_yaml_base:
+ * @self: This #ModulemdModuleStream object.
+ * @emitter: (inout): A libyaml emitter object positioned where a Module Stream
+ * document belongs in the YAML document.
+ * @error: (out): A #GError that will return the reason for an emission or
+ * validation error.
+ *
+ * Emit the common non-version specific YAML components for the Module Stream
+ * document.
+ *
+ * Returns: TRUE if the #ModulemdModuleStream components were emitted
+ * successfully. FALSE and sets @error appropriately if the YAML could not be
+ * emitted.
+ *
+ * Since: 2.0
+ */
 gboolean
 modulemd_module_stream_emit_yaml_base (ModulemdModuleStream *self,
                                        yaml_emitter_t *emitter,

--- a/modulemd/v2/include/private/modulemd-module-stream-private.h
+++ b/modulemd/v2/include/private/modulemd-module-stream-private.h
@@ -52,30 +52,6 @@ ModulemdTranslationEntry *
 modulemd_module_stream_get_translation_entry (ModulemdModuleStream *self,
                                               const gchar *locale);
 
-void
-modulemd_module_stream_v2_replace_content_licenses (
-  ModulemdModuleStreamV2 *self, GHashTable *set);
-
-void
-modulemd_module_stream_v2_replace_module_licenses (
-  ModulemdModuleStreamV2 *self, GHashTable *set);
-
-void
-modulemd_module_stream_v2_replace_rpm_api (ModulemdModuleStreamV2 *self,
-                                           GHashTable *set);
-
-void
-modulemd_module_stream_v2_replace_rpm_artifacts (ModulemdModuleStreamV2 *self,
-                                                 GHashTable *set);
-
-void
-modulemd_module_stream_v2_replace_rpm_filters (ModulemdModuleStreamV2 *self,
-                                               GHashTable *set);
-
-void
-modulemd_module_stream_v2_replace_dependencies (ModulemdModuleStreamV2 *self,
-                                                GPtrArray *array);
-
 gboolean
 modulemd_module_stream_validate_components (GHashTable *components,
                                             GError **error);

--- a/modulemd/v2/include/private/modulemd-module-stream-v1-private.h
+++ b/modulemd/v2/include/private/modulemd-module-stream-v1-private.h
@@ -89,7 +89,7 @@ modulemd_module_stream_v1_parse_yaml (ModulemdSubdocumentInfo *subdoc,
 
 /**
  * modulemd_module_stream_v1_emit_yaml:
- * @self: This #ModulemdModuleStreamV1 object
+ * @self: This #ModulemdModuleStreamV1 object.
  * @emitter: (inout): A libyaml emitter object positioned where a Module Stream
  * document belongs.
  * @error: (out): A #GError that will return the reason for an emission or

--- a/modulemd/v2/include/private/modulemd-module-stream-v2-private.h
+++ b/modulemd/v2/include/private/modulemd-module-stream-v2-private.h
@@ -72,7 +72,7 @@ struct _ModulemdModuleStreamV2
 /**
  * modulemd_module_stream_v2_parse_yaml:
  * @subdoc: (in): A #ModulemdSubdocumentInfo representing a stream v2
- * document
+ * document.
  * @strict: (in): Whether the parser should return failure if it encounters an
  * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError that will return the reason for a parsing or
@@ -91,7 +91,7 @@ modulemd_module_stream_v2_parse_yaml (ModulemdSubdocumentInfo *subdoc,
 
 /**
  * modulemd_module_stream_v2_emit_yaml:
- * @self: This #ModulemdModuleStreamV2 object
+ * @self: This #ModulemdModuleStreamV2 object.
  * @emitter: (inout): A libyaml emitter object positioned where the data
  * section of a #ModulemdModuleStreamV2 belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission or

--- a/modulemd/v2/include/private/modulemd-module-stream-v2-private.h
+++ b/modulemd/v2/include/private/modulemd-module-stream-v2-private.h
@@ -107,5 +107,95 @@ modulemd_module_stream_v2_emit_yaml (ModulemdModuleStreamV2 *self,
                                      yaml_emitter_t *emitter,
                                      GError **error);
 
+/**
+ * modulemd_module_stream_v2_replace_content_licenses:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @set: (in): A #GHashTable set of licenses under which one or more of the
+ * components of this module stream are distributed.
+ *
+ * Any existing content licenses associated with module stream @self are
+ * removed and replaced by @set.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_replace_content_licenses (
+  ModulemdModuleStreamV2 *self, GHashTable *set);
+
+/**
+ * modulemd_module_stream_v2_replace_module_licenses:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @set: (in): A #GHashTable set of licenses under which this module stream is
+ * distributed.
+ *
+ * Any existing module licenses associated with module stream @self are removed
+ * and replaced by @set.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_replace_module_licenses (
+  ModulemdModuleStreamV2 *self, GHashTable *set);
+
+/**
+ * modulemd_module_stream_v2_replace_rpm_api:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @set: (in): A #GHashTable set of binary RPMs present in this module stream that is
+ * considered stable public API.
+ *
+ * Any existing API RPMs associated with module stream @self are removed and
+ * replaced by @set.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_replace_rpm_api (ModulemdModuleStreamV2 *self,
+                                           GHashTable *set);
+
+/**
+ * modulemd_module_stream_v2_replace_rpm_artifacts:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @set: (in): A #GHashTable set of NEVRs of binary RPMs present in this module
+ * stream.
+ *
+ * Any existing artifact RPMs associated with module stream @self are removed
+ * and replaced by @set.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_replace_rpm_artifacts (ModulemdModuleStreamV2 *self,
+                                                 GHashTable *set);
+
+/**
+ * modulemd_module_stream_v2_replace_rpm_filters:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @set: (in): A #GHashTable set of names of binary RPMs to filter out of this
+ * module stream.
+ *
+ * Any existing filtered binary RPM names associated with module stream @self
+ * are removed and replaced by @set.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_replace_rpm_filters (ModulemdModuleStreamV2 *self,
+                                               GHashTable *set);
+
+/**
+ * modulemd_module_stream_v2_replace_dependencies:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @array: (in): A #GPtrArray of #ModulemdDependencies objects for this module
+ * stream.
+ *
+ * Any existing dependencies associated with module stream @self are removed
+ * and replaced by @array.
+ *
+ * Since: 2.0
+ */
+void
+modulemd_module_stream_v2_replace_dependencies (ModulemdModuleStreamV2 *self,
+                                                GPtrArray *array);
+
 
 G_END_DECLS

--- a/modulemd/v2/include/private/modulemd-profile-private.h
+++ b/modulemd/v2/include/private/modulemd-profile-private.h
@@ -50,8 +50,8 @@ modulemd_profile_parse_yaml (yaml_parser_t *parser,
                              GError **error);
 
 /**
- * modulemd_profile_emitter_yaml:
- * @self: This #ModulemdProfile
+ * modulemd_profile_emit_yaml:
+ * @self: This #ModulemdProfile object.
  * @emitter: (inout): A libyaml emitter object positioned where a Profile
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission or
@@ -69,10 +69,11 @@ modulemd_profile_emit_yaml (ModulemdProfile *self,
 
 /**
  * modulemd_profile_equals_wrapper:
- * @a: A void pointer
- * @b: A void pointer
+ * @a: A const void pointer.
+ * @b: A const void pointer.
  *
- * Returns: TRUE, if both the pointers are equal. FALSE, otherwise
+ * Returns: TRUE, if both arguments are pointers to #ModulemdProfile objects
+ * and all elements of both objects are equal. FALSE, otherwise.
  *
  * Since: 2.5
  */
@@ -82,7 +83,7 @@ modulemd_profile_equals_wrapper (const void *a, const void *b);
 
 /**
  * modulemd_profile_set_owner:
- * @self: This #ModulemdProfile
+ * @self: This #ModulemdProfile object.
  * @owner: A #ModulemdModuleStream that will own this profile. Used to look up
  * translations internally.
  *

--- a/modulemd/v2/include/private/modulemd-rpm-map-entry-private.h
+++ b/modulemd/v2/include/private/modulemd-rpm-map-entry-private.h
@@ -43,7 +43,7 @@ modulemd_rpm_map_entry_parse_yaml (yaml_parser_t *parser,
 
 /**
  * modulemd_rpm_map_entry_emit_yaml:
- * @self: This #ModulemdRpmMapEntry
+ * @self: This #ModulemdRpmMapEntry object.
  * @emitter: (inout): A libyaml emitter object positioned where a
  * #ModulemdRpmMapEntry belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission or
@@ -62,11 +62,11 @@ modulemd_rpm_map_entry_emit_yaml (ModulemdRpmMapEntry *self,
 
 /**
  * modulemd_rpm_map_entry_equals_wrapper:
- * @a: const void pointer
- * @b: const void pointer
+ * @a: A const void pointer.
+ * @b: A const void pointer.
  *
- * Returns: TRUE if the two entries contain equivalent data. FALSE if they
- * differ.
+ * Returns: TRUE if the two entries are both pointers to #ModulemdRpmMapEntry
+ * objects containing equivalent data. FALSE if they differ.
  *
  * Since: 2.5
  */
@@ -76,11 +76,12 @@ modulemd_rpm_map_entry_equals_wrapper (const void *a, const void *b);
 
 /**
  * modulemd_RpmMapEntry_hash_table_equals_wrapper:
- * @a: const void pointer
- * @b: const void pointer
+ * @a: A const void pointer.
+ * @b: A const void pointer.
  *
- * Returns: TRUE if the two entries contain equivalent data. FALSE if they
- * differ.
+ * Returns: TRUE if the two entries are equivalent #GHashTable<!-- -->s of
+ * pointers to #ModulemdRpmMapEntry objects containing equivalent data. FALSE
+ * if they differ.
  *
  * Since: 2.5
  */

--- a/modulemd/v2/include/private/modulemd-service-level-private.h
+++ b/modulemd/v2/include/private/modulemd-service-level-private.h
@@ -49,8 +49,8 @@ modulemd_service_level_parse_yaml (yaml_parser_t *parser,
                                    GError **error);
 
 /**
- * modulemd_service_level_emitter_yaml:
- * @self: This #ModulemdServiceLevel
+ * modulemd_service_level_emit_yaml:
+ * @self: This #ModulemdServiceLevel object.
  * @emitter: (inout): A libyaml emitter object positioned where a Service Level
  * entry belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission or
@@ -68,10 +68,11 @@ modulemd_service_level_emit_yaml (ModulemdServiceLevel *self,
 
 /**
  * modulemd_service_level_equals_wrapper:
- * @a: A void pointer
- * @b: A void pointer
+ * @a: A const void pointer.
+ * @b: A const void pointer.
  *
- * Returns: TRUE, if both the pointers are equal. FALSE, otherwise
+ * Returns: TRUE, if both arguments are pointers to equivalent
+ * #ModulemdServiceLevel objects. FALSE, otherwise.
  *
  * Since: 2.5
  */

--- a/modulemd/v2/include/private/modulemd-subdocument-info-private.h
+++ b/modulemd/v2/include/private/modulemd-subdocument-info-private.h
@@ -31,7 +31,7 @@
 /**
  * modulemd_subdocument_info_new:
  *
- * Returns: (transfer full): A newly-allocated #ModulemdSubdocumentInfo
+ * Returns: (transfer full): A newly-allocated #ModulemdSubdocumentInfo object.
  *
  * Since: 2.0
  */
@@ -41,9 +41,9 @@ modulemd_subdocument_info_new (void);
 
 /**
  * modulemd_subdocument_info_copy:
- * @self: This #ModulemdSubdocumentInfo
+ * @self: This #ModulemdSubdocumentInfo object.
  *
- * Returns: (transfer full): A deep copy of @self
+ * Returns: (transfer full): A deep copy of @self.
  *
  * Since: 2.0
  */
@@ -53,8 +53,9 @@ modulemd_subdocument_info_copy (ModulemdSubdocumentInfo *self);
 
 /**
  * modulemd_subdocument_info_set_doctype:
- * @self: This #ModulemdSubdocumentInfo
+ * @self: This #ModulemdSubdocumentInfo object.
  * @doctype: The #ModulemdYamlDocumentTypeEnum represented by this subdocument
+ * object.
  *
  * Since: 2.0
  */
@@ -65,9 +66,9 @@ modulemd_subdocument_info_set_doctype (ModulemdSubdocumentInfo *self,
 
 /**
  * modulemd_subdocument_info_get_doctype:
- * @self: This #ModulemdSubdocumentInfo
+ * @self: This #ModulemdSubdocumentInfo object.
  *
- * Returns: The type of subdocument represented by this SubdocumentInfo
+ * Returns: The type of subdocument represented by this #ModulemdSubdocumentInfo object.
  *
  * Since: 2.0
  */
@@ -77,8 +78,8 @@ modulemd_subdocument_info_get_doctype (ModulemdSubdocumentInfo *self);
 
 /**
  * modulemd_subdocument_info_set_mdversion:
- * @self: This #ModulemdSubdocumentInfo
- * @mdversion: The metadata version
+ * @self: This #ModulemdSubdocumentInfo object.
+ * @mdversion: The metadata version of this #ModulemdSubdocumentInfo object.
  *
  * Since: 2.0
  */
@@ -89,9 +90,9 @@ modulemd_subdocument_info_set_mdversion (ModulemdSubdocumentInfo *self,
 
 /**
  * modulemd_subdocument_info_get_mdversion:
- * @self: This #ModulemdSubdocumentInfo
+ * @self: This #ModulemdSubdocumentInfo object.
  *
- * Returns: The metadata version
+ * Returns: The metadata version of this #ModulemdSubdocumentInfo object.
  *
  * Since: 2.0
  */
@@ -101,8 +102,8 @@ modulemd_subdocument_info_get_mdversion (ModulemdSubdocumentInfo *self);
 
 /**
  * modulemd_subdocument_info_set_yaml:
- * @self: This #ModulemdSubdocumentInfo
- * @contents: The contents of the document
+ * @self: This #ModulemdSubdocumentInfo object.
+ * @contents: The contents of the document.
  *
  * Since: 2.0
  */
@@ -113,8 +114,8 @@ modulemd_subdocument_info_set_yaml (ModulemdSubdocumentInfo *self,
 
 /**
  * modulemd_subdocument_info_set_gerror:
- * @self: This #ModulemdSubdocumentInfo
- * @error: The error
+ * @self: This #ModulemdSubdocumentInfo object.
+ * @error: The error.
  *
  * Since: 2.0
  */
@@ -125,8 +126,8 @@ modulemd_subdocument_info_set_gerror (ModulemdSubdocumentInfo *self,
 
 /**
  * modulemd_subdocument_info_get_data_parser:
- * @self: This #ModulemdSubdocumentInfo
- * @parser: (inout): An unconfigured libyaml parser
+ * @self: This #ModulemdSubdocumentInfo object.
+ * @parser: (inout): An unconfigured libyaml parser.
  * @strict: (in): Whether the parser should return failure if it encounters an
  * unknown mapping key or if it should ignore it.
  * @error: (out): A #GError containing the parser error if this function fails.

--- a/modulemd/v2/include/private/modulemd-translation-entry-private.h
+++ b/modulemd/v2/include/private/modulemd-translation-entry-private.h
@@ -49,8 +49,8 @@ modulemd_translation_entry_parse_yaml (yaml_parser_t *parser,
                                        GError **error);
 
 /**
- * modulemd_translation_entry_emitter_yaml:
- * @self: This #ModulemdTranslationEntry
+ * modulemd_translation_entry_emit_yaml:
+ * @self: This #ModulemdTranslationEntry object.
  * @emitter: (inout): A libyaml emitter object positioned where a Translation Entry
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission or

--- a/modulemd/v2/include/private/modulemd-translation-private.h
+++ b/modulemd/v2/include/private/modulemd-translation-private.h
@@ -28,15 +28,48 @@
  */
 
 
+/**
+ * modulemd_translation_get_version:
+ * @self: (in): This #ModulemdTranslation object.
+ *
+ * Returns: The metadata version of this #ModulemdTranslation object.
+ *
+ * Since: 2.0
+ */
 guint64
 modulemd_translation_get_version (ModulemdTranslation *self);
 
+/**
+ * modulemd_translation_get_module_name:
+ * @self: (in): This #ModulemdTranslation object.
+ *
+ * Returns: The module name to which this #ModulemdTranslation object applies.
+ *
+ * Since: 2.0
+ */
 const gchar *
 modulemd_translation_get_module_name (ModulemdTranslation *self);
 
+/**
+ * modulemd_translation_get_module_stream:
+ * @self: (in): This #ModulemdTranslation object.
+ *
+ * Returns: The stream name to which this #ModulemdTranslation object applies.
+ *
+ * Since: 2.0
+ */
 const gchar *
 modulemd_translation_get_module_stream (ModulemdTranslation *self);
 
+/**
+ * modulemd_translation_get_modified:
+ * @self: (in): This #ModulemdTranslation object.
+ *
+ * Returns: The last modified time of this #ModulemdTranslation object
+ * represented as a 64-bit integer (such as 201807011200).
+ *
+ * Since: 2.0
+ */
 guint64
 modulemd_translation_get_modified (ModulemdTranslation *self);
 
@@ -63,7 +96,7 @@ modulemd_translation_parse_yaml (ModulemdSubdocumentInfo *subdoc,
 
 /**
  * modulemd_translation_emit_yaml:
- * @self: This #ModulemdTranslation
+ * @self: This #ModulemdTranslation object.
  * @emitter: (inout): A libyaml emitter object positioned where Translation data
  * belongs in the YAML document.
  * @error: (out): A #GError that will return the reason for an emission or

--- a/modulemd/v2/include/private/modulemd-yaml.h
+++ b/modulemd/v2/include/private/modulemd-yaml.h
@@ -380,7 +380,7 @@ modulemd_yaml_parse_uint64 (yaml_parser_t *parser, GError **error);
  * @parser: (inout): A libyaml parser object positioned at the beginning of a sequence with string scalars.
  * @error: (out): A #GError that will return the reason for a parsing or validation error.
  *
- * Returns: (transfer full): A newly-allocated GHashtTable * representing the parsed value.
+ * Returns: (transfer full): A newly-allocated #GHashTable * representing the parsed value.
  * All parsed sequence entries are added as keys in the hashtable.
  * NULL if a parse error occurred and sets @error appropriately.
  *
@@ -404,7 +404,7 @@ modulemd_yaml_parse_string_set (yaml_parser_t *parser, GError **error);
  * Function for retrieving a string set from a single-key map such as
  * data.artifacts, data.api or data.filter from a module stream document.
  *
- * Returns: (transfer full): A newly-allocated GHashtTable * representing the
+ * Returns: (transfer full): A newly-allocated #GHashTable * representing the
  * parsed values. All parsed sequence entries are added as keys in the
  * hashtable. NULL if a parse error occurred and sets @error appropriately.
  *
@@ -427,7 +427,7 @@ modulemd_yaml_parse_string_set_from_map (yaml_parser_t *parser,
  * Function for retrieving a hash table from a str/str map such as
  * data.dependencies in ModuleStreamV1.
  *
- * Returns: (transfer full): A newly-allocated GHashtTable * representing the
+ * Returns: (transfer full): A newly-allocated #GHashTable * representing the
  * parsed values. NULL if a parse error occurred and sets @error appropriately.
  *
  * Since: 2.0

--- a/modulemd/v2/modulemd-defaults-v1.c
+++ b/modulemd/v2/modulemd-defaults-v1.c
@@ -27,7 +27,7 @@ struct _ModulemdDefaultsV1
   gchar *default_stream;
 
   /* @key: stream name
-   * @value: GHashTable set of profile names
+   * @value: #GHashTable set of profile names
    */
   GHashTable *profile_defaults;
 
@@ -37,7 +37,7 @@ struct _ModulemdDefaultsV1
   GHashTable *intent_default_streams;
 
   /* @key: intent name
-   * @value: GHashTable set of profile names
+   * @value: #GHashTable set of profile names
    */
   GHashTable *intent_default_profiles;
 };

--- a/modulemd/v2/modulemd-dependencies.c
+++ b/modulemd/v2/modulemd-dependencies.c
@@ -25,12 +25,12 @@ struct _ModulemdDependencies
   GObject parent_instance;
 
   /* @key: dependent modules.
-   * @value: GHashTable set of compatible streams
+   * @value: #GHashTable set of compatible streams
    */
   GHashTable *buildtime_deps;
 
   /* @key: dependent modules.
-   * @value: GHashTable set of compatible streams
+   * @value: #GHashTable set of compatible streams
    */
   GHashTable *runtime_deps;
 };

--- a/modulemd/v2/modulemd-translation.c
+++ b/modulemd/v2/modulemd-translation.c
@@ -344,7 +344,7 @@ modulemd_translation_class_init (ModulemdTranslationClass *klass)
   properties[PROP_VERSION] =
     g_param_spec_uint64 ("version",
                          "Version",
-                         "The metadata version of this Modulemd.Translation.",
+                         "The metadata version of this Translation object.",
                          0,
                          G_MAXUINT64,
                          0,


### PR DESCRIPTION
This is the second (and hopefully final) batch of documentation updates for private functions requested by #317.

It also includes corrections for numerous minor spelling, grammar, style, punctuation errors, and other annoyances identified while going through the documentation. A few actual content errors were corrected, too.

For the newly documented functions, I'm not sure how to best identify the release in which they first appeared--so I put `Since: 2.X` as a place holder.