### PR TITLE
Emit empty dependencies

### DIFF
--- a/modulemd/modulemd-dependencies.c
+++ b/modulemd/modulemd-dependencies.c
@@ -589,12 +589,6 @@ modulemd_dependencies_emit_yaml (ModulemdDependencies *self,
   int ret;
   g_autoptr (GError) nested_error = NULL;
   MMD_INIT_YAML_EVENT (event);
-  if ((g_hash_table_size (self->runtime_deps) == 0) &&
-      g_hash_table_size (self->buildtime_deps) == 0)
-    {
-      // Nothing to emit...
-      return TRUE;
-    }
 
   ret = mmd_emitter_start_mapping (
     emitter, YAML_BLOCK_MAPPING_STYLE, &nested_error);

--- a/modulemd/tests/test-modulemd-dependencies.c
+++ b/modulemd/tests/test-modulemd-dependencies.c
@@ -522,6 +522,70 @@ dependencies_test_emit_yaml (DependenciesFixture *fixture,
                    "    rundef: []\n"
                    "    runmod1: [stream3, stream4]\n"
                    "...\n");
+
+
+  /* Test with only adding a buildrequires */
+
+  g_clear_pointer (&yaml_string, modulemd_yaml_string_free);
+  yaml_emitter_delete (&emitter);
+  yaml_emitter_initialize (&emitter);
+  yaml_string = g_malloc0_n (1, sizeof (modulemd_yaml_string));
+  yaml_emitter_set_output (&emitter, write_yaml_string, (void *)yaml_string);
+
+  g_clear_object (&d);
+  d = modulemd_dependencies_new ();
+  modulemd_dependencies_add_buildtime_stream (d, "buildmod1", "stream2");
+  modulemd_dependencies_add_buildtime_stream (d, "buildmod1", "stream1");
+  modulemd_dependencies_set_empty_buildtime_dependencies_for_module (
+    d, "builddef");
+
+  g_assert_true (mmd_emitter_start_stream (&emitter, &error));
+  g_assert_true (mmd_emitter_start_document (&emitter, &error));
+  g_assert_true (
+    mmd_emitter_start_sequence (&emitter, YAML_BLOCK_SEQUENCE_STYLE, &error));
+  g_assert_true (modulemd_dependencies_emit_yaml (d, &emitter, &error));
+  g_assert_true (mmd_emitter_end_sequence (&emitter, &error));
+  g_assert_true (mmd_emitter_end_document (&emitter, &error));
+  g_assert_true (mmd_emitter_end_stream (&emitter, &error));
+  g_assert_cmpstr (yaml_string->str,
+                   ==,
+                   "---\n"
+                   "- buildrequires:\n"
+                   "    builddef: []\n"
+                   "    buildmod1: [stream1, stream2]\n"
+                   "...\n");
+
+  /* Test with only adding a runtime requires */
+
+  g_clear_pointer (&yaml_string, modulemd_yaml_string_free);
+  yaml_emitter_delete (&emitter);
+  yaml_emitter_initialize (&emitter);
+  yaml_string = g_malloc0_n (1, sizeof (modulemd_yaml_string));
+  yaml_emitter_set_output (&emitter, write_yaml_string, (void *)yaml_string);
+
+  g_clear_object (&d);
+  d = modulemd_dependencies_new ();
+
+  modulemd_dependencies_add_runtime_stream (d, "runmod1", "stream3");
+  modulemd_dependencies_add_runtime_stream (d, "runmod1", "stream4");
+  modulemd_dependencies_set_empty_runtime_dependencies_for_module (d,
+                                                                   "rundef");
+
+  g_assert_true (mmd_emitter_start_stream (&emitter, &error));
+  g_assert_true (mmd_emitter_start_document (&emitter, &error));
+  g_assert_true (
+    mmd_emitter_start_sequence (&emitter, YAML_BLOCK_SEQUENCE_STYLE, &error));
+  g_assert_true (modulemd_dependencies_emit_yaml (d, &emitter, &error));
+  g_assert_true (mmd_emitter_end_sequence (&emitter, &error));
+  g_assert_true (mmd_emitter_end_document (&emitter, &error));
+  g_assert_true (mmd_emitter_end_stream (&emitter, &error));
+  g_assert_cmpstr (yaml_string->str,
+                   ==,
+                   "---\n"
+                   "- requires:\n"
+                   "    rundef: []\n"
+                   "    runmod1: [stream3, stream4]\n"
+                   "...\n");
 }
 
 int

--- a/modulemd/tests/test-modulemd-dependencies.c
+++ b/modulemd/tests/test-modulemd-dependencies.c
@@ -488,7 +488,7 @@ dependencies_test_emit_yaml (DependenciesFixture *fixture,
   g_assert_true (mmd_emitter_end_sequence (&emitter, &error));
   g_assert_true (mmd_emitter_end_document (&emitter, &error));
   g_assert_true (mmd_emitter_end_stream (&emitter, &error));
-  g_assert_cmpstr (yaml_string->str, ==, "--- []\n...\n");
+  g_assert_cmpstr (yaml_string->str, ==, "---\n- {}\n...\n");
 
   g_clear_pointer (&yaml_string, modulemd_yaml_string_free);
   yaml_emitter_delete (&emitter);


### PR DESCRIPTION
If someone has explicitly added a Dependencies object to a stream that contains no runtime or build-time requirements, it should still be emitted in the output YAML explicitly.
    
Fixes https://github.com/fedora-modularity/libmodulemd/issues/340

A second patch also adds tests for having just one or the other of {build|runtime} requires in a Dependencies object.
    
Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>
