### PR TITLE
CI: Quieter logs

### DIFF
--- a/.travis/archlinux/travis-tasks.sh
+++ b/.travis/archlinux/travis-tasks.sh
@@ -20,13 +20,6 @@ meson --buildtype=debug \
       $COMMON_MESON_ARGS \
       travis
 
-set +e
 ninja -C travis test
-ret=$?
-if [ $ret != 0 ]; then
-    cat travis/meson-logs/testlog.txt
-    exit $ret
-fi
-set -e
 
 popd #builddir

--- a/.travis/centos/travis-tasks.sh
+++ b/.travis/centos/travis-tasks.sh
@@ -23,13 +23,6 @@ meson --buildtype=debug \
       $COMMON_MESON_ARGS \
       travis
 
-set +e
 ninja-build -C travis test
-ret=$?
-if [ $ret != 0 ]; then
-    cat travis/meson-logs/testlog.txt
-    exit $ret
-fi
-set -e
 
 popd #builddir

--- a/.travis/fedora/travis-tasks.sh
+++ b/.travis/fedora/travis-tasks.sh
@@ -21,14 +21,7 @@ meson --buildtype=debug \
       $COMMON_MESON_ARGS \
       travis
 
-set +e
 ninja -C travis test
-ret=$?
-if [ $ret != 0 ]; then
-    cat travis/meson-logs/testlog.txt
-    exit $ret
-fi
-set -e
 
 # Test the code with clang-analyzer
 # This requires meson 0.49.0 or later

--- a/.travis/mageia/travis-tasks.sh
+++ b/.travis/mageia/travis-tasks.sh
@@ -22,15 +22,7 @@ meson --buildtype=debug \
       $COMMON_MESON_ARGS \
       travis
 
-set +e
 ninja -C travis test
-if [ $? != 0 ]; then
-    if [ "x$TRAVIS_JOB_NAME" != "x" ]; then
-        cat travis/meson-logs/testlog.txt
-    fi
-    exit $ret
-fi
-set -e
 
 # Test the code with clang-analyzer
 # This requires meson 0.49.0 or later

--- a/.travis/opensuse/travis-tasks.sh
+++ b/.travis/opensuse/travis-tasks.sh
@@ -21,13 +21,6 @@ meson --buildtype=debug \
       $COMMON_MESON_ARGS \
       travis
 
-set +e
 ninja -C travis test
-ret=$?
-if [ $ret != 0 ]; then
-    cat travis/meson-logs/testlog.txt
-    exit $ret
-fi
-set -e
 
 popd #builddir


### PR DESCRIPTION
Outputting the complete test logs is too noisy for Travis CI. Just
use ninja's built-in ability to print the last 100 lines of each
failed test's logs.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>