### PR TITLE
Rework defaults merging logic

### DIFF
--- a/modulemd/include/private/modulemd-defaults-v1-private.h
+++ b/modulemd/include/private/modulemd-defaults-v1-private.h
@@ -72,7 +72,6 @@ modulemd_defaults_v1_emit_yaml (ModulemdDefaultsV1 *self,
 
 /**
  * modulemd_defaults_v1_merge:
- * @module_name: (in): The name of the module for which defaults are being merged.
  * @from: (in): A #ModulemdDefaultsV1 object to merge from.
  * @into: (in): A #ModulemdDefaultsV1 object being merged into.
  * @strict_default_streams: (in): Whether a stream conflict should throw an
@@ -92,8 +91,7 @@ modulemd_defaults_v1_emit_yaml (ModulemdDefaultsV1 *self,
  * Since: 2.0
  */
 ModulemdDefaults *
-modulemd_defaults_v1_merge (const gchar *module_name,
-                            ModulemdDefaultsV1 *from,
+modulemd_defaults_v1_merge (ModulemdDefaultsV1 *from,
                             ModulemdDefaultsV1 *into,
                             gboolean strict_default_streams,
                             GError **error);

--- a/modulemd/modulemd-defaults.c
+++ b/modulemd/modulemd-defaults.c
@@ -397,9 +397,6 @@ modulemd_defaults_merge (ModulemdDefaults *from,
 {
   g_autoptr (ModulemdDefaults) merged_defaults = NULL;
   guint64 mdversion;
-  const gchar *module_name = NULL;
-  guint64 from_modified;
-  guint64 into_modified;
   g_autoptr (GError) nested_error = NULL;
 
   g_return_val_if_fail (MODULEMD_IS_DEFAULTS (from), NULL);
@@ -417,36 +414,19 @@ modulemd_defaults_merge (ModulemdDefaults *from,
                         NULL);
   g_return_val_if_fail (mdversion == MD_DEFAULTS_VERSION_ONE, NULL);
 
-  from_modified = modulemd_defaults_get_modified (from);
-  into_modified = modulemd_defaults_get_modified (into);
-
-  if (from_modified > into_modified)
-    {
-      /* Just return 'from' if it has a higher modified value */
-      return modulemd_defaults_copy (from);
-    }
-  else if (into_modified > from_modified)
-    {
-      /* Just return 'into' if it has a higher modified value */
-      return modulemd_defaults_copy (into);
-    }
-
-  /* Modified value is the same, so we need to merge */
-
-  module_name = modulemd_defaults_get_module_name (into);
-  if (!g_str_equal (module_name, modulemd_defaults_get_module_name (from)))
+  if (!g_str_equal (modulemd_defaults_get_module_name (into),
+                    modulemd_defaults_get_module_name (from)))
     {
       g_set_error (error,
                    MODULEMD_ERROR,
                    MODULEMD_ERROR_VALIDATE,
                    "Module name mismatch in merge: %s != %s",
-                   module_name,
+                   modulemd_defaults_get_module_name (into),
                    modulemd_defaults_get_module_name (from));
       return NULL;
     }
 
-  merged_defaults = modulemd_defaults_v1_merge (module_name,
-                                                MODULEMD_DEFAULTS_V1 (from),
+  merged_defaults = modulemd_defaults_v1_merge (MODULEMD_DEFAULTS_V1 (from),
                                                 MODULEMD_DEFAULTS_V1 (into),
                                                 strict_default_streams,
                                                 &nested_error);

--- a/modulemd/tests/test_data/merger/add_conflicting_profile.yaml
+++ b/modulemd/tests/test_data/merger/add_conflicting_profile.yaml
@@ -1,0 +1,7 @@
+document: modulemd-defaults
+version: 1
+data:
+    module: postgresql
+    stream: '8.1'
+    profiles:
+        '8.1': [client, server]

--- a/modulemd/tests/test_data/merger/add_conflicting_stream.yaml
+++ b/modulemd/tests/test_data/merger/add_conflicting_stream.yaml
@@ -1,0 +1,9 @@
+---
+document: modulemd-defaults
+version: 1
+data:
+    module: postgresql
+    stream: '8.2'
+    profiles:
+        '8.2': [client, server, foo]
+

--- a/modulemd/tests/test_data/merger/add_conflicting_stream_and_profile_modified.yaml
+++ b/modulemd/tests/test_data/merger/add_conflicting_stream_and_profile_modified.yaml
@@ -1,0 +1,11 @@
+---
+document: modulemd-defaults
+version: 1
+data:
+    module: postgresql
+    stream: '8.2'
+    modified: 201909270000
+    profiles:
+      '8.1': [client, server]
+      '8.2': [client, server, foo]
+

--- a/modulemd/tests/test_data/merger/add_only.yaml
+++ b/modulemd/tests/test_data/merger/add_only.yaml
@@ -1,0 +1,8 @@
+---
+document: modulemd-defaults
+version: 1
+data:
+    module: httpd
+    stream: 2.8
+    profiles:
+        '2.10': [notreal]

--- a/modulemd/tests/test_data/merger/base.yaml
+++ b/modulemd/tests/test_data/merger/base.yaml
@@ -1,0 +1,34 @@
+---
+# Intents optional:
+document: modulemd-defaults
+version: 1
+data:
+    module: httpd
+    profiles:
+        '2.2': [client, server]
+        '2.8': [notreal]
+    intents:
+        workstation:
+            stream: '2.4'
+            profiles:
+                '2.4': [client]
+                '2.6': [client, server, bindings]
+---
+document: modulemd-defaults
+version: 1
+data:
+    module: postgresql
+    stream: '8.1'
+    profiles:
+        '8.1': [client, server, foo]
+        '8.3': [client, server]
+---
+document: modulemd-defaults
+version: 1
+data:
+    module: nodejs
+    stream: '8.0'
+    modified: 201909270000
+    profiles:
+        '6.0': [default]
+        '8.0': [super]


### PR DESCRIPTION
Updates documentation of ModuleIndexMerger with the new algorithm.

Also fixes a memory leak in DefaultsV1.set_default_stream()

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/368

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>


This is the 2.x implementation of the new merge logic. I will be sending the 1.x implementation in a separate PR for the 1.x-maint branch once this is reviewed and merged.