### PR TITLE
Implement rpm buildroot flags

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-component-rpm.h
+++ b/modulemd/include/modulemd-2.0/modulemd-component-rpm.h
@@ -200,4 +200,53 @@ modulemd_component_rpm_set_repository (ModulemdComponentRpm *self,
 const gchar *
 modulemd_component_rpm_get_repository (ModulemdComponentRpm *self);
 
+
+/**
+ * modulemd_component_rpm_set_buildroot:
+ * @self: This #ModulemdComponentRpm object.
+ * @buildroot: (in): The #ModulemdComponentRpm:buildroot flag to set for @self.
+ *
+ * Since: 2.7
+ */
+void
+modulemd_component_rpm_set_buildroot (ModulemdComponentRpm *self,
+                                      gboolean buildroot);
+
+
+/**
+ * modulemd_component_rpm_get_buildroot:
+ * @self: This #ModulemdComponentRpm object.
+ *
+ * Returns: The #ModulemdComponentRpm:buildroot flag.
+ *
+ * Since: 2.7
+ */
+gboolean
+modulemd_component_rpm_get_buildroot (ModulemdComponentRpm *self);
+
+
+/**
+ * modulemd_component_rpm_set_srpm_buildroot:
+ * @self: This #ModulemdComponentRpm object.
+ * @srpm_buildroot: (in): The #ModulemdComponentRpm:srpm_buildroot flag to set
+ * for @self.
+ *
+ * Since: 2.7
+ */
+void
+modulemd_component_rpm_set_srpm_buildroot (ModulemdComponentRpm *self,
+                                           gboolean srpm_buildroot);
+
+
+/**
+ * modulemd_component_rpm_get_srpm_buildroot:
+ * @self: This #ModulemdComponentRpm object.
+ *
+ * Returns: The #ModulemdComponentRpm:srpm_buildroot flag.
+ *
+ * Since: 2.7
+ */
+gboolean
+modulemd_component_rpm_get_srpm_buildroot (ModulemdComponentRpm *self);
+
 G_END_DECLS

--- a/modulemd/include/private/modulemd-util.h
+++ b/modulemd/include/private/modulemd-util.h
@@ -295,6 +295,20 @@ modulemd_hash_table_unref (void *table);
 gboolean
 modulemd_validate_nevra (const gchar *nevra);
 
+/**
+ * modulemd_boolean_equals:
+ * @a: A #gboolean value.
+ * @b: A #gboolean value.
+ *
+ * Since a #gboolean could contain any value represented by a #gint, @a and @b
+ * are compared for logical equivalence.
+ *
+ * Returns: TRUE if @a and @b are logically equal, FALSE otherwise.
+ *
+ * Since: 2.7
+ */
+gboolean
+modulemd_boolean_equals (gboolean a, gboolean b);
 
 /**
  * MODULEMD_REPLACE_SET:

--- a/modulemd/modulemd-util.c
+++ b/modulemd/modulemd-util.c
@@ -389,3 +389,18 @@ modulemd_validate_nevra (const gchar *nevra)
 
   return TRUE;
 }
+
+
+gboolean
+modulemd_boolean_equals (gboolean a, gboolean b)
+{
+  /*
+   * There is no validation when assigning to a gboolean variable and so it
+   * could contain any value represented by a gint. Thus, each value needs to
+   * be canonicalized before comparing for equality.
+   */
+  if (!!a == !!b)
+    return TRUE;
+
+  return FALSE;
+}

