### PR TITLE
Retrieve Modulemd documents from Koji

### DIFF
--- a/.travis/archlinux/Dockerfile.deps.tmpl
+++ b/.travis/archlinux/Dockerfile.deps.tmpl
@@ -13,6 +13,5 @@ RUN pacman -Syu --needed --noconfirm \
 	libyaml \
 	meson \
 	python-gobject \
-	python-babel \
 	python2-six \
 && pacman -Scc --noconfirm

--- a/.travis/fedora/Dockerfile.deps.tmpl
+++ b/.travis/fedora/Dockerfile.deps.tmpl
@@ -26,15 +26,17 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	popt-devel \
 	python2-devel \
 	python2-six \
-	python2-gobject-base \
 	python2-babel \
+	python2-gobject-base \
 	python3-autopep8 \
 	python3-devel \
+	python3-koji \
 	python3-GitPython \
 	python3-gobject-base \
 	python3-pycodestyle \
 	python3-rpm-macros \
 	python3-babel \
+	python3-requests \
 	redhat-rpm-config \
 	rpm-build \
 	rpmdevtools \

--- a/.travis/mageia/Dockerfile.deps.tmpl
+++ b/.travis/mageia/Dockerfile.deps.tmpl
@@ -23,7 +23,6 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	openssl \
 	pkgconf \
 	popt-devel \
-	python-babel \
 	python2-six \
 	python3-autopep8 \
 	python3-devel \
@@ -31,7 +30,6 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	python3-gobject3 \
 	python3-pycodestyle \
 	python3-rpm-macros \
-	python3-babel \
 	rpm-mageia-setup-build \
 	rpm-build \
 	rpmdevtools \

--- a/.travis/opensuse/Dockerfile.deps.tmpl
+++ b/.travis/opensuse/Dockerfile.deps.tmpl
@@ -25,13 +25,11 @@ RUN zypper install --no-confirm --no-recommends \
 	python-devel \
 	python-gobject \
 	python2-six \
-	python2-Babel \
 	python3-autopep8 \
 	python3-devel \
 	python3-GitPython \
 	python3-gobject \
 	python3-pycodestyle \
-	python3-Babel \
 	python-rpm-macros \
 	rpm-build \
 	rpmdevtools \

