### PR TITLE
Make Module.get_translation() public

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module.h
@@ -17,6 +17,7 @@
 #include "modulemd-defaults.h"
 #include "modulemd-deprecated.h"
 #include "modulemd-module-stream.h"
+#include "modulemd-translation.h"
 
 G_BEGIN_DECLS
 
@@ -238,5 +239,18 @@ modulemd_module_remove_streams_by_NSVCA (ModulemdModule *self,
  */
 ModulemdDefaults *
 modulemd_module_get_defaults (ModulemdModule *self);
+
+
+/**
+ * modulemd_module_get_translation:
+ * @self: This #ModulemdModule object.
+ * @stream: The stream to look up translations for.
+ *
+ * Returns: (transfer none): The set of translations attached to streams.
+ *
+ * Since: 2.8
+ */
+ModulemdTranslation *
+modulemd_module_get_translation (ModulemdModule *self, const gchar *stream);
 
 G_END_DECLS

--- a/modulemd/include/private/modulemd-module-private.h
+++ b/modulemd/include/private/modulemd-module-private.h
@@ -103,19 +103,6 @@ modulemd_module_get_translated_streams (ModulemdModule *self);
 
 
 /**
- * modulemd_module_get_translation:
- * @self: This #ModulemdModule object.
- * @stream: The stream to look up translations for.
- *
- * Returns: (transfer none): The set of translations attached to streams.
- *
- * Since: 2.0
- */
-ModulemdTranslation *
-modulemd_module_get_translation (ModulemdModule *self, const gchar *stream);
-
-
-/**
  * modulemd_module_add_stream:
  * @self: This #ModulemdModule object.
  * @stream: A #ModulemdModuleStream object to associate with this


### PR DESCRIPTION
For tools like GrobiSplitter which need to extract the modules and
streams from a larger repo and create a smaller index, we need to
be able to retrieve the translation object to copy it.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>