### PR TITLE
Improvements to ModuleIndex.update_from_defaults_dir()

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-index.h
@@ -251,7 +251,7 @@ modulemd_module_index_update_from_custom (ModulemdModuleIndex *self,
  * @self: This #ModulemdModuleIndex object.
  * @path: (in): The path to a directory containing defaults documents.
  * @strict: (in): Whether the parser should return failure if it encounters an
- * unknown mapping key or if it should ignore it.
+ * unknown mapping key or a conflict in module default streams.
  * @overrides_path: (in) (nullable): If non-NULL, the path to a directory
  * containing defaults documents that should override those in @path.
  * @error: (out): A #GError indicating why this function failed.

--- a/modulemd/include/private/modulemd-rpm-map-entry-private.h
+++ b/modulemd/include/private/modulemd-rpm-map-entry-private.h
@@ -37,8 +37,8 @@
  */
 ModulemdRpmMapEntry *
 modulemd_rpm_map_entry_parse_yaml (yaml_parser_t *parser,
-                             gboolean strict,
-                             GError **error);
+                                   gboolean strict,
+                                   GError **error);
 
 
 /**

--- a/modulemd/tests/test_data/bad_defaults/meson-2.yaml
+++ b/modulemd/tests/test_data/bad_defaults/meson-2.yaml
@@ -1,0 +1,7 @@
+document: modulemd-defaults
+version: 1
+data:
+  module: meson
+  stream: old
+  profiles:
+    latest: [default]

--- a/modulemd/tests/test_data/bad_defaults/meson.yaml
+++ b/modulemd/tests/test_data/bad_defaults/meson.yaml
@@ -1,0 +1,7 @@
+document: modulemd-defaults
+version: 1
+data:
+  module: meson
+  stream: latest
+  profiles:
+    latest: [default]

--- a/modulemd/tests/test_data/bad_defaults/ninja.yaml
+++ b/modulemd/tests/test_data/bad_defaults/ninja.yaml
@@ -1,0 +1,7 @@
+document: modulemd-defaults
+version: 1
+data:
+  module: ninja
+  stream: latest
+  profiles:
+    latest: [default]

--- a/modulemd/tests/test_data/bad_defaults/nodejs.yaml
+++ b/modulemd/tests/test_data/bad_defaults/nodejs.yaml
@@ -1,0 +1,9 @@
+document: modulemd-defaults
+version: 1
+data:
+    modified: 201906261200
+    module: nodejs
+    profiles:
+        8: [default]
+        10: [default]
+        12: [default]


### PR DESCRIPTION
- Import each file in the directory as a merge rather than an an overwrite so we
can detect conflicts.
- Modify the meaning of the 'strict' argument to mean that it should fail if the
merge would result in a conflict in the default stream setting for a module.

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/366

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

Attn: @lubomir