--- a/builds.yaml
+++ b/builds.yaml
@@ -1,0 +1,211 @@
+---
+document: modulemd
+version: 2
+data:
+  name: ant
+  stream: 1.10
+  version: 20180629154141
+  context: 819b5873
+  arch: x86_64
+  summary: Java build tool
+  description: >-
+    Apache Ant is a Java library and command-line tool whose mission is to drive processes
+    described in build files as targets and extension points dependent upon each other.
+    The main known usage of Ant is the build of Java applications. Ant supplies a
+    number of built-in tasks allowing to compile, assemble, test and run Java applications.
+    Ant can also be used effectively to build non Java applications, for instance
+    C or C++ applications. More generally, Ant can be used to pilot any type of process
+    which can be described in terms of targets and tasks.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/ant.git?#efb686945a977ec8322eca2401e96e8da0f4e3f2
+      commit: efb686945a977ec8322eca2401e96e8da0f4e3f2
+      buildrequires:
+        javapackages-tools:
+          ref: 1e429a4d686d3fdd1d93ce7e8ac7254148ea3471
+          stream: 201801
+          context: b43b0c8f
+          version: 20180629150827
+          filtered_rpms: []
+        platform:
+          ref: virtual
+          stream: f28
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        ant:
+          ref: 1b60ebd3ac34e2c4648c4a5377c9e51fc44d658c
+  dependencies:
+  - requires:
+      platform: []
+  profiles:
+    default:
+      rpms:
+      - ant
+  api:
+    rpms:
+    - ant
+  filter:
+    rpms:
+    - ant-antlr
+    - ant-apache-bcel
+    - ant-apache-bsf
+    - ant-apache-log4j
+    - ant-apache-oro
+    - ant-apache-regexp
+    - ant-apache-resolver
+    - ant-apache-xalan2
+    - ant-commons-logging
+    - ant-commons-net
+    - ant-javadoc
+    - ant-javamail
+    - ant-jdepend
+    - ant-jmf
+    - ant-jsch
+    - ant-junit
+    - ant-manual
+    - ant-swing
+    - ant-testutil
+    - ant-xz
+  buildopts:
+    rpms:
+      macros: |
+        %_with_xmvn_javadoc 1
+        %_without_asciidoc 1
+        %_without_avalon 1
+        %_without_bouncycastle 1
+        %_without_cython 1
+        %_without_dafsa 1
+        %_without_desktop 1
+        %_without_doxygen 1
+        %_without_dtd 1
+        %_without_eclipse 1
+        %_without_ehcache 1
+        %_without_emacs 1
+        %_without_equinox 1
+        %_without_fop 1
+        %_without_ftp 1
+        %_without_gradle 1
+        %_without_groovy 1
+        %_without_hadoop 1
+        %_without_hsqldb 1
+        %_without_itext 1
+        %_without_jackson 1
+        %_without_jmh 1
+        %_without_jna 1
+        %_without_jpa 1
+        %_without_junit5 1
+        %_without_logback 1
+        %_without_markdown 1
+        %_without_memcached 1
+        %_without_memoryfilesystem 1
+        %_without_obr 1
+        %_without_python 1
+        %_without_reporting 1
+        %_without_scm 1
+        %_without_snappy 1
+        %_without_spring 1
+        %_without_ssh 1
+        %_without_testlib 1
+  components:
+    rpms:
+      ant:
+        rationale: 'Module API.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/ant
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/ant
+        ref: javapackages
+        buildorder: 10
+  artifacts:
+    rpms:
+    - ant-0:1.10.4-1.module_1886+ece9a977.noarch
+    - ant-lib-0:1.10.4-1.module_1886+ece9a977.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: avocado
+  stream: stable
+  version: 20180816135414
+  context: 6c81f848
+  arch: x86_64
+  summary: Framework with tools and libraries for Automated Testing
+  description: >-
+    Avocado is a set of tools and libraries (what people call these days a framework)
+    to perform automated testing.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2
+    - GPLv2 and MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/avocado.git?#10208a3095f9522485b933dbab830e3338af95e6
+      commit: 10208a3095f9522485b933dbab830e3338af95e6
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        python-avocado:
+          ref: 87dc683a36d0862340d3af99b78fa189a1aba424
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: http://avocado-framework.github.io/
+    documentation: http://avocado-framework.readthedocs.io/
+    tracker: https://github.com/avocado-framework/avocado/issues
+  profiles:
+    default:
+      rpms:
+      - python2-avocado
+      - python2-avocado-plugins-output-html
+      - python2-avocado-plugins-varianter-yaml-to-mux
+    minimal:
+      rpms:
+      - python2-avocado
+  api:
+    rpms:
+    - python-avocado-examples
+    - python2-avocado
+    - python2-avocado-plugins-output-html
+    - python2-avocado-plugins-resultsdb
+    - python2-avocado-plugins-runner-docker
+    - python2-avocado-plugins-runner-remote
+    - python2-avocado-plugins-runner-vm
+    - python2-avocado-plugins-varianter-yaml-to-mux
+  components:
+    rpms:
+      python-avocado:
+        rationale: Framework with tools and libraries for Automated Testing
+        repository: git://pkgs.fedoraproject.org/rpms/python-avocado
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-avocado
+        ref: master
+  artifacts:
+    rpms:
+    - python-avocado-examples-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-output-html-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-resultsdb-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-docker-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-remote-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-vm-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-varianter-yaml-to-mux-0:52.1-7.module_1939+1f9e88da.noarch
+...

