### PR TITLE
Type tweaks to be more friendly to gtk-doc documentation generation.

### DIFF
--- a/modulemd/v2/include/modulemd-2.0/modulemd-buildopts.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-buildopts.h
@@ -135,11 +135,11 @@ modulemd_buildopts_clear_rpm_whitelist (ModulemdBuildopts *self);
  * modulemd_buildopts_get_rpm_whitelist_as_strv: (rename-to modulemd_buildopts_get_rpm_whitelist)
  * @self: This #ModulemdBuildopts
  *
- * Returns: (transfer full): An ordered list of all RPMs in the whitelist.
+ * Returns: (transfer full): An ordered #GStrv list of all RPMs in the whitelist.
  *
  * Since: 2.0
  */
-gchar **
+GStrv
 modulemd_buildopts_get_rpm_whitelist_as_strv (ModulemdBuildopts *self);
 
 G_END_DECLS

--- a/modulemd/v2/include/modulemd-2.0/modulemd-profile.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-profile.h
@@ -151,12 +151,12 @@ modulemd_profile_clear_rpms (ModulemdProfile *self);
  * modulemd_profile_get_rpms_as_strv: (rename-to modulemd_profile_get_rpms)
  * @self: This #ModulemdProfile
  *
- * Returns: (transfer full): An ordered list of binary RPMS that would be
+ * Returns: (transfer full): An ordered #GStrv list of binary RPMS that would be
  * installed when this profile is selected for installation.
  *
  * Since: 2.0
  */
-gchar **
+GStrv
 modulemd_profile_get_rpms_as_strv (ModulemdProfile *self);
 
 G_END_DECLS

--- a/modulemd/v2/include/modulemd-2.0/modulemd-translation-entry.h
+++ b/modulemd/v2/include/modulemd-2.0/modulemd-translation-entry.h
@@ -134,11 +134,12 @@ modulemd_translation_entry_get_description (ModulemdTranslationEntry *self);
  *
  * Get a list of profiles that have descriptions.
  *
- * Returns: (transfer full): An ordered list of profiles for which descriptions have been translated for this locale.
+ * Returns: (transfer full): An ordered #GStrv list of profiles for which
+ * descriptions have been translated for this locale.
  *
  * Since: 2.0
  */
-gchar **
+GStrv
 modulemd_translation_entry_get_profiles_as_strv (
   ModulemdTranslationEntry *self);
 

--- a/modulemd/v2/include/private/gi-binding-renames.h
+++ b/modulemd/v2/include/private/gi-binding-renames.h
@@ -26,7 +26,7 @@ G_BEGIN_DECLS
 /**
  * modulemd_buildopts_get_rpm_whitelist: (skip)
  */
-gchar **
+GStrv
 modulemd_buildopts_get_rpm_whitelist (ModulemdBuildopts *self);
 
 /**
@@ -243,13 +243,13 @@ modulemd_module_stream_v2_get_servicelevel_names (
 /**
  * modulemd_profile_get_rpms: (skip)
  */
-gchar **
+GStrv
 modulemd_profile_get_rpms (ModulemdProfile *self);
 
 /**
  * modulemd_translation_entry_get_profiles: (skip)
  */
-gchar **
+GStrv
 modulemd_translation_entry_get_profiles (ModulemdTranslationEntry *self);
 
 /**

--- a/modulemd/v2/include/private/modulemd-subdocument-info-private.h
+++ b/modulemd/v2/include/private/modulemd-subdocument-info-private.h
@@ -54,13 +54,13 @@ modulemd_subdocument_info_copy (ModulemdSubdocumentInfo *self);
 /**
  * modulemd_subdocument_info_set_doctype:
  * @self: This #ModulemdSubdocumentInfo
- * @doctype: The #ModulemdYamlDocumentType represented by this subdocument
+ * @doctype: The #ModulemdYamlDocumentTypeEnum represented by this subdocument
  *
  * Since: 2.0
  */
 void
 modulemd_subdocument_info_set_doctype (ModulemdSubdocumentInfo *self,
-                                       enum ModulemdYamlDocumentType doctype);
+                                       ModulemdYamlDocumentTypeEnum doctype);
 
 
 /**
@@ -71,7 +71,7 @@ modulemd_subdocument_info_set_doctype (ModulemdSubdocumentInfo *self,
  *
  * Since: 2.0
  */
