### PR TITLE
Split Coverity scan into a separate test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ jobs:
       script: ./.travis/travis-centos.sh
     - name: "Documentation Update"
       script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./.travis/travis-docs.sh; fi'
+    - name: "Coverity Scan"
+      script: 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./.travis/travis-coverity.sh; fi'
     - name: "openSUSE tumbleweed"
       script: ./.travis/travis-opensuse.sh
     - name: "Arch Linux"

--- a/.travis/coverity/Dockerfile
+++ b/.travis/coverity/Dockerfile
@@ -1,0 +1,14 @@
+FROM fedora-modularity/libmodulemd-deps-rawhide
+
+MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
+
+RUN dnf -y --setopt=install_weak_deps=False install rsync \
+    && dnf -y clean all
+
+ARG TARBALL
+
+ADD $TARBALL /builddir/
+
+RUN  /builddir/.travis/coverity_prep.sh
+
+ENTRYPOINT /builddir/.travis/coverity/travis-tasks.sh

--- a/.travis/coverity/travis-tasks.sh
+++ b/.travis/coverity/travis-tasks.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#Exit on failures
+set -e
+
+set -x
+
+os_name=Fedora
+release=rawhide
+
+pushd /builddir/
+
+meson --buildtype=debug \
+      -Dbuild_api_v1=true \
+      -Dbuild_api_v2=true \
+      $COMMON_MESON_ARGS \
+      coverity
+
+pushd coverity
+
+# The coverity scan script returns an error despite succeeding...
+ TRAVIS_BRANCH="${TRAVIS_BRANCH:-master}" \
+ COVERITY_SCAN_PROJECT_NAME="${COVERITY_SCAN_PROJECT_NAME:-sgallagher/libmodulemd}" \
+ COVERITY_SCAN_NOTIFICATION_EMAIL="${COVERITY_SCAN_NOTIFICATION_EMAIL:-sgallagh@redhat.com}" \
+ COVERITY_SCAN_BUILD_COMMAND="${COVERITY_SCAN_BUILD_COMMAND:-ninja}" \
+ COVERITY_SCAN_BRANCH_PATTERN=${COVERITY_SCAN_BRANCH_PATTERN:-master} \
+ /usr/bin/travisci_build_coverity_scan.sh ||:
+
+popd #coverity
+
+popd #builddir

--- a/.travis/fedora/Dockerfile.tmpl
+++ b/.travis/fedora/Dockerfile.tmpl
@@ -6,6 +6,4 @@ ARG TARBALL
 
 ADD $TARBALL /builddir/
 
-RUN  /builddir/.travis/coverity_prep.sh
-
 ENTRYPOINT /builddir/.travis/fedora/travis-tasks.sh

--- a/.travis/fedora/travis-tasks.sh
+++ b/.travis/fedora/travis-tasks.sh
@@ -54,24 +54,6 @@ else
     popd #travis_scanbuild
 fi
 
-meson --buildtype=debug \
-      -Dbuild_api_v1=true \
-      -Dbuild_api_v2=true \
-      $COMMON_MESON_ARGS \
-      coverity
-
-pushd coverity
-
-# The coverity scan script returns an error despite succeeding...
- TRAVIS_BRANCH="${TRAVIS_BRANCH:-master}" \
- COVERITY_SCAN_PROJECT_NAME="${COVERITY_SCAN_PROJECT_NAME:-sgallagher/libmodulemd}" \
- COVERITY_SCAN_NOTIFICATION_EMAIL="${COVERITY_SCAN_NOTIFICATION_EMAIL:-sgallagh@redhat.com}" \
- COVERITY_SCAN_BUILD_COMMAND="${COVERITY_SCAN_BUILD_COMMAND:-ninja}" \
- COVERITY_SCAN_BRANCH_PATTERN=${COVERITY_SCAN_BRANCH_PATTERN:-master} \
- /usr/bin/travisci_build_coverity_scan.sh ||:
-
-popd #coverity
-
 
 # Always install and run the installed RPM tests last so we don't pollute the
 # testing environment above.

--- a/.travis/travis-archlinux.sh
+++ b/.travis/travis-archlinux.sh
@@ -26,11 +26,21 @@ sed -e "s/@IMAGE@/$repository\/$os\/$release/" \
     $SCRIPT_DIR/archlinux/Dockerfile.deps.tmpl > $SCRIPT_DIR/archlinux/Dockerfile.deps.$release
 sed -e "s/@RELEASE@/$release/" $SCRIPT_DIR/archlinux/Dockerfile.tmpl > $SCRIPT_DIR/archlinux/Dockerfile-$release
 
