### PR TITLE
Silence several "may be used uninitialized" compiler warnings

### DIFF
--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -140,7 +140,7 @@ int
 main (int argc, char *argv[])
 {
   const char *filename;
-  g_autoptr (GOptionContext) context;
+  g_autoptr (GOptionContext) context = NULL;
   g_autoptr (GError) error = NULL;
   gsize num_invalid = 0;
   gboolean ret;

--- a/modulemd/tests/test-modulemd-buildopts.c
+++ b/modulemd/tests/test-modulemd-buildopts.c
@@ -30,7 +30,7 @@ static void
 buildopts_test_construct (BuildoptsFixture *fixture, gconstpointer user_data)
 {
   g_autoptr (ModulemdBuildopts) b = NULL;
-  g_auto (GStrv) whitelist;
+  g_auto (GStrv) whitelist = NULL;
 
   /* Test that the new() function works */
   b = modulemd_buildopts_new ();
@@ -165,7 +165,7 @@ buildopts_test_copy (BuildoptsFixture *fixture, gconstpointer user_data)
 {
   g_autoptr (ModulemdBuildopts) b = NULL;
   g_autoptr (ModulemdBuildopts) b_copy = NULL;
-  g_auto (GStrv) whitelist;
+  g_auto (GStrv) whitelist = NULL;
 
   b = modulemd_buildopts_new ();
   g_assert_nonnull (b);
@@ -269,7 +269,7 @@ static void
 buildopts_test_whitelist (BuildoptsFixture *fixture, gconstpointer user_data)
 {
   g_autoptr (ModulemdBuildopts) b = NULL;
-  g_auto (GStrv) whitelist;
+  g_auto (GStrv) whitelist = NULL;
 
   b = modulemd_buildopts_new ();
   g_assert_nonnull (b);

--- a/modulemd/tests/test-modulemd-dependencies.c
+++ b/modulemd/tests/test-modulemd-dependencies.c
@@ -40,7 +40,7 @@ dependencies_test_construct (DependenciesFixture *fixture,
                              gconstpointer user_data)
 {
   g_autoptr (ModulemdDependencies) d = NULL;
-  g_auto (GStrv) list;
+  g_auto (GStrv) list = NULL;
 
   /* Test that the new() function works */
   d = modulemd_dependencies_new ();
@@ -65,7 +65,7 @@ dependencies_test_dependencies (DependenciesFixture *fixture,
                                 gconstpointer user_data)
 {
   g_autoptr (ModulemdDependencies) d = NULL;
-  g_auto (GStrv) list;
+  g_auto (GStrv) list = NULL;
 
   d = modulemd_dependencies_new ();
   g_assert_nonnull (d);
@@ -305,7 +305,7 @@ dependencies_test_copy (DependenciesFixture *fixture, gconstpointer user_data)
 {
   g_autoptr (ModulemdDependencies) d = NULL;
   g_autoptr (ModulemdDependencies) d_copy = NULL;
-  g_auto (GStrv) list;
+  g_auto (GStrv) list = NULL;
 
   d = modulemd_dependencies_new ();
   g_assert_nonnull (d);

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -816,7 +816,7 @@ static void
 module_stream_v1_test_dependencies (ModuleStreamFixture *fixture,
                                     gconstpointer user_data)
 {
-  g_auto (GStrv) list;
+  g_auto (GStrv) list = NULL;
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
   stream = modulemd_module_stream_v1_new (NULL, NULL);
   modulemd_module_stream_v1_add_buildtime_requirement (
@@ -848,7 +848,7 @@ static void
 module_stream_v2_test_dependencies (ModuleStreamFixture *fixture,
                                     gconstpointer user_data)
 {
-  g_auto (GStrv) list;
+  g_auto (GStrv) list = NULL;
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   g_autoptr (ModulemdDependencies) dep = NULL;
   stream = modulemd_module_stream_v2_new (NULL, NULL);

--- a/modulemd/tests/test-modulemd-profile.c
+++ b/modulemd/tests/test-modulemd-profile.c
@@ -230,7 +230,7 @@ profile_test_copy (ProfileFixture *fixture, gconstpointer user_data)
 {
   g_autoptr (ModulemdProfile) p = NULL;
   g_autoptr (ModulemdProfile) p_copy = NULL;
-  g_auto (GStrv) rpms;
+  g_auto (GStrv) rpms = NULL;
 
   p = modulemd_profile_new ("testprofile");
   g_assert_nonnull (p);
@@ -356,7 +356,7 @@ static void
 profile_test_rpms (ProfileFixture *fixture, gconstpointer user_data)
 {
   g_autoptr (ModulemdProfile) p = NULL;
-  g_auto (GStrv) rpms;
+  g_auto (GStrv) rpms = NULL;
 
   p = modulemd_profile_new ("testprofile");
   g_assert_nonnull (p);

--- a/modulemd/tests/test-modulemd-translation.c
+++ b/modulemd/tests/test-modulemd-translation.c
@@ -232,7 +232,7 @@ translation_test_translations (TranslationFixture *fixture,
 {
   g_autoptr (ModulemdTranslation) t = NULL;
   ModulemdTranslationEntry *te = NULL;
-  g_auto (GStrv) locales;
+  g_auto (GStrv) locales = NULL;
 
   t = modulemd_translation_new (1, "testmodule", "teststream", 5);
   te = modulemd_translation_entry_new ("en_US");


### PR DESCRIPTION
This PR (hopefully) silences a dozen compiler warnings about the possible use of uninitialized variables that currently appear in the Fedora CI build output logs--to improve the signal to noise ratio in the logs. The warnings are all similar to:

```
In file included from /usr/lib64/glib-2.0/include/glibconfig.h:9,
                 from /usr/include/glib-2.0/glib/gtypes.h:32,
                 from /usr/include/glib-2.0/glib/galloca.h:32,
                 from /usr/include/glib-2.0/glib.h:30,
                 from /usr/include/glib-2.0/gobject/gbinding.h:28,
                 from /usr/include/glib-2.0/glib-object.h:23,
                 from ../modulemd/include/modulemd-2.0/modulemd-buildopts.h:16,
                 from ../modulemd/include/modulemd-2.0/modulemd.h:16,
                 from ../modulemd/modulemd-validator.c:15:
../modulemd/modulemd-validator.c: In function 'main':
/usr/include/glib-2.0/glib/gmacros.h:523:17: warning: 'context' may be used uninitialized in this function [-Wmaybe-uninitialized]
  523 |     { if (_ptr) (cleanup) ((ParentName *) _ptr); }                                                              \
      |                 ^
../modulemd/modulemd-validator.c:143:30: note: 'context' was declared here
  143 |   g_autoptr (GOptionContext) context;
      |                              ^~~~~~~
```