### PR TITLE
DOCS: Fix references to common GLib objects

### DIFF
--- a/.travis/archlinux/Dockerfile.deps.tmpl
+++ b/.travis/archlinux/Dockerfile.deps.tmpl
@@ -7,6 +7,7 @@ ARG TARBALL
 RUN pacman -Syu --needed --noconfirm \
 	base-devel \
 	glib2 \
+	glib2-docs \
 	gobject-introspection \
 	gtk-doc \
 	libyaml \

--- a/.travis/centos/Dockerfile.deps.tmpl
+++ b/.travis/centos/Dockerfile.deps.tmpl
@@ -5,7 +5,7 @@ MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 ARG TARBALL
 
 RUN yum -y install epel-release \
-    && yum -y install \
+    && yum -y --setopt=tsflags='' install \
         clang \
 	createrepo_c \
 	elinks \
@@ -13,6 +13,7 @@ RUN yum -y install epel-release \
 	gcc-c++ \
 	git-core \
 	glib2-devel \
+	glib2-doc \
 	gobject-introspection-devel \
 	gtk-doc \
 	libyaml-devel \

--- a/.travis/docs/travis-tasks.sh
+++ b/.travis/docs/travis-tasks.sh
@@ -26,6 +26,11 @@ if [ $err != 0 ]; then
 fi
 set -e
 
