### PR TITLE
Fix modulemd_yaml_parse_bool()

### DIFF
--- a/modulemd/modulemd-yaml-util.c
+++ b/modulemd/modulemd-yaml-util.c
@@ -405,11 +405,11 @@ modulemd_yaml_parse_bool (yaml_parser_t *parser, GError **error)
         error, event, "Expected a scalar boolean");
     }
 
-  if (g_strcmp0 ((const gchar *)event.data.scalar.value, "false"))
+  if (g_str_equal ((const gchar *)event.data.scalar.value, "false"))
     {
       return FALSE;
     }
-  else if (g_strcmp0 ((const gchar *)event.data.scalar.value, "true"))
+  else if (g_str_equal ((const gchar *)event.data.scalar.value, "true"))
     {
       return TRUE;
     }

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -1221,7 +1221,6 @@ module_stream_v2_test_parse_dump (ModuleStreamFixture *fixture,
     "        repository: https://pagure.io/bar.git\n"
     "        cache: https://example.com/cache\n"
     "        ref: 26ca0c0\n"
-    "        buildonly: true\n"
     "      baz:\n"
     "        rationale: This one is here to demonstrate other stuff.\n"
     "      xxx:\n"


### PR DESCRIPTION
`modulemd_yaml_parse_bool()` currently returns `TRUE` when parsing a YAML `false` value, and `FALSE` when parsing `true`.

This PR fixes that issue, as well as corrects the defective test that was enforcing the backwards parsing behavior.