-sudo docker build -f $SCRIPT_DIR/archlinux/Dockerfile.deps.$release -t fedora-modularity/libmodulemd-deps-$release .
-sudo docker build -f $SCRIPT_DIR/archlinux/Dockerfile-$release -t fedora-modularity/libmodulemd:$release --build-arg TARBALL=$TARBALL .
+sudo docker build \
+    -f $SCRIPT_DIR/archlinux/Dockerfile.deps.$release \
+    -t fedora-modularity/libmodulemd-deps-$release .
+
+sudo docker build \
+    -f $SCRIPT_DIR/archlinux/Dockerfile-$release \
+    -t fedora-modularity/libmodulemd:$release \
+    --build-arg TARBALL=$TARBALL .
 
 rm -f $TARBALL_PATH $SCRIPT_DIR/archlinux/Dockerfile.deps.$release $SCRIPT_DIR/archlinux/Dockerfile-$release
 
-docker run -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
+docker run \
+    -e TRAVIS=$TRAVIS \
+    -e TRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" \
+    --rm fedora-modularity/libmodulemd:$release
+
 popd
 exit 0

--- a/.travis/travis-archlinux.sh
+++ b/.travis/travis-archlinux.sh
@@ -31,6 +31,6 @@ sudo docker build -f $SCRIPT_DIR/archlinux/Dockerfile-$release -t fedora-modular
 
 rm -f $TARBALL_PATH $SCRIPT_DIR/archlinux/Dockerfile.deps.$release $SCRIPT_DIR/archlinux/Dockerfile-$release
 
-docker run -e COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
+docker run -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
 popd
 exit 0

--- a/.travis/travis-centos.sh
+++ b/.travis/travis-centos.sh
@@ -27,12 +27,21 @@ sed -e "s/@IMAGE@/$repository\/$os:$release/" \
     $SCRIPT_DIR/centos/Dockerfile.deps.tmpl > $SCRIPT_DIR/centos/Dockerfile.deps.$release
 sed -e "s/@RELEASE@/$release/" $SCRIPT_DIR/centos/Dockerfile.tmpl > $SCRIPT_DIR/centos/Dockerfile-$release
 
-sudo docker build -f $SCRIPT_DIR/centos/Dockerfile.deps.$release -t fedora-modularity/libmodulemd-deps-$release .
-sudo docker build -f $SCRIPT_DIR/centos/Dockerfile-$release -t fedora-modularity/libmodulemd:$release --build-arg TARBALL=$TARBALL .
+sudo docker build \
+    -f $SCRIPT_DIR/centos/Dockerfile.deps.$release \
+    -t fedora-modularity/libmodulemd-deps-$release .
+
+sudo docker build \
+    -f $SCRIPT_DIR/centos/Dockerfile-$release \
+    -t fedora-modularity/libmodulemd:$release \
+    --build-arg TARBALL=$TARBALL .
 
 rm -f $TARBALL_PATH $SCRIPT_DIR/centos/Dockerfile.deps.$release $SCRIPT_DIR/centos/Dockerfile-$release
 
-docker run -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
+docker run \
+    -e TRAVIS=$TRAVIS \
+    -e TRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" \
+    --rm fedora-modularity/libmodulemd:$release
 
 popd
 exit 0

--- a/.travis/travis-centos.sh
+++ b/.travis/travis-centos.sh
@@ -30,14 +30,9 @@ sed -e "s/@RELEASE@/$release/" $SCRIPT_DIR/centos/Dockerfile.tmpl > $SCRIPT_DIR/
 sudo docker build -f $SCRIPT_DIR/centos/Dockerfile.deps.$release -t fedora-modularity/libmodulemd-deps-$release .
 sudo docker build -f $SCRIPT_DIR/centos/Dockerfile-$release -t fedora-modularity/libmodulemd:$release --build-arg TARBALL=$TARBALL .
 
-if [ $release != "rawhide" ]; then
-  # Only run Coverity scan on Rawhide since we have a limited number of scans per week.
-  unset COVERITY_SCAN_TOKEN
-fi
-
 rm -f $TARBALL_PATH $SCRIPT_DIR/centos/Dockerfile.deps.$release $SCRIPT_DIR/centos/Dockerfile-$release
 
-docker run -e COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
+docker run -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
 
 popd
 exit 0

--- a/.travis/travis-coverity.sh
+++ b/.travis/travis-coverity.sh
@@ -26,8 +26,14 @@ os="fedora"
 sed -e "s/@IMAGE@/$repository\/$os:$release/" \
     $SCRIPT_DIR/fedora/Dockerfile.deps.tmpl > $SCRIPT_DIR/fedora/Dockerfile.deps.$release
 
