### PR TITLE
Add ModuleIndex.update_from_defaults_directory()

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-index.h
@@ -247,6 +247,42 @@ modulemd_module_index_update_from_custom (ModulemdModuleIndex *self,
 
 
 /**
+ * modulemd_module_index_update_from_defaults_directory:
+ * @self: This #ModulemdModuleIndex object.
+ * @path: (in): The path to a directory containing defaults documents.
+ * @strict: (in): Whether the parser should return failure if it encounters an
+ * unknown mapping key or if it should ignore it.
+ * @overrides_path: (in) (nullable): If non-NULL, the path to a directory
+ * containing defaults documents that should override those in @path.
+ * @error: (out): A #GError indicating why this function failed.
+ *
+ * This function will open the directory at @path and iterate through it,
+ * adding any files with the suffix ".yaml" to @self. If @overrides_path is
+ * non-NULL, it will also open any files with the suffix ".yaml" in that
+ * location and import them, overriding any conflicts with the existing
+ * defaults.
+ *
+ * Note: If you need detailed information about what failed and why, it is
+ * better to implement the directory traversal yourself and use the
+ * modulemd_module_index_update_from_file() function, as it will return the
+ * failures information.
+ *
+ * Returns: TRUE if all ".yaml" files in the directory were imported
+ * successfully (this includes if no ".yaml" files were present). FALSE if one
+ * or more files could not be read successfully and sets @error appropriately.
+ *
+ * Since: 2.8
+ */
+gboolean
+modulemd_module_index_update_from_defaults_directory (
+  ModulemdModuleIndex *self,
+  const gchar *path,
+  gboolean strict,
+  const gchar *overrides_path,
+  GError **error);
+
+
+/**
  * modulemd_module_index_dump_to_string:
  * @self: This #ModulemdModuleIndex object.
  * @error: (out): A #GError containing the reason the function failed, NULL if

--- a/modulemd/tests/ModulemdTests/moduleindex.py
+++ b/modulemd/tests/ModulemdTests/moduleindex.py
@@ -122,6 +122,72 @@ profiles:
             yaml = idx.dump_to_string()
             self.assertIsNone(yaml)
 
+    def test_update_from_defaults_directory(self):
+        idx = Modulemd.ModuleIndex.new()
+        self.assertIsNotNone(idx)
+
+        # First, verify that it works without overrides
+        ret = idx.update_from_defaults_directory(
+            path=path.join(self.test_data_path, 'defaults'),
+            strict=True)
+        self.assertTrue(ret)
+
+        # There should be three modules here: meson, ninja and nodejs
+        self.assertEqual(len(idx.get_module_names()), 3)
+        self.assertIn('meson', idx.get_module_names())
+        self.assertIn('ninja', idx.get_module_names())
+        self.assertIn('nodejs', idx.get_module_names())
+
+        # Check default streams
+        defs = idx.get_default_streams()
+        self.assertIn('meson', defs)
+        self.assertEqual('latest', defs['meson'])
+        self.assertIn('ninja', defs)
+        self.assertEqual('latest', defs['ninja'])
+        self.assertNotIn('nodejs', defs)
+
+        # Now add overrides too
+        # First, verify that it works without overrides
+        ret = idx.update_from_defaults_directory(
+            path=path.join(
+                self.test_data_path, 'defaults'), overrides_path=path.join(
+                self.test_data_path, 'defaults', 'overrides'), strict=True)
+        self.assertTrue(ret)
+
+        # There should be four modules here: meson, ninja, nodejs and
+        # testmodule
+        self.assertEqual(len(idx.get_module_names()), 4)
+        self.assertIn('meson', idx.get_module_names())
+        self.assertIn('ninja', idx.get_module_names())
+        self.assertIn('nodejs', idx.get_module_names())
+        self.assertIn('testmodule', idx.get_module_names())
+
+        # Check default streams
+        defs = idx.get_default_streams()
+        self.assertIn('meson', defs)
+        self.assertEqual('latest', defs['meson'])
+        self.assertIn('ninja', defs)
+        self.assertEqual('latest', defs['ninja'])
+        self.assertIn('nodejs', defs)
+        self.assertEqual('12', defs['nodejs'])
+        self.assertIn('testmodule', defs)
+        self.assertIn('teststream', defs['testmodule'])
+
+        # Nonexistent defaults dir
+        with self.assertRaisesRegexp(GLib.Error, 'No such file or directory'):
+            ret = idx.update_from_defaults_directory(
+                path=path.join(self.test_data_path, 'defaults_nonexistent'),
+                strict=True)
+            self.assertFalse(ret)
+
+        # Nonexistent override dir
+        with self.assertRaisesRegexp(GLib.Error, 'No such file or directory'):
+            ret = idx.update_from_defaults_directory(
+                path=path.join(self.test_data_path, 'defaults'),
+                overrides_path='overrides_nonexistent',
+                strict=True)
+            self.assertFalse(ret)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/modulemd/tests/test_data/defaults/meson.yaml
+++ b/modulemd/tests/test_data/defaults/meson.yaml
@@ -1,0 +1,7 @@
+document: modulemd-defaults
+version: 1
+data:
+  module: meson
+  stream: latest
+  profiles:
+    latest: [default]

--- a/modulemd/tests/test_data/defaults/ninja.yaml
+++ b/modulemd/tests/test_data/defaults/ninja.yaml
@@ -1,0 +1,7 @@
+document: modulemd-defaults
+version: 1
+data:
+  module: ninja
+  stream: latest
+  profiles:
+    latest: [default]

--- a/modulemd/tests/test_data/defaults/nodejs.yaml
+++ b/modulemd/tests/test_data/defaults/nodejs.yaml
@@ -1,0 +1,9 @@
+document: modulemd-defaults
+version: 1
+data:
+    modified: 201906261200
+    module: nodejs
+    profiles:
+        8: [default]
+        10: [default]
+        12: [default]

--- a/modulemd/tests/test_data/defaults/overrides/nodejs.yaml
+++ b/modulemd/tests/test_data/defaults/overrides/nodejs.yaml
@@ -1,0 +1,10 @@
+document: modulemd-defaults
+version: 1
+data:
+    modified: 201906261200
+    module: nodejs
+    stream: 12
+    profiles:
+        8: [default]
+        10: [default]
+        12: [default]

--- a/modulemd/tests/test_data/defaults/overrides/testmodule.yaml
+++ b/modulemd/tests/test_data/defaults/overrides/testmodule.yaml
@@ -1,0 +1,8 @@
+document: modulemd-defaults
+version: 1
+data:
+    modified: 201906261200
+    module: testmodule
+    stream: teststream
+    profiles:
+        teststream: [ common ]


### PR DESCRIPTION
This function can be used by pungi and MBS to generate a buildroot for modular and
non-modular builds. It will read all files suffixed with .yaml from the provided
directory and add them to the index. If an overrides_path is provided, those
contents will also be merged in (and preferred in the event of a conflict).

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>