-enum ModulemdYamlDocumentType
+ModulemdYamlDocumentTypeEnum
 modulemd_subdocument_info_get_doctype (ModulemdSubdocumentInfo *self);
 
 

--- a/modulemd/v2/include/private/modulemd-util.h
+++ b/modulemd/v2/include/private/modulemd-util.h
@@ -93,7 +93,7 @@ modulemd_strcmp_sort (gconstpointer a, gconstpointer b);
 GPtrArray *
 modulemd_ordered_str_keys (GHashTable *htable, GCompareFunc compare_func);
 
-gchar **
+GStrv
 modulemd_ordered_str_keys_as_strv (GHashTable *htable);
 
 GVariant *

--- a/modulemd/v2/include/private/modulemd-yaml.h
+++ b/modulemd/v2/include/private/modulemd-yaml.h
@@ -34,15 +34,49 @@ G_BEGIN_DECLS
 GQuark
 modulemd_yaml_error_quark (void);
 
-enum ModulemdYamlDocumentType
+/**
+ * ModulemdYamlDocumentTypeEnum:
+ * @MODULEMD_YAML_DOC_UNKNOWN: Represents an unknown YAML document type.
+ * @MODULEMD_YAML_DOC_MODULESTREAM: Represents a `modulemd` (see
+ * #ModulemdModuleStream) YAML document type.
+ * @MODULEMD_YAML_DOC_DEFAULTS: Represents a `modulemd-defaults` (see
+ * #ModulemdDefaultsV1) YAML document type.
+ * @MODULEMD_YAML_DOC_TRANSLATIONS: Represents a `modulemd-translations` (see
+ * #ModulemdTranslation) YAML document type.
+ *
+ * Since: 2.0
+ */
+typedef enum
 {
   MODULEMD_YAML_DOC_UNKNOWN = 0,
   MODULEMD_YAML_DOC_MODULESTREAM,
   MODULEMD_YAML_DOC_DEFAULTS,
   MODULEMD_YAML_DOC_TRANSLATIONS
-};
+} ModulemdYamlDocumentTypeEnum;
 