-sudo docker build -f $SCRIPT_DIR/fedora/Dockerfile.deps.$release -t fedora-modularity/libmodulemd-deps-$release .
-sudo docker build -f $SCRIPT_DIR/coverity/Dockerfile -t fedora-modularity/libmodulemd-coverity --build-arg TARBALL=$TARBALL .
+sudo docker build \
+    -f $SCRIPT_DIR/fedora/Dockerfile.deps.$release \
+    -t fedora-modularity/libmodulemd-deps-$release .
+
+sudo docker build \
+    -f $SCRIPT_DIR/coverity/Dockerfile \
+    -t fedora-modularity/libmodulemd-coverity \
+    --build-arg TARBALL=$TARBALL .
 
 rm -f $TARBALL_PATH $SCRIPT_DIR/fedora/Dockerfile.deps.$release $SCRIPT_DIR/fedora/Dockerfile-$release
 

--- a/.travis/travis-docs.sh
+++ b/.travis/travis-docs.sh
@@ -26,8 +26,14 @@ os="fedora"
 sed -e "s/@IMAGE@/$repository\/$os:$release/" \
     $SCRIPT_DIR/fedora/Dockerfile.deps.tmpl > $SCRIPT_DIR/fedora/Dockerfile.deps.$release
 
-sudo docker build -f $SCRIPT_DIR/fedora/Dockerfile.deps.$release -t fedora-modularity/libmodulemd-deps-$release .
-sudo docker build -f $SCRIPT_DIR/docs/Dockerfile -t fedora-modularity/libmodulemd-docs --build-arg TARBALL=$TARBALL .
+sudo docker build \
+    -f $SCRIPT_DIR/fedora/Dockerfile.deps.$release \
+    -t fedora-modularity/libmodulemd-deps-$release .
+
+sudo docker build \
+    -f $SCRIPT_DIR/docs/Dockerfile \
+    -t fedora-modularity/libmodulemd-docs \
+    --build-arg TARBALL=$TARBALL .
 
 rm -f $TARBALL_PATH $SCRIPT_DIR/fedora/Dockerfile.deps.$release $SCRIPT_DIR/fedora/Dockerfile-$release
 

--- a/.travis/travis-docs.sh
+++ b/.travis/travis-docs.sh
@@ -33,7 +33,6 @@ rm -f $TARBALL_PATH $SCRIPT_DIR/fedora/Dockerfile.deps.$release $SCRIPT_DIR/fedo
 
 # Override the standard tasks with the doc-generation
 docker run \
-    -e COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN \
     -e TRAVIS=$TRAVIS \
     -e TRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" \
     -e TRAVIS_COMMIT="$TRAVIS_COMMIT" \

--- a/.travis/travis-fedora.sh
+++ b/.travis/travis-fedora.sh
@@ -27,12 +27,21 @@ sed -e "s/@IMAGE@/$repository\/$os:$release/" \
     $SCRIPT_DIR/fedora/Dockerfile.deps.tmpl > $SCRIPT_DIR/fedora/Dockerfile.deps.$release
 sed -e "s/@RELEASE@/$release/" $SCRIPT_DIR/fedora/Dockerfile.tmpl > $SCRIPT_DIR/fedora/Dockerfile-$release
 
-sudo docker build -f $SCRIPT_DIR/fedora/Dockerfile.deps.$release -t fedora-modularity/libmodulemd-deps-$release .
-sudo docker build -f $SCRIPT_DIR/fedora/Dockerfile-$release -t fedora-modularity/libmodulemd:$release --build-arg TARBALL=$TARBALL .
+sudo docker build \
+    -f $SCRIPT_DIR/fedora/Dockerfile.deps.$release \
+    -t fedora-modularity/libmodulemd-deps-$release .
+
+sudo docker build \
+    -f $SCRIPT_DIR/fedora/Dockerfile-$release \
+    -t fedora-modularity/libmodulemd:$release \
+    --build-arg TARBALL=$TARBALL .
 
 rm -f $TARBALL_PATH $SCRIPT_DIR/fedora/Dockerfile.deps.$release $SCRIPT_DIR/fedora/Dockerfile-$release
 
-docker run -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
+docker run \
+    -e TRAVIS=$TRAVIS \
+    -e TRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" \
+    --rm fedora-modularity/libmodulemd:$release
 
 popd
 exit 0

