### PR TITLE
Stop using deprecated build_always

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -107,7 +107,8 @@ rpmsetup_target = custom_target(
 spec_target = custom_target(
     'specfile',
     capture: true,
-    build_always: true,
+    build_by_default: true,
+    build_always_stale: true,
     command: [sh, spec_tmpl,
               meson.project_version(),
               '@INPUT@'],


### PR DESCRIPTION
Since we now require meson 0.47+ for building, we no longer need to
use the deprecated `build_always` argument for the specfile template
script. Switch to using the supported `build_always_stale` and
`build_by_default` arguments instead.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>