### PR TITLE
Emitter: Throw validation error for empty ModuleIndex

### DIFF
--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -423,6 +423,15 @@ modulemd_module_index_dump_to_emitter (ModulemdModuleIndex *self,
   g_autoptr (GPtrArray) modules =
     modulemd_ordered_str_keys (self->modules, modulemd_strcmp_sort);
 
+  if (modules->len == 0)
+    {
+      g_set_error_literal (error,
+                           MODULEMD_ERROR,
+                           MODULEMD_ERROR_VALIDATE,
+                           "Index contains no modules.");
+      return FALSE;
+    }
+
   if (!mmd_emitter_start_stream (emitter, error))
     return FALSE;
 

--- a/modulemd/tests/ModulemdTests/moduleindex.py
+++ b/modulemd/tests/ModulemdTests/moduleindex.py
@@ -115,6 +115,13 @@ profiles:
 
         self.assertNotIn("nodejs", default_streams.keys())
 
+    def test_dump_empty_index(self):
+        idx = Modulemd.ModuleIndex.new()
+
+        with self.assertRaisesRegexp(gi.repository.GLib.GError, "Index contains no modules."):
+            yaml = idx.dump_to_string()
+            self.assertIsNone(yaml)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -1002,6 +1002,22 @@ module_index_test_get_default_streams (void)
 }
 
 
+static void
+module_index_test_dump_empty_index (void)
+{
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *yaml = NULL;
+  g_autoptr (ModulemdModuleIndex) index = modulemd_module_index_new ();
+
+  g_assert_nonnull (index);
+  g_assert_true (MODULEMD_IS_MODULE_INDEX (index));
+
+  yaml = modulemd_module_index_dump_to_string (index, &error);
+  g_assert_null (yaml);
+  g_assert_error (error, MODULEMD_ERROR, MODULEMD_ERROR_VALIDATE);
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -1077,6 +1093,9 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/modulemd/v2/module/index/get_default_streams",
                    module_index_test_get_default_streams);
+
+  g_test_add_func ("/modulemd/v2/module/index/empty",
+                   module_index_test_dump_empty_index);
 
   return g_test_run ();
 }


### PR DESCRIPTION
Attempting to emit an empty `ModuleIndex` (one containing no modules) currently returns NULL for `dump_to_string()` or writes no data into `dump_to_file()` or `dump_to_custom()`. With this patch, it will return a `GError` indicating a validation error.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>