--- a/.travis/travis-mageia.sh
+++ b/.travis/travis-mageia.sh
@@ -34,7 +34,7 @@ sudo docker build -f $SCRIPT_DIR/mageia/Dockerfile-$release -t fedora-modularity
 
 rm -f $TARBALL_PATH $SCRIPT_DIR/mageia/Dockerfile.deps.$release $SCRIPT_DIR/mageia/Dockerfile-$release
 
-docker run -e COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
+docker run -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
 
 popd
 exit 0

--- a/.travis/travis-mageia.sh
+++ b/.travis/travis-mageia.sh
@@ -29,12 +29,21 @@ sed -e "s/@IMAGE@/$repository\/$os:$release/" \
     $SCRIPT_DIR/mageia/Dockerfile.deps.tmpl > $SCRIPT_DIR/mageia/Dockerfile.deps.$release
 sed -e "s/@RELEASE@/$release/" $SCRIPT_DIR/mageia/Dockerfile.tmpl > $SCRIPT_DIR/mageia/Dockerfile-$release
 
-sudo docker build -f $SCRIPT_DIR/mageia/Dockerfile.deps.$release -t fedora-modularity/libmodulemd-deps-$release .
-sudo docker build -f $SCRIPT_DIR/mageia/Dockerfile-$release -t fedora-modularity/libmodulemd:$release --build-arg TARBALL=$TARBALL .
+sudo docker build \
+    -f $SCRIPT_DIR/mageia/Dockerfile.deps.$release \
+    -t fedora-modularity/libmodulemd-deps-$release .
+
+sudo docker build \
+    -f $SCRIPT_DIR/mageia/Dockerfile-$release \
+    -t fedora-modularity/libmodulemd:$release \
+    --build-arg TARBALL=$TARBALL .
 
 rm -f $TARBALL_PATH $SCRIPT_DIR/mageia/Dockerfile.deps.$release $SCRIPT_DIR/mageia/Dockerfile-$release
 
-docker run -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
+docker run \
+    -e TRAVIS=$TRAVIS \
+    -e TRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" \
+    --rm fedora-modularity/libmodulemd:$release
 
 popd
 exit 0

--- a/.travis/travis-opensuse.sh
+++ b/.travis/travis-opensuse.sh
@@ -27,11 +27,20 @@ sed -e "s/@IMAGE@/$repository\/$os\/$release/" \
     $SCRIPT_DIR/opensuse/Dockerfile.deps.tmpl > $SCRIPT_DIR/opensuse/Dockerfile.deps.$release
 sed -e "s/@RELEASE@/$release/" $SCRIPT_DIR/opensuse/Dockerfile.tmpl > $SCRIPT_DIR/opensuse/Dockerfile-$release
 
-sudo docker build -f $SCRIPT_DIR/opensuse/Dockerfile.deps.$release -t fedora-modularity/libmodulemd-deps-$release .
-sudo docker build -f $SCRIPT_DIR/opensuse/Dockerfile-$release -t fedora-modularity/libmodulemd:$release --build-arg TARBALL=$TARBALL .
+sudo docker build \
+    -f $SCRIPT_DIR/opensuse/Dockerfile.deps.$release \
+    -t fedora-modularity/libmodulemd-deps-$release .
+
+sudo docker build \
+    -f $SCRIPT_DIR/opensuse/Dockerfile-$release \
+    -t fedora-modularity/libmodulemd:$release \
+    --build-arg TARBALL=$TARBALL .
 
 rm -f $TARBALL_PATH $SCRIPT_DIR/opensuse/Dockerfile.deps.$release $SCRIPT_DIR/opensuse/Dockerfile-$release
 
-docker run -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
+docker run \
+    -e TRAVIS=$TRAVIS \
+    -e TRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" \
+    --rm fedora-modularity/libmodulemd:$release
 popd
 exit 0

--- a/.travis/travis-opensuse.sh
+++ b/.travis/travis-opensuse.sh
@@ -32,6 +32,6 @@ sudo docker build -f $SCRIPT_DIR/opensuse/Dockerfile-$release -t fedora-modulari
 
 rm -f $TARBALL_PATH $SCRIPT_DIR/opensuse/Dockerfile.deps.$release $SCRIPT_DIR/opensuse/Dockerfile-$release
 
-docker run -e COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
+docker run -e TRAVIS=$TRAVIS -eTRAVIS_JOB_NAME="$TRAVIS_JOB_NAME" --rm fedora-modularity/libmodulemd:$release
 popd
 exit 0


### PR DESCRIPTION
Allows us to more easily exclude it for pull-requests and to speed
up the Fedora tests slightly.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>