--- a/f29_build_1.yaml
+++ b/f29_build_1.yaml
@@ -1,0 +1,130 @@
+document: modulemd
+version: 2
+data:
+  name: ant
+  stream: 1.10
+  version: 20180629154141
+  context: 819b5873
+  arch: x86_64
+  summary: Java build tool
+  description: >-
+    Apache Ant is a Java library and command-line tool whose mission is to drive processes
+    described in build files as targets and extension points dependent upon each other.
+    The main known usage of Ant is the build of Java applications. Ant supplies a
+    number of built-in tasks allowing to compile, assemble, test and run Java applications.
+    Ant can also be used effectively to build non Java applications, for instance
+    C or C++ applications. More generally, Ant can be used to pilot any type of process
+    which can be described in terms of targets and tasks.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/ant.git?#efb686945a977ec8322eca2401e96e8da0f4e3f2
+      commit: efb686945a977ec8322eca2401e96e8da0f4e3f2
+      buildrequires:
+        javapackages-tools:
+          ref: 1e429a4d686d3fdd1d93ce7e8ac7254148ea3471
+          stream: 201801
+          context: b43b0c8f
+          version: 20180629150827
+          filtered_rpms: []
+        platform:
+          ref: virtual
+          stream: f28
+          context: 00000000
+          version: 4
+          filtered_rpms: []
+      rpms:
+        ant:
+          ref: 1b60ebd3ac34e2c4648c4a5377c9e51fc44d658c
+  dependencies:
+  - requires:
+      platform: []
+  profiles:
+    default:
+      rpms:
+      - ant
+  api:
+    rpms:
+    - ant
+  filter:
+    rpms:
+    - ant-antlr
+    - ant-apache-bcel
+    - ant-apache-bsf
+    - ant-apache-log4j
+    - ant-apache-oro
+    - ant-apache-regexp
+    - ant-apache-resolver
+    - ant-apache-xalan2
+    - ant-commons-logging
+    - ant-commons-net
+    - ant-javadoc
+    - ant-javamail
+    - ant-jdepend
+    - ant-jmf
+    - ant-jsch
+    - ant-junit
+    - ant-manual
+    - ant-swing
+    - ant-testutil
+    - ant-xz
+  buildopts:
+    rpms:
+      macros: |
+        %_with_xmvn_javadoc 1
+        %_without_asciidoc 1
+        %_without_avalon 1
+        %_without_bouncycastle 1
+        %_without_cython 1
+        %_without_dafsa 1
+        %_without_desktop 1
+        %_without_doxygen 1
+        %_without_dtd 1
+        %_without_eclipse 1
+        %_without_ehcache 1
+        %_without_emacs 1
+        %_without_equinox 1
+        %_without_fop 1
+        %_without_ftp 1
+        %_without_gradle 1
+        %_without_groovy 1
+        %_without_hadoop 1
+        %_without_hsqldb 1
+        %_without_itext 1
+        %_without_jackson 1
+        %_without_jmh 1
+        %_without_jna 1
+        %_without_jpa 1
+        %_without_junit5 1
+        %_without_logback 1
+        %_without_markdown 1
+        %_without_memcached 1
+        %_without_memoryfilesystem 1
+        %_without_obr 1
+        %_without_python 1
+        %_without_reporting 1
+        %_without_scm 1
+        %_without_snappy 1
+        %_without_spring 1
+        %_without_ssh 1
+        %_without_testlib 1
+  components:
+    rpms:
+      ant:
+        rationale: 'Module API.
+
+'
+        repository: git://pkgs.fedoraproject.org/rpms/ant
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/ant
+        ref: javapackages
+        buildorder: 10
+  artifacts:
+    rpms:
+    - ant-0:1.10.4-1.module_1886+ece9a977.noarch
+    - ant-lib-0:1.10.4-1.module_1886+ece9a977.noarch
+    