-enum ModulemdYamlError
+/**
+ * ModulemdYamlErrorEnum:
+ * @MODULEMD_YAML_ERROR_OPEN: Represents an error encountered while opening a
+ * YAML file.
+ * @MODULEMD_YAML_ERROR_PROGRAMMING: Represents an internal programming error
+ * encountered while parsing a YAML document.
+ * @MODULEMD_YAML_ERROR_UNPARSEABLE: Represents an error indicating that
+ * unexpected data or some other parsing error was encountered while parsing a
+ * YAML document.
+ * @MODULEMD_YAML_ERROR_PARSE: Represents an error indicating invalid data was
+ * encountered while parsing a YAML document.
+ * @MODULEMD_YAML_ERROR_EMIT: Represents an error encountered while writing a
+ * YAML file.
+ * @MODULEMD_YAML_ERROR_MISSING_REQUIRED: Represents an error indicating that
+ * required elements are missing encountered while parsing a YAML document.
+ * @MODULEMD_YAML_ERROR_EVENT_INIT: Represents an error indicating that a YAML
+ * output event could not be initialized.
+ * @MODULEMD_YAML_ERROR_INCONSISTENT: Represents a data inconsistency error
+ * encountered while parsing a YAML document.
+ *
+ * Since: 2.0
+ */
+typedef enum
 {
   MODULEMD_YAML_ERROR_OPEN,
   MODULEMD_YAML_ERROR_PROGRAMMING,
@@ -52,7 +86,7 @@ enum ModulemdYamlError
   MODULEMD_YAML_ERROR_MISSING_REQUIRED,
   MODULEMD_YAML_ERROR_EVENT_INIT,
   MODULEMD_YAML_ERROR_INCONSISTENT
-};
+} ModulemdYamlErrorEnum;
 
 typedef struct _modulemd_yaml_string
 {
@@ -423,7 +457,7 @@ modulemd_yaml_parse_document_type (yaml_parser_t *parser);
  * @emitter: (inout): A libyaml emitter object that is positioned where the
  * YAML_DOCUMENT_START_EVENT should occur (so this must be after either a
  * YAML_STREAM_START_EVENT or YAML_DOCUMENT_END_EVENT).
- * @doctype: (in): The document type (see #ModulemdYamlDocumentType)
+ * @doctype: (in): The document type (see #ModulemdYamlDocumentTypeEnum)
  * @mdversion: (in): The metadata version for this document
  * @error: (out): A #GError that will return the reason for failing to emit.
  *
@@ -437,7 +471,7 @@ modulemd_yaml_parse_document_type (yaml_parser_t *parser);
  */
 gboolean
 modulemd_yaml_emit_document_headers (yaml_emitter_t *emitter,
-                                     enum ModulemdYamlDocumentType doctype,
+                                     ModulemdYamlDocumentTypeEnum doctype,
                                      guint64 mdversion,
                                      GError **error);
 

--- a/modulemd/v2/modulemd-buildopts.c
+++ b/modulemd/v2/modulemd-buildopts.c
@@ -153,7 +153,7 @@ modulemd_buildopts_clear_rpm_whitelist (ModulemdBuildopts *self)
 }
 
 
-gchar **
+GStrv
 modulemd_buildopts_get_rpm_whitelist_as_strv (ModulemdBuildopts *self)
 {
   g_return_val_if_fail (MODULEMD_IS_BUILDOPTS (self), NULL);

--- a/modulemd/v2/modulemd-profile.c
+++ b/modulemd/v2/modulemd-profile.c
@@ -204,7 +204,7 @@ modulemd_profile_clear_rpms (ModulemdProfile *self)
 }
 
 
-gchar **
+GStrv
 modulemd_profile_get_rpms_as_strv (ModulemdProfile *self)
 {
   g_return_val_if_fail (MODULEMD_IS_PROFILE (self), NULL);

--- a/modulemd/v2/modulemd-subdocument-info.c
+++ b/modulemd/v2/modulemd-subdocument-info.c
@@ -26,7 +26,7 @@ struct _ModulemdSubdocumentInfo
 {
   GObject parent_instance;
 
-  enum ModulemdYamlDocumentType doctype;
+  ModulemdYamlDocumentTypeEnum doctype;
   guint64 mdversion;
   GError *error;
   gchar *contents;
@@ -127,7 +127,7 @@ modulemd_subdocument_info_get_gerror (ModulemdSubdocumentInfo *self)
 
 void
 modulemd_subdocument_info_set_doctype (ModulemdSubdocumentInfo *self,
-                                       enum ModulemdYamlDocumentType doctype)
+                                       ModulemdYamlDocumentTypeEnum doctype)
 {
   g_return_if_fail (MODULEMD_IS_SUBDOCUMENT_INFO (self));
 
@@ -135,7 +135,7 @@ modulemd_subdocument_info_set_doctype (ModulemdSubdocumentInfo *self,
 }
 
 
-enum ModulemdYamlDocumentType
+ModulemdYamlDocumentTypeEnum
 modulemd_subdocument_info_get_doctype (ModulemdSubdocumentInfo *self)
 {
   g_return_val_if_fail (MODULEMD_IS_SUBDOCUMENT_INFO (self),

--- a/modulemd/v2/modulemd-translation-entry.c
+++ b/modulemd/v2/modulemd-translation-entry.c
@@ -170,7 +170,7 @@ modulemd_translation_entry_get_locale (ModulemdTranslationEntry *self)
 }
 
 
-gchar **
+GStrv
 modulemd_translation_entry_get_profiles_as_strv (
   ModulemdTranslationEntry *self)
 {

--- a/modulemd/v2/modulemd-util.c
+++ b/modulemd/v2/modulemd-util.c
@@ -249,14 +249,14 @@ modulemd_ordered_str_keys (GHashTable *htable, GCompareFunc compare_func)
   return keys;
 }
 
-gchar **
+GStrv
 modulemd_ordered_str_keys_as_strv (GHashTable *htable)
 {
   GPtrArray *keys = modulemd_ordered_str_keys (htable, modulemd_strcmp_sort);
   // Add the NULL sentinel
   g_ptr_array_add (keys, NULL);
   // Store the pdata for returning after we free the container
-  gchar **result = (gchar **)keys->pdata;
+  GStrv result = (GStrv)keys->pdata;
   g_ptr_array_free (keys, FALSE);
   return result;
 }

--- a/modulemd/v2/modulemd-yaml-util.c
+++ b/modulemd/v2/modulemd-yaml-util.c
@@ -625,7 +625,7 @@ modulemd_yaml_parse_string_string_map (yaml_parser_t *parser, GError **error)
 static gboolean
 modulemd_yaml_parse_document_type_internal (
   yaml_parser_t *parser,
-  enum ModulemdYamlDocumentType *_doctype,
+  ModulemdYamlDocumentTypeEnum *_doctype,
   guint64 *_mdversion,
   yaml_emitter_t *emitter,
   GError **error)
@@ -634,7 +634,7 @@ modulemd_yaml_parse_document_type_internal (
   MMD_INIT_YAML_EVENT (event);
   gboolean done = FALSE;
   gboolean had_data = FALSE;
-  enum ModulemdYamlDocumentType doctype = MODULEMD_YAML_DOC_UNKNOWN;
+  ModulemdYamlDocumentTypeEnum doctype = MODULEMD_YAML_DOC_UNKNOWN;
   guint64 mdversion = 0;
   g_autofree gchar *doctype_scalar = NULL;
   g_autofree gchar *mdversion_string = NULL;
@@ -834,7 +834,7 @@ modulemd_yaml_parse_document_type (yaml_parser_t *parser)
   MMD_INIT_YAML_EMITTER (emitter);
   MMD_INIT_YAML_STRING (&emitter, yaml_string);
   g_autoptr (ModulemdSubdocumentInfo) s = modulemd_subdocument_info_new ();
-  enum ModulemdYamlDocumentType doctype = MODULEMD_YAML_DOC_UNKNOWN;
+  ModulemdYamlDocumentTypeEnum doctype = MODULEMD_YAML_DOC_UNKNOWN;
   guint64 mdversion = 0;
   g_autoptr (GError) error = NULL;
 
@@ -853,7 +853,7 @@ modulemd_yaml_parse_document_type (yaml_parser_t *parser)
 
 
 static const gchar *
-modulemd_yaml_get_doctype_string (enum ModulemdYamlDocumentType doctype)
+modulemd_yaml_get_doctype_string (ModulemdYamlDocumentTypeEnum doctype)
 {
   switch (doctype)
     {
@@ -870,7 +870,7 @@ modulemd_yaml_get_doctype_string (enum ModulemdYamlDocumentType doctype)
 
 gboolean
 modulemd_yaml_emit_document_headers (yaml_emitter_t *emitter,
-                                     enum ModulemdYamlDocumentType doctype,
+                                     ModulemdYamlDocumentTypeEnum doctype,
                                      guint64 mdversion,
                                      GError **error)
 {


### PR DESCRIPTION
- Private enum ModulemdYamlDocumentType changed to typedef ModulemdYamlDocumentTypeEnum, and descriptions added for enum constants.
- Private enum ModulemdYamlError changed to typedef ModulemdYamlErrorEnum, and descriptions added for enum constants.
- Several methods returning type gchar ** were changed to return GStrv, and type links were added to docs.

Note: The enum changes are not part of the public API, so there is no ABI breakage. The `GStrv` update does change a few public methods, but `gstrfuncs.h` defines `typedef gchar** GStrv` so the types are exactly equivalent.