--- a/modulemd/tests/test-modulemd-component-rpm.c
+++ b/modulemd/tests/test-modulemd-component-rpm.c
@@ -98,6 +98,8 @@ component_rpm_test_equals (ComponentRpmFixture *fixture,
   modulemd_component_rpm_set_ref (r_1, "someref");
   modulemd_component_rpm_set_repository (r_1, "somerepo");
   modulemd_component_rpm_set_cache (r_1, "somecache");
+  modulemd_component_rpm_set_buildroot (r_1, TRUE);
+  modulemd_component_rpm_set_srpm_buildroot (r_1, TRUE);
   modulemd_component_rpm_add_restricted_arch (r_1, "x86_64");
   modulemd_component_rpm_add_restricted_arch (r_1, "i686");
   modulemd_component_rpm_add_multilib_arch (r_1, "ppc64le");
@@ -110,6 +112,8 @@ component_rpm_test_equals (ComponentRpmFixture *fixture,
   modulemd_component_rpm_set_ref (r_2, "someref");
   modulemd_component_rpm_set_repository (r_2, "somerepo");
   modulemd_component_rpm_set_cache (r_2, "somecache");
+  modulemd_component_rpm_set_buildroot (r_2, TRUE);
+  modulemd_component_rpm_set_srpm_buildroot (r_2, TRUE);
   modulemd_component_rpm_add_restricted_arch (r_2, "x86_64");
   modulemd_component_rpm_add_restricted_arch (r_2, "i686");
   modulemd_component_rpm_add_multilib_arch (r_2, "ppc64le");
@@ -128,6 +132,8 @@ component_rpm_test_equals (ComponentRpmFixture *fixture,
   modulemd_component_rpm_set_ref (r_1, "refA");
   modulemd_component_rpm_set_repository (r_1, "somerepo");
   modulemd_component_rpm_set_cache (r_1, "cacheA");
+  modulemd_component_rpm_set_buildroot (r_1, TRUE);
+  modulemd_component_rpm_set_srpm_buildroot (r_1, TRUE);
   modulemd_component_rpm_add_restricted_arch (r_1, "x86_64");
   modulemd_component_rpm_add_restricted_arch (r_1, "i686");
   modulemd_component_rpm_add_multilib_arch (r_1, "ppc64le");
@@ -140,6 +146,8 @@ component_rpm_test_equals (ComponentRpmFixture *fixture,
   modulemd_component_rpm_set_ref (r_2, "someref");
   modulemd_component_rpm_set_repository (r_2, "somerepo");
   modulemd_component_rpm_set_cache (r_2, "somecache");
+  modulemd_component_rpm_set_buildroot (r_2, TRUE);
+  modulemd_component_rpm_set_srpm_buildroot (r_2, TRUE);
   modulemd_component_rpm_add_restricted_arch (r_2, "x86_64");
   modulemd_component_rpm_add_restricted_arch (r_2, "i686");
   modulemd_component_rpm_add_multilib_arch (r_2, "ppc64le");
@@ -158,6 +166,8 @@ component_rpm_test_equals (ComponentRpmFixture *fixture,
   modulemd_component_rpm_set_ref (r_1, "someref");
   modulemd_component_rpm_set_repository (r_1, "somerepo");
   modulemd_component_rpm_set_cache (r_1, "somecache");
+  modulemd_component_rpm_set_buildroot (r_1, TRUE);
+  modulemd_component_rpm_set_srpm_buildroot (r_1, TRUE);
   modulemd_component_rpm_add_restricted_arch (r_1, "x86_65");
   modulemd_component_rpm_add_restricted_arch (r_1, "i687");
   modulemd_component_rpm_add_multilib_arch (r_1, "ppc64le");
@@ -170,6 +180,8 @@ component_rpm_test_equals (ComponentRpmFixture *fixture,
   modulemd_component_rpm_set_ref (r_2, "someref");
   modulemd_component_rpm_set_repository (r_2, "somerepo");
   modulemd_component_rpm_set_cache (r_2, "somecache");
+  modulemd_component_rpm_set_buildroot (r_2, TRUE);
+  modulemd_component_rpm_set_srpm_buildroot (r_2, TRUE);
   modulemd_component_rpm_add_restricted_arch (r_2, "x86_64");
   modulemd_component_rpm_add_restricted_arch (r_2, "i686");
   modulemd_component_rpm_add_multilib_arch (r_2, "ppc64le");
@@ -197,6 +209,8 @@ component_rpm_test_copy (ComponentRpmFixture *fixture, gconstpointer user_data)
   modulemd_component_rpm_set_ref (r_orig, "someref");
   modulemd_component_rpm_set_repository (r_orig, "somerepo");
   modulemd_component_rpm_set_cache (r_orig, "somecache");
+  modulemd_component_rpm_set_buildroot (r_orig, TRUE);
+  modulemd_component_rpm_set_srpm_buildroot (r_orig, TRUE);
   modulemd_component_rpm_add_restricted_arch (r_orig, "x86_64");
   modulemd_component_rpm_add_restricted_arch (r_orig, "i686");
   modulemd_component_rpm_add_multilib_arch (r_orig, "ppc64le");
@@ -216,6 +230,8 @@ component_rpm_test_copy (ComponentRpmFixture *fixture, gconstpointer user_data)
   g_assert_cmpstr (modulemd_component_rpm_get_ref (r), ==, "someref");
   g_assert_cmpstr (modulemd_component_rpm_get_repository (r), ==, "somerepo");
   g_assert_cmpstr (modulemd_component_rpm_get_cache (r), ==, "somecache");
+  g_assert_true (modulemd_component_rpm_get_buildroot (r));
+  g_assert_true (modulemd_component_rpm_get_srpm_buildroot (r));
 
   list = modulemd_component_rpm_get_arches_as_strv (r);
   g_assert_cmpint (g_strv_length (list), ==, 2);
@@ -244,6 +260,8 @@ component_rpm_test_copy (ComponentRpmFixture *fixture, gconstpointer user_data)
   g_assert_cmpstr (modulemd_component_rpm_get_ref (r), ==, "someref");
   g_assert_cmpstr (modulemd_component_rpm_get_repository (r), ==, "somerepo");
   g_assert_cmpstr (modulemd_component_rpm_get_cache (r), ==, "somecache");
+  g_assert_true (modulemd_component_rpm_get_buildroot (r));
+  g_assert_true (modulemd_component_rpm_get_srpm_buildroot (r));
 
   list = modulemd_component_rpm_get_arches_as_strv (r);
   g_assert_cmpint (g_strv_length (list), ==, 2);
@@ -298,6 +316,8 @@ component_rpm_test_emit_yaml (ComponentRpmFixture *fixture,
   modulemd_component_rpm_set_repository (r, "testrepository");
   modulemd_component_rpm_set_ref (r, "testref");
   modulemd_component_rpm_set_cache (r, "testcache");
+  modulemd_component_rpm_set_buildroot (r, TRUE);
+  modulemd_component_rpm_set_srpm_buildroot (r, TRUE);
   modulemd_component_rpm_add_restricted_arch (r, "x86_64");
   modulemd_component_rpm_add_restricted_arch (r, "i686");
   modulemd_component_rpm_add_multilib_arch (r, "ppc64le");
@@ -319,6 +339,8 @@ component_rpm_test_emit_yaml (ComponentRpmFixture *fixture,
                    "  repository: testrepository\n"
                    "  cache: testcache\n"
                    "  ref: testref\n"
+                   "  buildroot: true\n"
+                   "  srpm-buildroot: true\n"
                    "  buildorder: 42\n"
                    "  arches: [i686, x86_64]\n"
                    "  multilib: [ppc64le, s390x]\n"
@@ -368,6 +390,8 @@ component_rpm_test_parse_yaml (ComponentRpmFixture *fixture,
   g_assert_cmpstr (modulemd_component_rpm_get_ref (r), ==, "26ca0c0");
   g_assert_cmpstr (
     modulemd_component_rpm_get_cache (r), ==, "https://example.com/cache");
+  g_assert_true (modulemd_component_rpm_get_buildroot (r));
+  g_assert_true (modulemd_component_rpm_get_srpm_buildroot (r));
 
   list = modulemd_component_rpm_get_arches_as_strv (r);
   g_assert_cmpint (g_strv_length (list), ==, 2);

--- a/modulemd/tests/test_data/cr.yaml
+++ b/modulemd/tests/test_data/cr.yaml
@@ -5,6 +5,8 @@ bar:
     cache: https://example.com/cache
     buildorder: 100
     ref: 26ca0c0
+    buildroot: true
+    srpm-buildroot: true
     arches: [i686, x86_64]
     multilib: [x86_64]
 ...

--- a/spec.v2.yaml
+++ b/spec.v2.yaml
@@ -285,6 +285,19 @@ data:
                 # data.filter.rpms list after the build is complete.
                 # Optional. Defaults to "false" if not specified.
                 buildonly: false
+                # If buildroot is set to True, the packages listed in this
+                # module's buildroot profile will be installed into the
+                # buildroot of any component built in subsequent
+                # buildorder/buildafter batches, even if that module does not
+                # explicitly include these packages in its BuildRequires.
+                # Optional. Defaults to "false" if not specified.
+                buildroot: false
+                # If srpm-buildroot is set to True, the packages listed in this
+                # module's srpm-buildroot profile will be installed into the
+                # buildroot when performing the buildSRPMfromSCM step in
+                # subsequent buildorder/buildafter batches.
+                # Optional. Defaults to "false" if not specified.
+                srpm-buildroot: false
             # baz has no extra options
             baz:
                 rationale: This one is here to demonstrate other stuff.


### PR DESCRIPTION
Implementation for #288:

- New component rpm "buildroot" and "srpm-buildroot" flags were added to modulemd 2.0 spec
- Code was updated to handle new properties
- YAML parsing and emitting capabilities for new properties were added 
- Tests were updated to verify handling new properties