--- a/f29_build_2.yaml
+++ b/f29_build_2.yaml
@@ -1,0 +1,78 @@
+document: modulemd
+version: 2
+data:
+  name: avocado
+  stream: stable
+  version: 20180816135414
+  context: 6c81f848
+  arch: x86_64
+  summary: Framework with tools and libraries for Automated Testing
+  description: >-
+    Avocado is a set of tools and libraries (what people call these days a framework)
+    to perform automated testing.
+  license:
+    module:
+    - MIT
+    content:
+    - GPLv2
+    - GPLv2 and MIT
+  xmd:
+    mbs:
+      mse: TRUE
+      scmurl: https://src.fedoraproject.org/modules/avocado.git?#10208a3095f9522485b933dbab830e3338af95e6
+      commit: 10208a3095f9522485b933dbab830e3338af95e6
+      buildrequires:
+        platform:
+          ref: f29
+          stream: f29
+          context: 00000000
+          version: 5
+          filtered_rpms: []
+      rpms:
+        python-avocado:
+          ref: 87dc683a36d0862340d3af99b78fa189a1aba424
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: http://avocado-framework.github.io/
+    documentation: http://avocado-framework.readthedocs.io/
+    tracker: https://github.com/avocado-framework/avocado/issues
+  profiles:
+    default:
+      rpms:
+      - python2-avocado
+      - python2-avocado-plugins-output-html
+      - python2-avocado-plugins-varianter-yaml-to-mux
+    minimal:
+      rpms:
+      - python2-avocado
+  api:
+    rpms:
+    - python-avocado-examples
+    - python2-avocado
+    - python2-avocado-plugins-output-html
+    - python2-avocado-plugins-resultsdb
+    - python2-avocado-plugins-runner-docker
+    - python2-avocado-plugins-runner-remote
+    - python2-avocado-plugins-runner-vm
+    - python2-avocado-plugins-varianter-yaml-to-mux
+  components:
+    rpms:
+      python-avocado:
+        rationale: Framework with tools and libraries for Automated Testing
+        repository: git://pkgs.fedoraproject.org/rpms/python-avocado
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-avocado
+        ref: master
+  artifacts:
+    rpms:
+    - python-avocado-examples-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-output-html-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-resultsdb-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-docker-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-remote-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-runner-vm-0:52.1-7.module_1939+1f9e88da.noarch
+    - python2-avocado-plugins-varianter-yaml-to-mux-0:52.1-7.module_1939+1f9e88da.noarch

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -374,22 +374,6 @@ get_babel = '''
 import babel
 '''
 
-# Python 2
-if (get_option('with_py2_overrides') and not test_installed_lib)
-  ret2 = run_command([python2, '-c', get_babel])
-
-  if ret2.returncode() != 0
-    warning('No Babel on Python 2: skipping TranslationHelper tests')
-  else
-    test ('translation_helpers_python2_debug', python2,
-          env : py_test_env,
-          args : translation_helpers_python_script)
-    test ('translation_helpers_python2_release', python2,
-          env : py_test_release_env,
-          args : translation_helpers_python_script)
-  endif
-endif
-
 # Python 3
 if (get_option('with_py3_overrides') and not test_installed_lib)
   ret2 = run_command([python3, '-c', get_babel])

--- a/modulemd/tests/ModulemdTests/translation_helpers.py
+++ b/modulemd/tests/ModulemdTests/translation_helpers.py
@@ -14,12 +14,13 @@
 
 import os
 import sys
+import unittest
 from ModulemdTranslationHelpers import Utils
 from babel.messages import pofile
 from six import text_type
+from unittest import mock
 
 try:
-    import unittest
     import gi
     gi.require_version('Modulemd', '2.0')
     from gi.repository import Modulemd
@@ -29,6 +30,61 @@ except ImportError:
     sys.exit(77)
 
 from base import TestBase
