### PR TITLE
Synchronize the user docs in the main header file and the repo's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ with repodata (that is, streams of YAML that contains information on multiple
 streams, default data and translations). The documentation will use two
 repositories, called "fedora" and "updates" for demonstrative purposes. It
 will assume that the content of the YAML module metadata from those two
-repositories have been loaded into string variables `"fedora_yaml"` and
-`"updates_yaml"`, respectively.
+repositories have been loaded into string variables `fedora_yaml` and
+`updates_yaml`, respectively.
 
 First step is to load the metadata from these two repositories into
 ModulemdModuleIndex objects. This is done as follows:
@@ -91,8 +91,8 @@ At this point, you now have either a complete view of the merged repodata,
 or else have received an error describing why the merge was unable to
 complete successfully. Additionally, it should be noted that the combined
 metadata in any ModulemdModuleIndex will have all of its component parts
-upgraded to match the highest version of those objects seen. So for
-example if the repodata has a mix of v1 and v2 ModuleStream objects, the
+upgraded to match the highest version of those objects seen. So for example
+if the repodata has a mix of v1 and v2 ModulemdModuleStream objects, the
 index will contain only v2 objects (with the v1 objects automatically
 upgraded internally).
 
@@ -103,22 +103,22 @@ specification for a full list of information that can be retrieved.
 ## Discover the default stream for a particular module.
 ## C
 ```C
- ModulemdModule * module =  modulemd_module_index_get_module (merged_index, "modulename");
- ModulemdDefaults * defaults = modulemd_module_get_defaults (module);
- printf ("Default stream for modulename is %s\n",
-         modulemd_defaults_v1_get_default_stream (MODULEMD_DEFAULTS_V1 (defaults), NULL));
-  ```
+ModulemdModule * module =  modulemd_module_index_get_module (merged_index, "modulename");
+ModulemdDefaults * defaults = modulemd_module_get_defaults (module);
+printf ("Default stream for modulename is %s\n",
+        modulemd_defaults_v1_get_default_stream (MODULEMD_DEFAULTS_V1 (defaults), NULL));
+```
 
 ## Python
 ```python
- module = merged_index.get_module ('modulename')
- defaults = module.get_defaults()
- print ('Default stream for modulename is %s' % (
+module = merged_index.get_module ('modulename')
+defaults = module.get_defaults()
+print ('Default stream for modulename is %s' % (
        defaults.get_default_stream())
-  ```
+```
 
 ## Get the list of RPMs defining the public API for a particular module NSVCA
-First, query the Modulemd.ModuleIndex for the module with a given name.
+First, query the ModulemdModuleIndex for the module with a given name.
 ## C
 ```C
 ModulemdModule * module = modulemd_module_index_get_module (merged_index, "modulename");
@@ -129,19 +129,25 @@ ModulemdModule * module = modulemd_module_index_get_module (merged_index, "modul
  module = merged_index.get_module ('modulename')
 ```
 
-Then, query the Modulemd.Module for the Modulemd.ModuleStream associated with the provided NSVCA
-(name-stream-version-context-architechture identifier).
+Then, query the ModulemdModule for the ModulemdModuleStream associated with the
+provided NSVCA (name-stream-version-context-architecture identifier).
 ## C
 ```C
-ModulemdModuleStream * stream = modulemd_module_get_stream_by_NSVCA (module, "modulestream", 0, "deadbeef", "coolarch", &error);
+ModulemdModuleStream * stream = modulemd_module_get_stream_by_NSVCA (module,
+                                                                     "modulestream",
+                                                                     0,
+                                                                     "deadbeef",
+                                                                     "coolarch",
+                                                                     &error);
 ```
 
 ## Python
 ```python
- stream = module.get_stream_by_NSVCA('modulestream', 0, 'deadbeef', 'coolarch')
+stream = module.get_stream_by_NSVCA('modulestream', 0, 'deadbeef', 'coolarch')
 ```
 
-Lastly, read the RPM API from the Modulemd.ModuleStream. Here, `api_list` is a list of strings containing package names.
+Lastly, read the RPM API from the ModulemdModuleStream. Here, `api_list` is
+a list of strings containing package names.
 ## C
 ```C
 GStrv api_list = modulemd_module_stream_v2_get_rpm_api_as_strv (MODULEMD_MODULE_STREAM_V2 (stream));
@@ -149,7 +155,7 @@ GStrv api_list = modulemd_module_stream_v2_get_rpm_api_as_strv (MODULEMD_MODULE_
 
 ## Python
 ```python
- api_list = stream.get_rpm_api()
+api_list = stream.get_rpm_api()
 ```
 
 ## Retrieve the modular runtime dependencies for a particular module NSVCA
@@ -167,12 +173,12 @@ for (gint i = 0; i < deps_list->len; i++)
 
 ## Python
 ```python
- module = merged_index.get_module ('modulename')
- stream = module.get_stream_by_NSVCA('modulestream', 0, 'deadbeef', 'coolarch')
- deps_list = stream.get_dependencies()
- for dep in deps_list:
-    depstream_list = dep.get_runtime_streams('depstreamname')
-    <do_stuff>
+module = merged_index.get_module ('modulename')
+stream = module.get_stream_by_NSVCA('modulestream', 0, 'deadbeef', 'coolarch')
+deps_list = stream.get_dependencies()
+for dep in deps_list:
+   depstream_list = dep.get_runtime_streams('depstreamname')
+   <do_stuff>
 ```
 
 # Working with a single module stream (Packager/MBS use-case)
@@ -187,7 +193,7 @@ use the ModulemdModuleStream interface.
 
 This example will assume that the module name and stream name have
 already been determined from the repodata and that they are stored in
-string variables named 'module_name' and 'stream_name', respectively.
+string variables named `module_name` and `stream_name`, respectively.
 
 ## Python
 ```python
@@ -198,7 +204,15 @@ stream = Modulemd.ModuleStream.read_file ('/path/to/module_name.yaml',
 v2_stream = stream.upgrade(Modulemd.ModuleStreamVersionEnum.TWO)
 v2_stream.validate()
 ```
-In the example above, we upgraded the stream to v2, in case we were reading from v1 metadata. This will allow us to avoid having to manage multiple code-paths and support only the latest we understand. After that, it calls validate() to ensure that the content that was read in was valid both syntactically and referentially.
+In the example above, we upgraded the stream to v2, in case we were reading
+from v1 metadata. This will allow us to avoid having to manage multiple
+code-paths and support only the latest we understand. After that, it calls
+validate() to ensure that the content that was read in was valid both
+syntactically and referentially.
+
+Also available is `Modulemd.ModuleStreamVersionEnum.LATEST` which will
+always represent the highest-supported version of the
+ModulemdModuleStream metadata format. This may change at any time.
 
 # Getting started with developing
 ## Prerequisites


### PR DESCRIPTION
The libmodulemd user guide in `modulemd/include/modulemd-2.0/modulemd.h` hasn't kept up with the content of the repository's front page `README.md`. This PR takes care of a few minor clean-ups to the README and then incorporates that into the gtk-doc section of `modulemd.h`.