### PR TITLE
Component buildonly property fix

### DIFF
--- a/modulemd/modulemd-component.c
+++ b/modulemd/modulemd-component.c
@@ -415,7 +415,7 @@ modulemd_component_get_property (GObject *object,
   switch (prop_id)
     {
     case PROP_BUILDONLY:
-      g_value_set_boolean (value, modulemd_component_get_buildorder (self));
+      g_value_set_boolean (value, modulemd_component_get_buildonly (self));
       break;
 
     case PROP_BUILDORDER:
@@ -449,7 +449,7 @@ modulemd_component_set_property (GObject *object,
   switch (prop_id)
     {
     case PROP_BUILDONLY:
-      modulemd_component_set_buildorder (self, g_value_get_boolean (value));
+      modulemd_component_set_buildonly (self, g_value_get_boolean (value));
       break;
 
     case PROP_BUILDORDER:

--- a/modulemd/tests/ModulemdTests/componentrpm.py
+++ b/modulemd/tests/ModulemdTests/componentrpm.py
@@ -34,6 +34,8 @@ class TestComponentRpm(TestBase):
         assert rpm
         assert rpm.props.buildorder == 0
         assert rpm.get_buildorder() == 0
+        assert rpm.props.buildonly is False
+        assert rpm.get_buildonly() is False
         assert rpm.props.name == "testrpm"
         assert rpm.get_name() == "testrpm"
         assert rpm.props.rationale is None
@@ -50,6 +52,7 @@ class TestComponentRpm(TestBase):
         # Test that object instantiation works
         rpm = ComponentRpm(
             buildorder=42,
+            buildonly=True,
             name='testrpm',
             rationale='Testing all the things',
             ref='someref',
@@ -58,6 +61,8 @@ class TestComponentRpm(TestBase):
         assert rpm
         assert rpm.props.buildorder == 42
         assert rpm.get_buildorder() == 42
+        assert rpm.props.buildonly is True
+        assert rpm.get_buildonly() is True
         assert rpm.props.name == 'testrpm'
         assert rpm.get_name() == 'testrpm'
         assert rpm.props.rationale == 'Testing all the things'
@@ -74,6 +79,7 @@ class TestComponentRpm(TestBase):
     def test_copy(self):
         rpm_orig = ComponentRpm(
             buildorder=42,
+            buildonly=True,
             name='testrpm',
             rationale='Testing all the things',
             ref='someref',
@@ -88,6 +94,8 @@ class TestComponentRpm(TestBase):
         assert rpm
         assert rpm.props.buildorder == 42
         assert rpm.get_buildorder() == 42
+        assert rpm.props.buildonly is True
+        assert rpm.get_buildonly() is True
         assert rpm.props.name == 'testrpm'
         assert rpm.get_name() == 'testrpm'
         assert rpm.props.rationale == 'Testing all the things'


### PR DESCRIPTION
Correct bugs--likely the result of copy & paste errors--where component `buildonly` and `buildorder` properties are getting mixed up. Add python tests for same.