+# Fix external references for publishing on the web
+pushd doc-generation/modulemd/v2/html
+/builddir/modulemd/contrib/doc-tools/fix-xref.sh
+popd
+
 git clone https://sgallagher:$DOC_TOKEN@github.com/fedora-modularity/fedora-modularity.github.io
 rsync -avh --delete-before --no-perms --omit-dir-times /builddir/doc-generation/modulemd/v2/html/* fedora-modularity.github.io/libmodulemd/latest
 

--- a/.travis/fedora/Dockerfile.deps.tmpl
+++ b/.travis/fedora/Dockerfile.deps.tmpl
@@ -4,7 +4,7 @@ MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
 ARG TARBALL
 
-RUN dnf -y --setopt=install_weak_deps=False install \
+RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	clang \
 	clang-analyzer \
 	createrepo_c \
@@ -15,6 +15,7 @@ RUN dnf -y --setopt=install_weak_deps=False install \
 	gcc-c++ \
 	git-core \
 	glib2-devel \
+	glib2-doc \
 	gobject-introspection-devel \
 	gtk-doc \
 	libyaml-devel \

--- a/.travis/mageia/Dockerfile.deps.tmpl
+++ b/.travis/mageia/Dockerfile.deps.tmpl
@@ -4,7 +4,7 @@ MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
 ARG TARBALL
 
-RUN dnf -y --setopt=install_weak_deps=False install \
+RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	clang \
 	clang-analyzer \
 	createrepo_c \
@@ -14,6 +14,7 @@ RUN dnf -y --setopt=install_weak_deps=False install \
 	gcc-c++ \
 	git-core \
 	glib2-devel \
+	/usr/share/gtk-doc/html/glib/index.html \
 	gobject-introspection-devel \
 	gtk-doc \
 	libyaml-devel \

--- a/.travis/opensuse/Dockerfile.deps.tmpl
+++ b/.travis/opensuse/Dockerfile.deps.tmpl
@@ -4,6 +4,9 @@ MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
 ARG TARBALL
 
+RUN sed -i /etc/zypp/zypp.conf \
+        -e "s/rpm.install.excludedocs = yes/rpm.install.excludedocs = no/"
+
 RUN zypper install --no-confirm --no-recommends \
 	clang \
 	clang-checker \

--- a/contrib/doc-tools/fix-xref.sh
+++ b/contrib/doc-tools/fix-xref.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+devdocs_url="https://developer.gnome.org"
+
+dir=`pwd`
+
+for file in $dir/*.html; do
+  echo "Fixing cross-references in ${file}..."
+  sed -i \
+        -e "s|/usr/share/gtk-doc/html/gobject|${devdocs_url}/gobject/stable|" \
+        -e "s|/usr/share/gtk-doc/html/glib|${devdocs_url}/glib/stable|" \
+        -e "s|\.\./glib|${devdocs_url}/glib/stable|" \
+        -e "s|\.\./gobject|${devdocs_url}/gobject/stable|" \
+  ${file}
+done

--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -35,6 +35,7 @@ BuildRequires:  python3-gobject-base
 BuildRequires:  python3-babel
 BuildRequires:  python2-babel
 BuildRequires:  valgrind
+BuildRequires:  glib2-doc
 
 # Make sure we upgrade libmodulemd1 to match
 Conflicts:      libmodulemd1 < %{libmodulemd_v1_version}-%{release}

--- a/meson.build
+++ b/meson.build
@@ -54,8 +54,22 @@ gobject = dependency('gobject-2.0')
 yaml = dependency('yaml-0.1')
 gtkdoc = dependency('gtk-doc')
 
+glib_prefix = dependency('glib-2.0').get_pkgconfig_variable('prefix')
+glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
+
 sh = find_program('sh')
 sed = find_program('sed')
+test = find_program('test')
+
+ret = run_command ([test, '-e', join_paths(glib_docpath, 'glib/index.html')])
+if ret.returncode() != 0
+  error('Missing documentation for GLib.')
+endif
+
+ret = run_command ([test, '-e', join_paths(glib_docpath, 'gobject/index.html')])
+if ret.returncode() != 0
+  error('Missing documentation for GObject.')
+endif
 
 python_name = get_option('python_name')
 

--- a/modulemd/v2/meson.build
+++ b/modulemd/v2/meson.build
@@ -295,6 +295,10 @@ gnome.gtkdoc(
     dependencies : [
         modulemd_v2_dep,
     ],
+    fixxref_args: [
+                 '--extra-dir=@0@'.format(join_paths(glib_docpath, 'glib')),
+                 '--extra-dir=@0@'.format(join_paths(glib_docpath, 'gobject')),
+               ],
     install : true,
 )
 

--- a/modulemd/v2/modulemd-v2-docs.xml
+++ b/modulemd/v2/modulemd-v2-docs.xml
@@ -84,4 +84,52 @@
         <xi:include href="xml/test-utils.xml"/>
     </chapter>
   </reference>
+  <reference id="modulemd-2.0-resources">
+    <title>resources</title>
+    <partintro>
+      <para>
+        Additional resources for libmodulemd
+      </para>
+    </partintro>
+    <chapter>
+      <title>Annotations</title>
+      <xi:include href="xml/annotation-glossary.xml"/>
+    </chapter>
+    <chapter>
+      <title>2.0 API Index</title>
+      <xi:include href="xml/api-index-2.0.xml"/>
+    </chapter>
+    <chapter>
+      <title>2.1 API Index</title>
+      <xi:include href="xml/api-index-2.1.xml"/>
+    </chapter>
+    <chapter>
+      <title>2.2 API Index</title>
+      <xi:include href="xml/api-index-2.2.xml"/>
+    </chapter>
+    <chapter>
+      <title>2.3 API Index</title>
+      <xi:include href="xml/api-index-2.3.xml"/>
+    </chapter>
+    <chapter>
+      <title>2.4 API Index</title>
+      <xi:include href="xml/api-index-2.4.xml"/>
+    </chapter>
+    <chapter>
+      <title>2.5 API Index</title>
+      <xi:include href="xml/api-index-2.5.xml"/>
+    </chapter>
+    <chapter>
+      <title>2.6 API Index</title>
+      <xi:include href="xml/api-index-2.6.xml"/>
+    </chapter>
+    <chapter>
+      <title>Deprecated API Index</title>
+      <xi:include href="xml/api-index-deprecated.xml"/>
+    </chapter>
+    <chapter>
+      <title>Full API Index</title>
+      <xi:include href="xml/api-index-full.xml"/>
+    </chapter>
+  </reference>
 </book>


### PR DESCRIPTION
This patch adds support for linking to common GLib objects (fixing broken links in the installed docs and also including a shell script to clean up the ones published to the web).

It also adds a new resources section to the docs, mainly for cross-referencing.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>