+
+
+class KojiSessionMock:
+
+    def __init__(self):
+        with open("%s/f29_build_1.yaml" % (os.getenv('MESON_SOURCE_ROOT')), 'r') as file:
+            self.build_1_yaml = file.read()
+
+        with open("%s/f29_build_2.yaml" % (os.getenv('MESON_SOURCE_ROOT')), 'r') as file:
+            self.build_2_yaml = file.read()
+
+    def listTagged(self, tag):
+        tagged_builds = [{
+            'id': 1,
+            'name': 'foo',
+            'version': 'master',
+            'release': '10.1'
+        },
+            {
+            'id': 2,
+            'name': 'bar',
+            'version': 'master',
+            'release': '2.1'
+        }]
+        return tagged_builds
+
+    def getBuild(self, build_id):
+        build = [{
+            'id': 1,
+            'package_name': 'marvel',
+            'nvr': 'black',
+            'extra': {
+                'typeinfo': {
+                    'module': {
+                        'modulemd_str': self.build_1_yaml
+                    }
+                }
+            }
+        },
+            {
+            'id': 2,
+            'package_name': 'marvel',
+            'nvr': 'black',
+            'extra': {
+                'typeinfo': {
+                    'module': {
+                        'modulemd_str': self.build_2_yaml
+                    }
+                }
+            }
+        }]
+
+        if build_id == 1:
+            return build[0]
+        return build[1]
 
 
 class TestTranslationHelpers(TestBase):
@@ -141,6 +197,49 @@ class TestTranslationHelpers(TestBase):
                             self.assertEqual(
                                 profile.get_description(
                                     str(catalog.locale)), msg_string)
+
+    @mock.patch('koji.ClientSession')
+    def test_index_from_tags(self, mock_session):
+        koji_session_mock = KojiSessionMock()
+        tags = ['f29']
+
+        # Create a Modulemd.ModuleIndex object containing the YAML stream
+        idx = Modulemd.ModuleIndex.new()
+        self.assertIsNotNone(idx)
+        ret, failures = idx.update_from_file(
+            "%s/builds.yaml" %
+            (os.getenv('MESON_SOURCE_ROOT')), True)
+        self.assertTrue(ret)
+        self.assertTrue(len(failures) == 0)
+
+        # Test when koji returns no modules
+        mock_session.listTagged.return_value = []
+        mock_session.getBuild.return_value = None
+
+        index = Utils.get_index_from_tags(mock_session, tags)
+        self.assertIsNotNone(index)
+        mock_session.listTagged.assert_called_once_with('f29')
+        self.assertListEqual(index.get_module_names(), [])
+        mock_session.reset_mock()
+
+        # Test when koji returns proper modules
+        mock_session.listTagged.side_effect = koji_session_mock.listTagged
+        mock_session.getBuild.side_effect = koji_session_mock.getBuild
+
+        index = Utils.get_index_from_tags(mock_session, tags)
+        self.assertIsNotNone(index)
+        mock_session.listTagged.assert_called_once_with('f29')
+        mock_session.getBuild.assert_called_with(2)
+        self.assertEqual(idx.dump_to_string(), index.dump_to_string())
+        self.assertListEqual(index.get_module_names(), ['ant', 'avocado'])
+        module = index.get_module('ant')
+        self.assertIsNotNone(module)
+        stream = module.get_stream_by_NSVCA(
+            "1.10", 20180629154141, "819b5873")
+        self.assertIsNotNone(stream)
+        self.assertEqual(stream.get_nsvc(),
+                         "ant:1.10:20180629154141:819b5873")
+        self.assertEqual(stream.get_summary(None), "Java build tool")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Continuing #335 here. 

List of tasks taken care of in this PR:

1. Get Koji tags.
2. Query Koji using these tags and get tagged builds from Koji.
3. Retrieve YAML documents from each build.
4. Create a ModulemdIndex object from each YAML document.