### PR TITLE
ModuleStream: Properly override names when asked to

### DIFF
--- a/modulemd/modulemd-module-stream-v1.c
+++ b/modulemd/modulemd-module-stream-v1.c
@@ -1786,15 +1786,6 @@ modulemd_module_stream_v1_parse_yaml (ModulemdSubdocumentInfo *subdoc,
       yaml_event_delete (&event);
     }
 
-
-  if (!modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (modulestream),
-                                        &nested_error))
-    {
-      g_propagate_error (error, g_steal_pointer (&nested_error));
-      return NULL;
-    }
-
-
   return g_steal_pointer (&modulestream);
 }
 

--- a/modulemd/modulemd-module-stream-v2.c
+++ b/modulemd/modulemd-module-stream-v2.c
@@ -1773,15 +1773,6 @@ modulemd_module_stream_v2_parse_yaml (ModulemdSubdocumentInfo *subdoc,
       yaml_event_delete (&event);
     }
 
-
-  if (!modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (modulestream),
-                                        &nested_error))
-    {
-      g_propagate_error (error, g_steal_pointer (&nested_error));
-      return NULL;
-    }
-
-
   return g_steal_pointer (&modulestream);
 }
 

--- a/modulemd/modulemd-module-stream.c
+++ b/modulemd/modulemd-module-stream.c
@@ -278,6 +278,13 @@ modulemd_module_stream_read_yaml (yaml_parser_t *parser,
     }
   yaml_event_delete (&event);
 
+
+  if (!modulemd_module_stream_validate (stream, &nested_error))
+    {
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return NULL;
+    }
+
   return g_steal_pointer (&stream);
 }
 

--- a/modulemd/modulemd-module-stream.c
+++ b/modulemd/modulemd-module-stream.c
@@ -254,6 +254,7 @@ modulemd_module_stream_read_yaml (yaml_parser_t *parser,
                    MODULEMD_YAML_ERROR_PARSE,
                    "Unknown ModuleStream version: %" PRIu64,
                    modulemd_subdocument_info_get_mdversion (subdoc));
+      return NULL;
       break;
     }
 

--- a/modulemd/modulemd-module-stream.c
+++ b/modulemd/modulemd-module-stream.c
@@ -278,6 +278,15 @@ modulemd_module_stream_read_yaml (yaml_parser_t *parser,
     }
   yaml_event_delete (&event);
 
+  if (module_name)
+    {
+      modulemd_module_stream_set_module_name (stream, module_name);
+    }
+
+  if (module_stream)
+    {
+      modulemd_module_stream_set_stream_name (stream, module_stream);
+    }
 
   if (!modulemd_module_stream_validate (stream, &nested_error))
     {


### PR DESCRIPTION
Fixes: https://github.com/fedora-modularity/libmodulemd/issues/382

This PR also includes two other minor fixes, a missing error return (that shouldn't be reachable, but better safe than sorry) and moves the validation of the ModuleStream YAML constructors to the common parent.