### PR TITLE
Use more comprehensive auto-formatting tools for Python and C

### DIFF
--- a/.travis/fedora/Dockerfile.deps.tmpl
+++ b/.travis/fedora/Dockerfile.deps.tmpl
@@ -3,6 +3,7 @@ FROM @IMAGE@
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
 RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
+	python3-black \
 	clang \
 	clang-analyzer \
 	createrepo_c \

--- a/.travis/fedora/Dockerfile.deps.tmpl
+++ b/.travis/fedora/Dockerfile.deps.tmpl
@@ -6,6 +6,7 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	python3-black \
 	clang \
 	clang-analyzer \
+	clang-tools-extra \
 	createrepo_c \
 	"libmodulemd >= 2.3" \
 	curl \

--- a/.travis/mageia/travis-tasks.sh
+++ b/.travis/mageia/travis-tasks.sh
@@ -5,7 +5,7 @@ set -e
 set -x
 
 
-COMMON_MESON_ARGS="-Dtest_dirty_git=${DIRTY_REPO_CHECK:-true}"
+COMMON_MESON_ARGS="-Dtest_dirty_git=${DIRTY_REPO_CHECK:-true} -Ddeveloper_build=false"
 
 
 pushd /builddir/

--- a/.travis/travis-common.inc
+++ b/.travis/travis-common.inc
@@ -7,6 +7,22 @@ MMD_OS=
 MMD_RELEASE=
 MMD_TARBALL_PATH=
 
+BUILDAH_PATH=$(which buildah)
+DOCKER_PATH=/usr/bin/docker
+
+if [ -x ${BUILDAH_PATH--} ]; then
+    MMD_BUILDAH="$BUILDAH_PATH bud"
+else
+    MMD_BUILDAH="$DOCKER_PATH build"
+fi
+
+PODMAN_PATH=$(which podman)
+if [ -x ${PODMAN_PATH--} ]; then
+    MMD_OCI="$PODMAN_PATH"
+else
+    MMD_OCI="$DOCKER_PATH"
+fi
+
 function common_finalize {
     # If any specific test launcher needs to do its own cleanup as well,
     # it should set the EXIT trap and make sure to also call this functino
@@ -55,16 +71,16 @@ function mmd_run_docker_tests {
         $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.tmpl > $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE
     sed -e "s/@RELEASE@/$MMD_OS:$MMD_RELEASE/" $SCRIPT_DIR/$MMD_OS/Dockerfile.tmpl > $SCRIPT_DIR/$MMD_OS/Dockerfile-$MMD_RELEASE
 
-    sudo docker build \
+    $MMD_BUILDAH \
         -f $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE \
         -t fedora-modularity/libmodulemd-deps-$MMD_OS:$MMD_RELEASE .
 
-    sudo docker build \
+    $MMD_BUILDAH \
         -f $SCRIPT_DIR/$MMD_OS/Dockerfile-$MMD_RELEASE \
         -t fedora-modularity/libmodulemd-$MMD_OS:$MMD_RELEASE \
         --build-arg TARBALL=${TARBALL} .
 
-    docker run --rm fedora-modularity/libmodulemd-$MMD_OS:$MMD_RELEASE
+    $MMD_OCI run --rm fedora-modularity/libmodulemd-$MMD_OS:$MMD_RELEASE
 
     popd
 

--- a/.travis/travis-common.inc
+++ b/.travis/travis-common.inc
@@ -8,19 +8,25 @@ MMD_RELEASE=
 MMD_TARBALL_PATH=
 
 BUILDAH_PATH=$(which buildah)
-DOCKER_PATH=/usr/bin/docker
 
-if [ -x ${BUILDAH_PATH--} ]; then
-    MMD_BUILDAH="$BUILDAH_PATH bud"
+DOCKER_PATH=$(which docker)
+
+if [ x$BUILDAH_PATH == x ]; then
+    if [ x$DOCKER_PATH == x ]; then
+        >&2 echo "error: Neither docker nor podman available"
+        exit 1
+    else
+        MMD_BUILDAH="sudo $DOCKER_PATH build"
+    fi
 else
-    MMD_BUILDAH="$DOCKER_PATH build"
+    MMD_BUILDAH="$BUILDAH_PATH bud"
 fi
 
 PODMAN_PATH=$(which podman)
-if [ -x ${PODMAN_PATH--} ]; then
-    MMD_OCI="$PODMAN_PATH"
+if [  x$PODMAN_PATH == x ]; then
+    MMD_OCI="sudo $DOCKER_PATH"
 else
-    MMD_OCI="$DOCKER_PATH"
+    MMD_OCI="$PODMAN_PATH"
 fi
 
 function common_finalize {

--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -33,20 +33,19 @@ from gi.repository import GLib
 
 import datetime
 
-Modulemd = get_introspection_module('Modulemd')
+Modulemd = get_introspection_module("Modulemd")
 
 
 __all__ = []
 
 
 class ModulemdUtil(object):
-
     @staticmethod
     def variant_str(s):
         """ Converts a string to a GLib.Variant
         """
         if not isinstance(s, str):
-            raise TypeError('Only strings are supported for scalars')
+            raise TypeError("Only strings are supported for scalars")
 
         return GLib.Variant.new_string(s)
 
@@ -55,7 +54,7 @@ class ModulemdUtil(object):
         """ Converts a boolean to a GLib.Varant
         """
         if not isinstance(b, bool):
-            raise TypeError('Only booleans are supported')
+            raise TypeError("Only booleans are supported")
 
         return GLib.Variant.new_boolean(b)
 
@@ -65,14 +64,14 @@ class ModulemdUtil(object):
         """
 
         # If this is a zero-length array, handle it specially
-        if (len(l) == 0):
-            return GLib.Variant.new_array(GLib.VariantType('v'))
+        if len(l) == 0:
+            return GLib.Variant.new_array(GLib.VariantType("v"))
 
         # Build the array from each entry
-        builder = GLib.VariantBuilder(GLib.VariantType('a*'))
+        builder = GLib.VariantBuilder(GLib.VariantType("a*"))
         for item in l:
             if item is None:
-                item = ''
+                item = ""
             builder.add_value(ModulemdUtil.python_to_variant(item))
 
         return builder.end()
@@ -82,13 +81,13 @@ class ModulemdUtil(object):
         """ Converts a dictionary to a dictionary of GLib.Variant
         """
         if not isinstance(d, dict):
-            raise TypeError('Only dictionaries are supported for mappings')
+            raise TypeError("Only dictionaries are supported for mappings")
 
         vdict = GLib.VariantDict()
 
         for k, v in d.items():
             if v is None:
-                v = ''
+                v = ""
             vdict.insert_value(k, ModulemdUtil.python_to_variant(v))
 
         return vdict.end()
@@ -100,7 +99,7 @@ class ModulemdUtil(object):
             return ModulemdUtil.variant_str(obj)
 
         elif isinstance(obj, text_type):
-            return ModulemdUtil.variant_str(obj.encode('utf-8'))
+            return ModulemdUtil.variant_str(obj.encode("utf-8"))
 
         elif isinstance(obj, bool):
             return ModulemdUtil.variant_bool(obj)
@@ -112,17 +111,16 @@ class ModulemdUtil(object):
             return ModulemdUtil.variant_dict(obj)
 
         else:
-            raise TypeError('Cannot convert unknown type')
+            raise TypeError("Cannot convert unknown type")
 
 
 if float(Modulemd._version) >= 2:
 
     class ModuleStreamV2(Modulemd.ModuleStreamV2):
-
         def set_xmd(self, xmd):
-            super(
-                ModuleStreamV2, self).set_xmd(
-                ModulemdUtil.python_to_variant(xmd))
+            super(ModuleStreamV2, self).set_xmd(
+                ModulemdUtil.python_to_variant(xmd)
+            )
 
         def get_xmd(self):
             variant_xmd = super(ModuleStreamV2, self).get_xmd()
@@ -134,11 +132,10 @@ if float(Modulemd._version) >= 2:
     __all__.append(ModuleStreamV2)
 
     class ModuleStreamV1(Modulemd.ModuleStreamV1):
-
         def set_xmd(self, xmd):
-            super(
-                ModuleStreamV1, self).set_xmd(
-                ModulemdUtil.python_to_variant(xmd))
+            super(ModuleStreamV1, self).set_xmd(
+                ModulemdUtil.python_to_variant(xmd)
+            )
 
         def get_xmd(self):
             variant_xmd = super(ModuleStreamV1, self).get_xmd()
@@ -150,19 +147,15 @@ if float(Modulemd._version) >= 2:
     __all__.append(ModuleStreamV1)
 
     class ServiceLevel(Modulemd.ServiceLevel):
-
         def set_eol(self, eol):
-            if (isinstance(eol, datetime.date)):
-                return super(
-                    ServiceLevel,
-                    self).set_eol_ymd(
-                    eol.year,
-                    eol.month,
-                    eol.day)
+            if isinstance(eol, datetime.date):
+                return super(ServiceLevel, self).set_eol_ymd(
+                    eol.year, eol.month, eol.day
+                )
 
             raise TypeError(
-                "Expected datetime.date, but got %s." % (
-                    type(eol).__name__))
+                "Expected datetime.date, but got %s." % (type(eol).__name__)
+            )
 
         def get_eol(self):
             eol = super(ServiceLevel, self).get_eol()
@@ -170,9 +163,8 @@ if float(Modulemd._version) >= 2:
                 return None
 
             return datetime.date(
-                eol.get_year(),
-                eol.get_month(),
-                eol.get_day())
+                eol.get_year(), eol.get_month(), eol.get_day()
+            )
 
     ServiceLevel = override(ServiceLevel)
     __all__.append(ServiceLevel)

--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,7 @@ test_cflags = [
   '-Werror=return-type',
   '-Werror=array-bounds',
   '-Werror=write-strings',
-  '-D_POSIX_SOURCE',
+  '-D_GNU_SOURCE',
   '-DG_LOG_USE_STRUCTURED',
   '-DG_LOG_DOMAIN="libmodulemd"',
 ]

--- a/modulemd/clang_simple_version.sh
+++ b/modulemd/clang_simple_version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/sh
+
+$1 --version | awk '/LLVM version/ {print $NF}' -
+

--- a/modulemd/include/modulemd-2.0/modulemd-component-module.h
+++ b/modulemd/include/modulemd-2.0/modulemd-component-module.h
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include <glib-object.h>
 #include "modulemd-component.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/modulemd-2.0/modulemd-component-rpm.h
+++ b/modulemd/include/modulemd-2.0/modulemd-component-rpm.h
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include <glib-object.h>
 #include "modulemd-component.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/modulemd-2.0/modulemd-defaults-v1.h
+++ b/modulemd/include/modulemd-2.0/modulemd-defaults-v1.h
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include <glib-object.h>
 #include "modulemd-defaults.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/modulemd-2.0/modulemd-module-index-merger.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-index-merger.h
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include <glib-object.h>
 #include "modulemd-module-index.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-index.h
@@ -13,10 +13,10 @@
 
 #pragma once
 
-#include <glib-object.h>
 #include "modulemd-module.h"
-#include "modulemd-translation.h"
 #include "modulemd-subdocument-info.h"
+#include "modulemd-translation.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/modulemd-2.0/modulemd-module-stream-v1.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-stream-v1.h
@@ -13,15 +13,15 @@
 
 #pragma once
 
-#include <glib-object.h>
 #include "modulemd-buildopts.h"
-#include "modulemd-component.h"
 #include "modulemd-component-module.h"
 #include "modulemd-component-rpm.h"
+#include "modulemd-component.h"
 #include "modulemd-deprecated.h"
 #include "modulemd-module-stream.h"
 #include "modulemd-profile.h"
 #include "modulemd-service-level.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/modulemd-2.0/modulemd-module-stream-v2.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-stream-v2.h
@@ -13,16 +13,16 @@
 
 #pragma once
 
-#include <glib-object.h>
 #include "modulemd-buildopts.h"
-#include "modulemd-component.h"
 #include "modulemd-component-module.h"
 #include "modulemd-component-rpm.h"
+#include "modulemd-component.h"
 #include "modulemd-dependencies.h"
 #include "modulemd-module-stream.h"
 #include "modulemd-profile.h"
 #include "modulemd-rpm-map-entry.h"
 #include "modulemd-service-level.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/modulemd-2.0/modulemd-module-stream.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-stream.h
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include <glib.h>
 #include <glib-object.h>
+#include <glib.h>
 #include <glib/gstdio.h>
 
 #include "modulemd-deprecated.h"

--- a/modulemd/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module.h
@@ -13,11 +13,11 @@
 
 #pragma once
 
-#include <glib-object.h>
 #include "modulemd-defaults.h"
 #include "modulemd-deprecated.h"
 #include "modulemd-module-stream.h"
 #include "modulemd-translation.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 
@@ -131,7 +131,7 @@ MMD_DEPRECATED_FOR (modulemd_module_get_stream_by_NSVCA)
 ModulemdModuleStream *
 modulemd_module_get_stream_by_NSVC (ModulemdModule *self,
                                     const gchar *stream_name,
-                                    const guint64 version,
+                                    guint64 version,
                                     const gchar *context);
 
 
@@ -158,7 +158,7 @@ modulemd_module_get_stream_by_NSVC (ModulemdModule *self,
 GPtrArray *
 modulemd_module_search_streams (ModulemdModule *self,
                                 const gchar *stream_name,
-                                const guint64 version,
+                                guint64 version,
                                 const gchar *context,
                                 const gchar *arch);
 
@@ -185,7 +185,7 @@ modulemd_module_search_streams (ModulemdModule *self,
 ModulemdModuleStream *
 modulemd_module_get_stream_by_NSVCA (ModulemdModule *self,
                                      const gchar *stream_name,
-                                     const guint64 version,
+                                     guint64 version,
                                      const gchar *context,
                                      const gchar *arch,
                                      GError **error);
@@ -210,7 +210,7 @@ modulemd_module_get_stream_by_NSVCA (ModulemdModule *self,
 void
 modulemd_module_remove_streams_by_NSVCA (ModulemdModule *self,
                                          const gchar *stream_name,
-                                         const guint64 version,
+                                         guint64 version,
                                          const gchar *context,
                                          const gchar *arch);
 

--- a/modulemd/include/modulemd-2.0/modulemd-translation.h
+++ b/modulemd/include/modulemd-2.0/modulemd-translation.h
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include <glib-object.h>
 #include "modulemd-translation-entry.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/modulemd-2.0/modulemd.h
+++ b/modulemd/include/modulemd-2.0/modulemd.h
@@ -14,27 +14,27 @@
 #pragma once
 
 #include "modulemd-buildopts.h"
-#include "modulemd-component.h"
 #include "modulemd-component-module.h"
 #include "modulemd-component-rpm.h"
+#include "modulemd-component.h"
 #include "modulemd-compression.h"
-#include "modulemd-defaults.h"
 #include "modulemd-defaults-v1.h"
+#include "modulemd-defaults.h"
 #include "modulemd-dependencies.h"
 #include "modulemd-deprecated.h"
 #include "modulemd-errors.h"
-#include "modulemd-module.h"
-#include "modulemd-module-index.h"
 #include "modulemd-module-index-merger.h"
-#include "modulemd-module-stream.h"
+#include "modulemd-module-index.h"
 #include "modulemd-module-stream-v1.h"
 #include "modulemd-module-stream-v2.h"
+#include "modulemd-module-stream.h"
+#include "modulemd-module.h"
 #include "modulemd-profile.h"
 #include "modulemd-rpm-map-entry.h"
 #include "modulemd-service-level.h"
 #include "modulemd-subdocument-info.h"
-#include "modulemd-translation.h"
 #include "modulemd-translation-entry.h"
+#include "modulemd-translation.h"
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/private/modulemd-defaults-v1-private.h
+++ b/modulemd/include/private/modulemd-defaults-v1-private.h
@@ -13,10 +13,10 @@
 
 #pragma once
 
-#include <glib-object.h>
-#include <yaml.h>
 #include "modulemd-defaults-v1.h"
 #include "modulemd-subdocument-info.h"
+#include <glib-object.h>
+#include <yaml.h>
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/private/modulemd-module-index-private.h
+++ b/modulemd/include/private/modulemd-module-index-private.h
@@ -13,9 +13,9 @@
 
 #pragma once
 
+#include "modulemd-module-index.h"
 #include <glib-object.h>
 #include <yaml.h>
-#include "modulemd-module-index.h"
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/private/modulemd-module-stream-private.h
+++ b/modulemd/include/private/modulemd-module-stream-private.h
@@ -13,13 +13,13 @@
 
 #pragma once
 
-#include <glib-object.h>
 #include "modulemd-module-stream.h"
-#include "modulemd-translation.h"
 #include "modulemd-translation-entry.h"
-#include "private/modulemd-yaml.h"
+#include "modulemd-translation.h"
 #include "private/modulemd-module-stream-v1-private.h"
 #include "private/modulemd-module-stream-v2-private.h"
+#include "private/modulemd-yaml.h"
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 

--- a/modulemd/include/private/modulemd-module-stream-v1-private.h
+++ b/modulemd/include/private/modulemd-module-stream-v1-private.h
@@ -13,10 +13,10 @@
 
 #pragma once
 
-#include <glib-object.h>
-#include <yaml.h>
 #include "modulemd-module-stream-v1.h"
 #include "modulemd-subdocument-info.h"
+#include <glib-object.h>
+#include <yaml.h>
 
 
 G_BEGIN_DECLS

--- a/modulemd/include/private/modulemd-module-stream-v2-private.h
+++ b/modulemd/include/private/modulemd-module-stream-v2-private.h
@@ -13,10 +13,10 @@
 
 #pragma once
 
-#include <glib-object.h>
-#include <yaml.h>
 #include "modulemd-module-stream-v2.h"
 #include "modulemd-subdocument-info.h"
+#include <glib-object.h>
+#include <yaml.h>
 
 
 G_BEGIN_DECLS

--- a/modulemd/include/private/modulemd-yaml.h
+++ b/modulemd/include/private/modulemd-yaml.h
@@ -646,7 +646,7 @@ mmd_emitter_scalar (yaml_emitter_t *emitter,
 gboolean
 mmd_emitter_strv (yaml_emitter_t *emitter,
                   yaml_sequence_style_t seq_style,
-                  const GStrv list,
+                  GStrv list,
                   GError **error);
 
 

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -21,16 +21,15 @@ if not clang_format.found()
     clang_format = disabler()
 endif
 
+python_formatter = find_program('black', required : developer_build)
+if not python_formatter.found()
+    python_formatter = disabler()
+endif
+
 pycodestyle = find_program('pycodestyle-3', 'pycodestyle',
                            required : developer_build)
 if not pycodestyle.found()
     pycodestyle = disabler()
-endif
-
-autopep8 = find_program('python3-autopep8', 'autopep8',
-                        required : developer_build)
-if not autopep8.found()
-    autopep8 = disabler()
 endif
 
 valgrind = find_program('valgrind', required: developer_build)
@@ -393,23 +392,24 @@ test('clang_format', clang_format,
 
 
 # Fake test to ensure that the python tests are formatted according to PEP8
-autopep8_args = [ '--in-place', '-a', '-a', '--global-config', '../tox.ini' ]
-autopep8_scripts = [ files('tests/test-dirty.py',
-                           'tests/test-valgrind.py',
-                           '../bindings/python/gi/overrides/Modulemd.py') +
-                     test_python_scripts ]
-test('autopep8', autopep8,
-     args: autopep8_args + autopep8_scripts)
+python_formatter_args = [ '--verbose', '--line-length', '79' ]
+test('python_formatter', python_formatter,
+     args: python_formatter_args + [ meson.source_root() ] )
 
 
 # Test all python files for compliance with pycodestyle
 # Ignore line-length as there are a number of places where this is unavoidable
+python_scripts = [ files('tests/test-dirty.py',
+                         'tests/test-valgrind.py',
+                         '../bindings/python/gi/overrides/Modulemd.py') +
+                   test_python_scripts ]
+
 pycodestyle_args = [
     '--show-pep8',
     '--ignore=E121,E123,E126,E226,E24,E501,E704,W503,W504'
 ]
 test('pycodestyle', pycodestyle,
-     args: pycodestyle_args + autopep8_scripts)
+     args: pycodestyle_args + python_scripts)
 
 
 # Fake test to ensure that the autoformatters didn't end up making changes

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -16,9 +16,37 @@ test_dirty_git = get_option('test_dirty_git')
 test_installed_lib = get_option('test_installed_lib')
 skip_introspection = get_option('skip_introspection')
 
-clang_format = find_program('clang-format', required: developer_build)
-if not clang_format.found()
+clang_simple_version_script = find_program ('clang_simple_version.sh')
+clang_tidy = find_program('clang-tidy', required: false)
+if clang_tidy.found()
+    ret = run_command (clang_simple_version_script, clang_tidy.path())
+    if ret.returncode() != 0
+        warning('Unable to determine clang-tidy version.')
+        clang_tidy = disabler()
+    else
+        clang_tidy_version = ret.stdout().strip()
+
+        # Older versions of clang_tidy have issues with producing changes that
+        # do not compile. Only use this tool if we have a sufficiently new
+        # version.
+        if not clang_tidy_version.version_compare('>=9.0.0')
+            warning('clang-tidy version too old: ' +
+                    clang_tidy_version +
+                    ' < 9.0.0')
+            clang_tidy = disabler()
+        endif
+    endif
+else
+    clang_tidy = disabler()
+endif
+
+if clang_tidy.found()
     clang_format = disabler()
+else
+    clang_format = find_program('clang-format', required: developer_build)
+    if not clang_format.found()
+        clang_format = disabler()
+    endif
 endif
 
 python_formatter = find_program('black', required : developer_build)
@@ -380,15 +408,20 @@ endforeach
 
 
 # Fake test to ensure that all sources and headers are formatted properly
+clang_files = modulemd_srcs + modulemd_hdrs + modulemd_priv_hdrs + modulemd_validator_srcs + test_srcs + test_priv_hdrs
+
 clang_args = [ '-i' ]
 test('clang_format', clang_format,
-     args : clang_args +
-            modulemd_srcs +
-            modulemd_hdrs +
-            modulemd_priv_hdrs +
-            modulemd_validator_srcs +
-            test_srcs +
-            test_priv_hdrs)
+     args : clang_args + clang_files)
+
+clang_tidy_args = [ '-p', meson.build_root(),
+                    '--checks=*,-llvm-header-guard,-bugprone-macro-parentheses',
+                    '--format-style=file',
+                    '--fix',
+                    '--fix-errors' ]
+test('clang_tidy', clang_tidy,
+     args: clang_tidy_args + clang_files,
+     timeout: 300)
 
 
 # Fake test to ensure that the python tests are formatted according to PEP8

--- a/modulemd/modulemd-buildopts.c
+++ b/modulemd/modulemd-buildopts.c
@@ -50,20 +50,28 @@ modulemd_buildopts_equals (ModulemdBuildopts *self_1,
                            ModulemdBuildopts *self_2)
 {
   if (!self_1 && !self_2)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   if (!self_1 || !self_2)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_BUILDOPTS (self_1), FALSE);
   g_return_val_if_fail (MODULEMD_IS_BUILDOPTS (self_2), FALSE);
 
   if (!modulemd_hash_table_sets_are_equal (self_1->whitelist,
                                            self_2->whitelist))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (self_1->rpm_macros, self_2->rpm_macros) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -266,8 +274,10 @@ modulemd_buildopts_parse_yaml (yaml_parser_t *parser,
 
         case YAML_SCALAR_EVENT:
           if (!in_map)
-            MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-              error, event, "Missing mapping in buildopts");
+            {
+              MMD_YAML_ERROR_EVENT_EXIT_BOOL (
+                error, event, "Missing mapping in buildopts");
+            }
 
           if (g_str_equal ((const gchar *)event.data.scalar.value, "rpms"))
             {
@@ -330,8 +340,10 @@ modulemd_buildopts_parse_rpm_buildopts (yaml_parser_t *parser,
 
         case YAML_SCALAR_EVENT:
           if (!in_map)
-            MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-              error, event, "Missing mapping in buildopts rpms entry");
+            {
+              MMD_YAML_ERROR_EVENT_EXIT_BOOL (
+                error, event, "Missing mapping in buildopts rpms entry");
+            }
 
           if (g_str_equal (event.data.scalar.value, "whitelist"))
             {
@@ -351,11 +363,13 @@ modulemd_buildopts_parse_rpm_buildopts (yaml_parser_t *parser,
             {
               value = modulemd_yaml_parse_string (parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-                  error,
-                  event,
-                  "Failed to parse rpm_macros in buildopts: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT_BOOL (
+                    error,
+                    event,
+                    "Failed to parse rpm_macros in buildopts: %s",
+                    nested_error->message);
+                }
               modulemd_buildopts_set_rpm_macros (buildopts, value);
               g_clear_pointer (&value, g_free);
             }

--- a/modulemd/modulemd-component-module.c
+++ b/modulemd/modulemd-component-module.c
@@ -12,8 +12,8 @@
  */
 
 #include "modulemd-component-module.h"
-#include "private/modulemd-component-private.h"
 #include "private/modulemd-component-module-private.h"
+#include "private/modulemd-component-private.h"
 #include "private/modulemd-util.h"
 #include "private/modulemd-yaml.h"
 
@@ -77,13 +77,19 @@ modulemd_component_module_equals (ModulemdComponent *self_1,
 
   if (!MODULEMD_COMPONENT_CLASS (modulemd_component_module_parent_class)
          ->equals (self_1, self_2))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (module_self_1->ref, module_self_2->ref) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (module_self_1->repository, module_self_2->repository) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -245,39 +251,53 @@ modulemd_component_module_emit_yaml (ModulemdComponentModule *self,
 
   if (!modulemd_component_emit_yaml_start (
         MODULEMD_COMPONENT (self), emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (modulemd_component_module_get_repository (self) != NULL)
     {
       if (!mmd_emitter_scalar (
             emitter, "repository", YAML_PLAIN_SCALAR_STYLE, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       if (!mmd_emitter_scalar (emitter,
                                modulemd_component_module_get_repository (self),
                                YAML_PLAIN_SCALAR_STYLE,
                                error))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   if (modulemd_component_module_get_ref (self) != NULL)
     {
       if (!mmd_emitter_scalar (emitter, "ref", YAML_PLAIN_SCALAR_STYLE, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       if (!mmd_emitter_scalar (emitter,
                                modulemd_component_module_get_ref (self),
                                YAML_PLAIN_SCALAR_STYLE,
                                error))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   if (!modulemd_component_emit_yaml_build_common (
         MODULEMD_COMPONENT (self), emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_end_mapping (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -328,11 +348,13 @@ modulemd_component_module_parse_yaml (yaml_parser_t *parser,
             {
               value = modulemd_yaml_parse_string (parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse rationale in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse rationale in component: %s",
+                    nested_error->message);
+                }
 
               modulemd_component_set_rationale (MODULEMD_COMPONENT (m), value);
               g_clear_pointer (&value, g_free);
@@ -342,11 +364,13 @@ modulemd_component_module_parse_yaml (yaml_parser_t *parser,
             {
               value = modulemd_yaml_parse_string (parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse repository in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse repository in component: %s",
+                    nested_error->message);
+                }
 
               modulemd_component_module_set_repository (m, value);
               g_clear_pointer (&value, g_free);
@@ -355,11 +379,13 @@ modulemd_component_module_parse_yaml (yaml_parser_t *parser,
             {
               value = modulemd_yaml_parse_string (parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse ref in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse ref in component: %s",
+                    nested_error->message);
+                }
 
               modulemd_component_module_set_ref (m, value);
               g_clear_pointer (&value, g_free);
@@ -382,11 +408,13 @@ modulemd_component_module_parse_yaml (yaml_parser_t *parser,
             {
               buildorder = modulemd_yaml_parse_int64 (parser, &nested_error);
               if (buildorder == 0 && nested_error != NULL)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse buildorder in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse buildorder in component: %s",
+                    nested_error->message);
+                }
 
               modulemd_component_set_buildorder (MODULEMD_COMPONENT (m),
                                                  buildorder);

--- a/modulemd/modulemd-component-rpm.c
+++ b/modulemd/modulemd-component-rpm.c
@@ -91,34 +91,52 @@ modulemd_component_rpm_equals (ModulemdComponent *self_1,
 
   if (!MODULEMD_COMPONENT_CLASS (modulemd_component_rpm_parent_class)
          ->equals (self_1, self_2))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (rpm_self_1->override_name, rpm_self_2->override_name) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (rpm_self_1->ref, rpm_self_2->ref) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (rpm_self_1->repository, rpm_self_2->repository) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (rpm_self_1->cache, rpm_self_2->cache) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!modulemd_boolean_equals (rpm_self_1->buildroot, rpm_self_2->buildroot))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!modulemd_boolean_equals (rpm_self_1->srpm_buildroot,
                                 rpm_self_2->srpm_buildroot))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!modulemd_hash_table_sets_are_equal (rpm_self_1->arches,
                                            rpm_self_2->arches))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!modulemd_hash_table_sets_are_equal (rpm_self_1->multilib,
                                            rpm_self_2->multilib))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -224,7 +242,9 @@ modulemd_component_rpm_get_name (ModulemdComponent *self)
 
   /* If an override name was set, return it */
   if (rpm_self->override_name)
-    return rpm_self->override_name;
+    {
+      return rpm_self->override_name;
+    }
 
   /* Otherwise, return the hash table key as the name */
   return MODULEMD_COMPONENT_CLASS (modulemd_component_rpm_parent_class)
@@ -535,7 +555,9 @@ modulemd_component_rpm_emit_yaml (ModulemdComponentRpm *self,
 
   if (!modulemd_component_emit_yaml_start (
         MODULEMD_COMPONENT (self), emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   EMIT_KEY_VALUE_IF_SET (emitter, error, "name", self->override_name);
 
@@ -547,26 +569,36 @@ modulemd_component_rpm_emit_yaml (ModulemdComponentRpm *self,
 
   /* Only output buildroot if it's TRUE */
   if (modulemd_component_rpm_get_buildroot (self))
-    EMIT_KEY_VALUE (emitter, error, "buildroot", "true");
+    {
+      EMIT_KEY_VALUE (emitter, error, "buildroot", "true");
+    }
 
   /* Only output srpm-buildroot if it's TRUE */
   if (modulemd_component_rpm_get_srpm_buildroot (self))
-    EMIT_KEY_VALUE (emitter, error, "srpm-buildroot", "true");
+    {
+      EMIT_KEY_VALUE (emitter, error, "srpm-buildroot", "true");
+    }
 
   if (!modulemd_component_emit_yaml_build_common (
         MODULEMD_COMPONENT (self), emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_hash_table_size (self->arches) != 0)
     {
       if (!mmd_emitter_scalar (
             emitter, "arches", YAML_PLAIN_SCALAR_STYLE, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       list = modulemd_component_rpm_get_arches_as_strv (self);
 
       if (!mmd_emitter_strv (emitter, YAML_FLOW_SEQUENCE_STYLE, list, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       g_clear_pointer (&list, g_strfreev);
     }
@@ -575,18 +607,24 @@ modulemd_component_rpm_emit_yaml (ModulemdComponentRpm *self,
     {
       if (!mmd_emitter_scalar (
             emitter, "multilib", YAML_PLAIN_SCALAR_STYLE, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       list = modulemd_component_rpm_get_multilib_arches_as_strv (self);
 
       if (!mmd_emitter_strv (emitter, YAML_FLOW_SEQUENCE_STYLE, list, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       g_clear_pointer (&list, g_strfreev);
     }
 
   if (!mmd_emitter_end_mapping (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -639,11 +677,13 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
             {
               value = modulemd_yaml_parse_string (parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse rationale in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse rationale in component: %s",
+                    nested_error->message);
+                }
 
               modulemd_component_set_rationale (MODULEMD_COMPONENT (r), value);
               g_clear_pointer (&value, g_free);
@@ -653,11 +693,13 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
             {
               value = modulemd_yaml_parse_string (parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse override name in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse override name in component: %s",
+                    nested_error->message);
+                }
 
               modulemd_component_set_name (MODULEMD_COMPONENT (r), value);
               g_clear_pointer (&value, g_free);
@@ -668,11 +710,13 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
             {
               value = modulemd_yaml_parse_string (parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse repository in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse repository in component: %s",
+                    nested_error->message);
+                }
 
               modulemd_component_rpm_set_repository (r, value);
               g_clear_pointer (&value, g_free);
@@ -681,11 +725,13 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
             {
               value = modulemd_yaml_parse_string (parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse ref in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse ref in component: %s",
+                    nested_error->message);
+                }
 
               modulemd_component_rpm_set_ref (r, value);
               g_clear_pointer (&value, g_free);
@@ -695,11 +741,13 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
             {
               value = modulemd_yaml_parse_string (parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse cache in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse cache in component: %s",
+                    nested_error->message);
+                }
 
               modulemd_component_rpm_set_cache (r, value);
               g_clear_pointer (&value, g_free);
@@ -709,11 +757,13 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
             {
               list = modulemd_yaml_parse_string_set (parser, &nested_error);
               if (!list)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse arches in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse arches in component: %s",
+                    nested_error->message);
+                }
 
               g_clear_pointer (&r->arches, g_hash_table_unref);
               r->arches = g_steal_pointer (&list);
@@ -723,11 +773,13 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
             {
               list = modulemd_yaml_parse_string_set (parser, &nested_error);
               if (!list)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse arches in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse arches in component: %s",
+                    nested_error->message);
+                }
 
               g_clear_pointer (&r->multilib, g_hash_table_unref);
               r->multilib = g_steal_pointer (&list);
@@ -793,11 +845,13 @@ modulemd_component_rpm_parse_yaml (yaml_parser_t *parser,
             {
               buildorder = modulemd_yaml_parse_int64 (parser, &nested_error);
               if (buildorder == 0 && nested_error != NULL)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse buildorder in component: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse buildorder in component: %s",
+                    nested_error->message);
+                }
 
               modulemd_component_set_buildorder (MODULEMD_COMPONENT (r),
                                                  buildorder);

--- a/modulemd/modulemd-component.c
+++ b/modulemd/modulemd-component.c
@@ -65,10 +65,14 @@ modulemd_component_equals (ModulemdComponent *self_1,
                            ModulemdComponent *self_2)
 {
   if (!self_1 && !self_2)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   if (!self_1 || !self_2)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_COMPONENT (self_1), FALSE);
   g_return_val_if_fail (MODULEMD_IS_COMPONENT (self_2), FALSE);
@@ -115,7 +119,9 @@ static gboolean
 modulemd_component_default_validate (ModulemdComponent *self, GError **error)
 {
   if (!self)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   ModulemdComponentPrivate *priv =
     modulemd_component_get_instance_private (self);
@@ -145,7 +151,9 @@ modulemd_component_validate (ModulemdComponent *self, GError **error)
   ModulemdComponentClass *klass;
 
   if (!self)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_COMPONENT (self), FALSE);
 
@@ -164,7 +172,9 @@ modulemd_component_copy_component (ModulemdComponent *self, const gchar *key)
   ModulemdComponentPrivate *m_priv = NULL;
   g_autoptr (ModulemdComponent) m = NULL;
   if (key == NULL)
-    key = priv->name;
+    {
+      key = priv->name;
+    }
 
   m = g_object_new (G_OBJECT_TYPE (self), "name", key, NULL);
 
@@ -190,24 +200,34 @@ modulemd_component_default_equals (ModulemdComponent *self_1,
 {
   if (modulemd_component_get_buildorder (self_1) !=
       modulemd_component_get_buildorder (self_2))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (modulemd_component_get_buildonly (self_1) !=
       modulemd_component_get_buildonly (self_2))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (modulemd_component_get_name (self_1),
                  modulemd_component_get_name (self_2)) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (modulemd_component_get_rationale (self_1),
                  modulemd_component_get_rationale (self_2)) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!modulemd_hash_table_sets_are_equal (
         modulemd_component_get_buildafter_internal (self_1),
         modulemd_component_get_buildafter_internal (self_2)))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -348,7 +368,9 @@ modulemd_component_set_name (ModulemdComponent *self, const gchar *name)
 
   /* Do nothing if the child class has not implemented this */
   if (!klass->set_name)
-    return;
+    {
+      return;
+    }
 
   klass->set_name (self, name);
 }
@@ -600,22 +622,30 @@ modulemd_component_emit_yaml_start (ModulemdComponent *self,
 
   if (!mmd_emitter_scalar (
         emitter, priv->name, YAML_PLAIN_SCALAR_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_start_mapping (emitter, YAML_BLOCK_MAPPING_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (modulemd_component_get_rationale (self) != NULL)
     {
       if (!mmd_emitter_scalar (
             emitter, "rationale", YAML_PLAIN_SCALAR_STYLE, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       if (!mmd_emitter_scalar (emitter,
                                modulemd_component_get_rationale (self),
                                YAML_PLAIN_SCALAR_STYLE,
                                error))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   /* The rest of the fields are emitted by childs, after which they need to call
@@ -644,11 +674,15 @@ modulemd_component_emit_yaml_build_common (ModulemdComponent *self,
       ;
       if (!mmd_emitter_scalar (
             emitter, "buildorder", YAML_PLAIN_SCALAR_STYLE, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       if (!mmd_emitter_scalar (
             emitter, buildorder, YAML_PLAIN_SCALAR_STYLE, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   else if (g_hash_table_size (priv->buildafter))

--- a/modulemd/modulemd-compression.c
+++ b/modulemd/modulemd-compression.c
@@ -15,6 +15,7 @@
 #include <glib.h>
 #include <inttypes.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 
 #ifdef HAVE_RPMIO
@@ -81,13 +82,15 @@ modulemd_detect_compression (const gchar *filename, int fd, GError **error)
   /* No known suffix? Try using libmagic from file-utils */
   const char *mime_type;
   g_auto (magic_t) magic = NULL;
-  int magic_fd = dup (fd);
+  int magic_fd = fcntl (fd, F_DUPFD_CLOEXEC, 0);
+  int err = errno;
   if (magic_fd < 0)
     {
       g_set_error (error,
                    MODULEMD_ERROR,
                    MODULEMD_ERROR_MAGIC,
-                   "Could not dup() the file descriptor");
+                   "Could not dup() the file descriptor: %s",
+                   g_strerror (err));
       return MODULEMD_COMPRESSION_TYPE_DETECTION_FAILED;
     }
 

--- a/modulemd/modulemd-compression.c
+++ b/modulemd/modulemd-compression.c
@@ -12,10 +12,10 @@
  */
 
 #include <errno.h>
+#include <fcntl.h>
 #include <glib.h>
 #include <inttypes.h>
 #include <unistd.h>
-#include <fcntl.h>
 
 
 #ifdef HAVE_RPMIO
@@ -25,8 +25,8 @@
 #include "modulemd-compression.h"
 #include "modulemd-errors.h"
 
-#include "private/modulemd-util.h"
 #include "private/modulemd-compression-private.h"
+#include "private/modulemd-util.h"
 
 #ifdef HAVE_LIBMAGIC
 #include <magic.h>
@@ -62,18 +62,18 @@ modulemd_detect_compression (const gchar *filename, int fd, GError **error)
     {
       return MODULEMD_COMPRESSION_TYPE_GZ_COMPRESSION;
     }
-  else if (g_str_has_suffix (filename, ".bz2") ||
-           g_str_has_suffix (filename, ".bzip2"))
+  if (g_str_has_suffix (filename, ".bz2") ||
+      g_str_has_suffix (filename, ".bzip2"))
     {
       return MODULEMD_COMPRESSION_TYPE_BZ2_COMPRESSION;
     }
-  else if (g_str_has_suffix (filename, ".xz"))
+  if (g_str_has_suffix (filename, ".xz"))
     {
       return MODULEMD_COMPRESSION_TYPE_XZ_COMPRESSION;
     }
-  else if (g_str_has_suffix (filename, ".yaml") ||
-           g_str_has_suffix (filename, ".yml") ||
-           g_str_has_suffix (filename, ".txt"))
+  if (g_str_has_suffix (filename, ".yaml") ||
+      g_str_has_suffix (filename, ".yml") ||
+      g_str_has_suffix (filename, ".txt"))
     {
       return MODULEMD_COMPRESSION_TYPE_NO_COMPRESSION;
     }
@@ -179,19 +179,29 @@ ModulemdCompressionTypeEnum
 modulemd_compression_type (const gchar *name)
 {
   if (!name)
-    return MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION;
+    {
+      return MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION;
+    }
 
   int type = MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION;
 
   if (!g_strcmp0 (name, "gz") || !g_strcmp0 (name, "gzip") ||
       !g_strcmp0 (name, "gunzip"))
-    type = MODULEMD_COMPRESSION_TYPE_GZ_COMPRESSION;
+    {
+      type = MODULEMD_COMPRESSION_TYPE_GZ_COMPRESSION;
+    }
   if (!g_strcmp0 (name, "bz2") || !g_strcmp0 (name, "bzip2"))
-    type = MODULEMD_COMPRESSION_TYPE_BZ2_COMPRESSION;
+    {
+      type = MODULEMD_COMPRESSION_TYPE_BZ2_COMPRESSION;
+    }
   if (!g_strcmp0 (name, "xz"))
-    type = MODULEMD_COMPRESSION_TYPE_XZ_COMPRESSION;
+    {
+      type = MODULEMD_COMPRESSION_TYPE_XZ_COMPRESSION;
+    }
   if (!g_strcmp0 (name, "zck"))
-    type = MODULEMD_COMPRESSION_TYPE_ZCK_COMPRESSION;
+    {
+      type = MODULEMD_COMPRESSION_TYPE_ZCK_COMPRESSION;
+    }
 
   return type;
 }
@@ -240,12 +250,16 @@ modulemd_get_rpmio_fmode (const gchar *mode,
   const gchar *type_string;
 
   if (!mode)
-    return NULL;
+    {
+      return NULL;
+    }
 
   type_string = get_comtype_string (comtype);
 
   if (type_string == NULL)
-    return NULL;
+    {
+      return NULL;
+    }
 
   return g_strdup_printf ("%s.%s", mode, type_string);
 }

--- a/modulemd/modulemd-defaults.c
+++ b/modulemd/modulemd-defaults.c
@@ -12,13 +12,13 @@
  */
 
 
-#include <inttypes.h>
 #include "modulemd-defaults.h"
 #include "modulemd-defaults-v1.h"
 #include "modulemd-errors.h"
 #include "private/modulemd-defaults-private.h"
 #include "private/modulemd-defaults-v1-private.h"
 #include "private/modulemd-util.h"
+#include <inttypes.h>
 
 #define DEF_DEFAULT_NAME_STRING "__NAME_UNSET__"
 
@@ -51,10 +51,14 @@ modulemd_defaults_equals (ModulemdDefaults *self_1, ModulemdDefaults *self_2)
   ModulemdDefaultsClass *klass;
 
   if (!self_1 && !self_2)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   if (!self_1 || !self_2)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_DEFAULTS (self_1), FALSE);
   g_return_val_if_fail (MODULEMD_IS_DEFAULTS (self_2), FALSE);
@@ -72,15 +76,21 @@ modulemd_defaults_default_equals (ModulemdDefaults *self_1,
 {
   if (g_strcmp0 (modulemd_defaults_get_module_name (self_1),
                  modulemd_defaults_get_module_name (self_2)) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (modulemd_defaults_get_modified (self_1) !=
       modulemd_defaults_get_modified (self_2))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (modulemd_defaults_get_mdversion (self_1) !=
       modulemd_defaults_get_mdversion (self_2))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -121,7 +131,9 @@ modulemd_defaults_copy (ModulemdDefaults *self)
   ModulemdDefaultsClass *klass;
 
   if (!self)
-    return NULL;
+    {
+      return NULL;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_DEFAULTS (self), NULL);
 
@@ -152,7 +164,9 @@ modulemd_defaults_validate (ModulemdDefaults *self, GError **error)
   ModulemdDefaultsClass *klass;
 
   if (!self)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_DEFAULTS (self), FALSE);
 
@@ -178,7 +192,7 @@ modulemd_defaults_default_validate (ModulemdDefaults *self, GError **error)
                            "Metadata version is unset.");
       return FALSE;
     }
-  else if (mdversion > MD_DEFAULTS_VERSION_LATEST)
+  if (mdversion > MD_DEFAULTS_VERSION_LATEST)
     {
       g_set_error (error,
                    MODULEMD_ERROR,
@@ -220,7 +234,9 @@ modulemd_defaults_upgrade (ModulemdDefaults *self,
   g_assert_true (MODULEMD_IS_DEFAULTS (self));
 
   if (!mdversion)
-    mdversion = MD_DEFAULTS_VERSION_LATEST;
+    {
+      mdversion = MD_DEFAULTS_VERSION_LATEST;
+    }
 
   if (mdversion > MD_DEFAULTS_VERSION_LATEST)
     {

--- a/modulemd/modulemd-dependencies.c
+++ b/modulemd/modulemd-dependencies.c
@@ -50,10 +50,14 @@ modulemd_dependencies_equals (ModulemdDependencies *self_1,
                               ModulemdDependencies *self_2)
 {
   if (!self_1 && !self_2)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   if (!self_1 || !self_2)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_DEPENDENCIES (self_1), FALSE);
   g_return_val_if_fail (MODULEMD_IS_DEPENDENCIES (self_2), FALSE);
@@ -61,12 +65,16 @@ modulemd_dependencies_equals (ModulemdDependencies *self_1,
   if (!modulemd_hash_table_equals (self_1->buildtime_deps,
                                    self_2->buildtime_deps,
                                    modulemd_hash_table_sets_are_equal_wrapper))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!modulemd_hash_table_equals (self_1->runtime_deps,
                                    self_2->runtime_deps,
                                    modulemd_hash_table_sets_are_equal_wrapper))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -110,7 +118,9 @@ modulemd_dependencies_nested_table_get_or_create (GHashTable *table,
   GHashTable *inner = NULL;
   inner = g_hash_table_lookup (table, key);
   if (inner != NULL)
-    return inner;
+    {
+      return inner;
+    }
 
   // We know that the hash table will end up holding on to it for us.
   keyi = g_strdup (key);
@@ -131,7 +141,9 @@ modulemd_dependencies_nested_table_add (GHashTable *table,
     modulemd_dependencies_nested_table_get_or_create (table, key);
   g_return_if_fail (inner);
   if (value != NULL)
-    g_hash_table_add (inner, g_strdup (value));
+    {
+      g_hash_table_add (inner, g_strdup (value));
+    }
 }
 
 
@@ -254,7 +266,8 @@ static gboolean
 modulemd_dependencies_validate_deps (GHashTable *deps, GError **error)
 {
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
   gchar *module_name = NULL;
   gchar *stream_name = NULL;
   gssize signedness = 0;
@@ -412,11 +425,13 @@ modulemd_dependencies_parse_yaml_nested_set (yaml_parser_t *parser,
           key = g_strdup ((const gchar *)event.data.scalar.value);
           if (g_hash_table_contains (t,
                                      (const gchar *)event.data.scalar.value))
-            MMD_YAML_ERROR_EVENT_EXIT (
-              error,
-              event,
-              "Key %s encountered twice in dependencies",
-              (const gchar *)event.data.scalar.value);
+            {
+              MMD_YAML_ERROR_EVENT_EXIT (
+                error,
+                event,
+                "Key %s encountered twice in dependencies",
+                (const gchar *)event.data.scalar.value);
+            }
 
           value = modulemd_yaml_parse_string_set (parser, &nested_error);
           if (value == NULL)
@@ -670,7 +685,8 @@ requires_module_and_stream (GHashTable *modules,
 {
   GHashTable *streams = NULL;
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
   g_autofree gchar *negated = NULL;
 
   streams = g_hash_table_lookup (modules, module_name);

--- a/modulemd/modulemd-module-index-merger.c
+++ b/modulemd/modulemd-module-index-merger.c
@@ -11,14 +11,14 @@
  * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
  */
 
-#include <glib.h>
 #include "modulemd-defaults.h"
-#include "modulemd-module.h"
-#include "modulemd-module-index.h"
 #include "modulemd-module-index-merger.h"
+#include "modulemd-module-index.h"
 #include "modulemd-module-stream.h"
+#include "modulemd-module.h"
 #include "private/modulemd-module-index-private.h"
 #include "private/modulemd-util.h"
+#include <glib.h>
 
 
 typedef struct _priorities

--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -21,20 +21,20 @@
 #include <rpm/rpmio.h>
 #endif
 
-#include "modulemd-errors.h"
 #include "modulemd-compression.h"
+#include "modulemd-errors.h"
 #include "modulemd-module-index.h"
 #include "modulemd-subdocument-info.h"
 #include "private/glib-extensions.h"
-#include "private/modulemd-module-private.h"
 #include "private/modulemd-compression-private.h"
 #include "private/modulemd-defaults-private.h"
 #include "private/modulemd-defaults-v1-private.h"
-#include "private/modulemd-subdocument-info-private.h"
 #include "private/modulemd-module-index-private.h"
+#include "private/modulemd-module-private.h"
 #include "private/modulemd-module-stream-private.h"
 #include "private/modulemd-module-stream-v1-private.h"
 #include "private/modulemd-module-stream-v2-private.h"
+#include "private/modulemd-subdocument-info-private.h"
 #include "private/modulemd-translation-private.h"
 #include "private/modulemd-util.h"
 #include "private/modulemd-yaml.h"
@@ -168,7 +168,9 @@ add_subdoc (ModulemdModuleIndex *self,
         }
 
       if (stream == NULL)
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       if (autogen_module_name &&
           !modulemd_module_stream_get_module_name (stream))
@@ -190,7 +192,9 @@ add_subdoc (ModulemdModuleIndex *self,
 
 
       if (!modulemd_module_index_add_module_stream (self, stream, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       break;
 
@@ -201,9 +205,13 @@ add_subdoc (ModulemdModuleIndex *self,
           defaults = (ModulemdDefaults *)modulemd_defaults_v1_parse_yaml (
             subdoc, strict, error);
           if (defaults == NULL)
-            return FALSE;
+            {
+              return FALSE;
+            }
           if (!modulemd_module_index_add_defaults (self, defaults, error))
-            return FALSE;
+            {
+              return FALSE;
+            }
           break;
 
         default:
@@ -218,9 +226,13 @@ add_subdoc (ModulemdModuleIndex *self,
     case MODULEMD_YAML_DOC_TRANSLATIONS:
       translation = modulemd_translation_parse_yaml (subdoc, strict, error);
       if (translation == NULL)
-        return FALSE;
+        {
+          return FALSE;
+        }
       if (!modulemd_module_index_add_translation (self, translation, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
       break;
 
     default:
@@ -249,12 +261,16 @@ modulemd_module_index_update_from_parser (ModulemdModuleIndex *self,
   MMD_INIT_YAML_EVENT (event);
 
   if (*failures == NULL)
-    *failures = g_ptr_array_new_with_free_func (g_object_unref);
+    {
+      *failures = g_ptr_array_new_with_free_func (g_object_unref);
+    }
 
   YAML_PARSER_PARSE_WITH_EXIT_BOOL (parser, &event, error);
   if (event.type != YAML_STREAM_START_EVENT)
-    MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-      error, event, "Did not encounter stream start");
+    {
+      MMD_YAML_ERROR_EVENT_EXIT_BOOL (
+        error, event, "Did not encounter stream start");
+    }
 
   while (!done)
     {
@@ -309,7 +325,9 @@ dump_defaults (ModulemdModule *module, yaml_emitter_t *emitter, GError **error)
   g_autoptr (GError) nested_error = NULL;
 
   if (defaults == NULL)
-    return TRUE; /* Nothing to dump -> all a success */
+    {
+      return TRUE; /* Nothing to dump -> all a success */
+    }
 
   if (!modulemd_defaults_validate (defaults, &nested_error))
     {
@@ -323,7 +341,9 @@ dump_defaults (ModulemdModule *module, yaml_emitter_t *emitter, GError **error)
     {
       if (!modulemd_defaults_v1_emit_yaml (
             (ModulemdDefaultsV1 *)defaults, emitter, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
   else
     {
@@ -354,7 +374,9 @@ dump_translations (ModulemdModule *module,
         module, g_ptr_array_index (streams, i));
 
       if (!modulemd_translation_emit_yaml (translation, emitter, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   return TRUE;
@@ -402,14 +424,18 @@ dump_streams (ModulemdModule *module, yaml_emitter_t *emitter, GError **error)
         {
           if (!modulemd_module_stream_v1_emit_yaml (
                 MODULEMD_MODULE_STREAM_V1 (stream), emitter, error))
-            return FALSE;
+            {
+              return FALSE;
+            }
         }
       else if (modulemd_module_stream_get_mdversion (stream) ==
                MD_MODULESTREAM_VERSION_TWO)
         {
           if (!modulemd_module_stream_v2_emit_yaml (
                 MODULEMD_MODULE_STREAM_V2 (stream), emitter, error))
-            return FALSE;
+            {
+              return FALSE;
+            }
         }
       else
         {
@@ -445,7 +471,9 @@ modulemd_module_index_dump_to_emitter (ModulemdModuleIndex *self,
     }
 
   if (!mmd_emitter_start_stream (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   for (i = 0; i < modules->len; i++)
     {
@@ -453,17 +481,25 @@ modulemd_module_index_dump_to_emitter (ModulemdModuleIndex *self,
         self, g_ptr_array_index (modules, i));
 
       if (!dump_defaults (module, emitter, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       if (!dump_translations (module, emitter, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       if (!dump_streams (module, emitter, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   if (!mmd_emitter_end_stream (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -477,7 +513,9 @@ modulemd_module_index_update_from_file (ModulemdModuleIndex *self,
                                         GError **error)
 {
   if (*failures == NULL)
-    *failures = g_ptr_array_new_full (0, g_object_unref);
+    {
+      *failures = g_ptr_array_new_full (0, g_object_unref);
+    }
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
 
@@ -488,7 +526,7 @@ modulemd_module_index_update_from_file (ModulemdModuleIndex *self,
   ModulemdCompressionTypeEnum comtype;
   g_autofree gchar *fmode = NULL;
 
-  yaml_stream = g_fopen (yaml_file, "rb");
+  yaml_stream = g_fopen (yaml_file, "rbe");
   saved_errno = errno;
 
   if (yaml_stream == NULL)
@@ -513,8 +551,8 @@ modulemd_module_index_update_from_file (ModulemdModuleIndex *self,
       g_propagate_error (error, g_steal_pointer (&nested_error));
       return FALSE;
     }
-  else if (comtype == MODULEMD_COMPRESSION_TYPE_NO_COMPRESSION ||
-           comtype == MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION)
+  if (comtype == MODULEMD_COMPRESSION_TYPE_NO_COMPRESSION ||
+      comtype == MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION)
     {
       /* If it's not compressed (or we can't figure out what compression is in
        * use), just use the libyaml function. It's fast and will fail quickly
@@ -599,7 +637,9 @@ modulemd_module_index_update_from_string (ModulemdModuleIndex *self,
                                           GError **error)
 {
   if (*failures == NULL)
-    *failures = g_ptr_array_new_full (0, g_object_unref);
+    {
+      *failures = g_ptr_array_new_full (0, g_object_unref);
+    }
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
 
@@ -628,7 +668,9 @@ modulemd_module_index_update_from_stream (ModulemdModuleIndex *self,
                                           GError **error)
 {
   if (*failures == NULL)
-    *failures = g_ptr_array_new_full (0, g_object_unref);
+    {
+      *failures = g_ptr_array_new_full (0, g_object_unref);
+    }
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
 
@@ -657,7 +699,9 @@ modulemd_module_index_update_from_custom (ModulemdModuleIndex *self,
                                           GError **error)
 {
   if (*failures == NULL)
-    *failures = g_ptr_array_new_full (0, g_object_unref);
+    {
+      *failures = g_ptr_array_new_full (0, g_object_unref);
+    }
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
   g_return_val_if_fail (custom_read_fn, FALSE);
@@ -804,7 +848,9 @@ modulemd_module_index_dump_to_string (ModulemdModuleIndex *self,
   MMD_INIT_YAML_STRING (&emitter, yaml_string);
 
   if (!modulemd_module_index_dump_to_emitter (self, &emitter, error))
-    return NULL;
+    {
+      return NULL;
+    }
 
   return g_steal_pointer (&yaml_string->str);
 }
@@ -924,7 +970,8 @@ modulemd_module_index_upgrade_streams (
   GError **error)
 {
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
   g_autoptr (ModulemdModule) module = NULL;
   g_autoptr (GError) nested_error = NULL;
 
@@ -1013,7 +1060,8 @@ modulemd_module_index_get_default_streams_as_hash_table (
 {
   GHashTable *defaults = NULL;
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
   ModulemdDefaults *defs = NULL;
   const gchar *def_stream_name = NULL;
 
@@ -1060,7 +1108,8 @@ modulemd_module_index_upgrade_defaults (ModulemdModuleIndex *self,
                                         GError **error)
 {
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
   g_autoptr (ModulemdModule) module = NULL;
   g_autoptr (ModulemdDefaults) defaults = NULL;
   ModulemdDefaultsVersionEnum returned_mdversion = MD_DEFAULTS_VERSION_UNSET;
@@ -1146,7 +1195,8 @@ modulemd_module_index_merge (ModulemdModuleIndex *from,
 {
   MODULEMD_INIT_TRACE ();
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
   const gchar *module_name = NULL;
   const gchar *trans_stream = NULL;
   ModulemdModule *module = NULL;

--- a/modulemd/modulemd-module-stream-v1.c
+++ b/modulemd/modulemd-module-stream-v1.c
@@ -12,20 +12,20 @@
  */
 
 #include "modulemd-buildopts.h"
-#include "modulemd-component.h"
 #include "modulemd-component-module.h"
 #include "modulemd-component-rpm.h"
+#include "modulemd-component.h"
 #include "modulemd-errors.h"
-#include "modulemd-module-stream.h"
 #include "modulemd-module-stream-v1.h"
-#include "modulemd-translation-entry.h"
+#include "modulemd-module-stream.h"
 #include "modulemd-profile.h"
 #include "modulemd-service-level.h"
+#include "modulemd-translation-entry.h"
 #include "private/glib-extensions.h"
 #include "private/modulemd-buildopts-private.h"
+#include "private/modulemd-component-module-private.h"
 #include "private/modulemd-component-private.h"
 #include "private/modulemd-component-rpm-private.h"
-#include "private/modulemd-component-module-private.h"
 #include "private/modulemd-dependencies-private.h"
 #include "private/modulemd-module-stream-private.h"
 #include "private/modulemd-module-stream-v1-private.h"
@@ -201,7 +201,9 @@ modulemd_module_stream_v1_get_description (ModulemdModuleStreamV1 *self,
       MODULEMD_MODULE_STREAM (self), locale);
   if (entry != NULL &&
       modulemd_translation_entry_get_description (entry) != NULL)
-    return modulemd_translation_entry_get_description (entry);
+    {
+      return modulemd_translation_entry_get_description (entry);
+    }
 
   return self->description;
 }
@@ -250,7 +252,9 @@ modulemd_module_stream_v1_get_summary (ModulemdModuleStreamV1 *self,
     modulemd_module_stream_get_translation_entry (
       MODULEMD_MODULE_STREAM (self), locale);
   if (entry != NULL && modulemd_translation_entry_get_summary (entry) != NULL)
-    return modulemd_translation_entry_get_summary (entry);
+    {
+      return modulemd_translation_entry_get_summary (entry);
+    }
 
   return self->summary;
 }
@@ -289,7 +293,9 @@ modulemd_module_stream_v1_add_component (ModulemdModuleStreamV1 *self,
 
   /* Do nothing if we were passed a NULL component */
   if (!component)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
   g_return_if_fail (MODULEMD_IS_COMPONENT (component));
@@ -323,7 +329,9 @@ modulemd_module_stream_v1_remove_module_component (
 {
   /* Do nothing if we were passed a NULL component_name */
   if (!component_name)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -347,7 +355,9 @@ modulemd_module_stream_v1_remove_rpm_component (ModulemdModuleStreamV1 *self,
 {
   /* Do nothing if we were passed a NULL component_name */
   if (!component_name)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -409,7 +419,9 @@ modulemd_module_stream_v1_add_content_license (ModulemdModuleStreamV1 *self,
                                                const gchar *license)
 {
   if (!license)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -441,7 +453,9 @@ modulemd_module_stream_v1_add_module_license (ModulemdModuleStreamV1 *self,
                                               const gchar *license)
 {
   if (!license)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -473,7 +487,9 @@ modulemd_module_stream_v1_remove_content_license (ModulemdModuleStreamV1 *self,
                                                   const gchar *license)
 {
   if (!license)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -486,7 +502,9 @@ modulemd_module_stream_v1_remove_module_license (ModulemdModuleStreamV1 *self,
                                                  const gchar *license)
 {
   if (!license)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -519,7 +537,9 @@ modulemd_module_stream_v1_add_profile (ModulemdModuleStreamV1 *self,
                                        ModulemdProfile *profile)
 {
   if (!profile)
-    return;
+    {
+      return;
+    }
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
   g_return_if_fail (MODULEMD_IS_PROFILE (profile));
 
@@ -566,7 +586,9 @@ modulemd_module_stream_v1_add_rpm_api (ModulemdModuleStreamV1 *self,
                                        const gchar *rpm)
 {
   if (!rpm)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -589,7 +611,9 @@ modulemd_module_stream_v1_remove_rpm_api (ModulemdModuleStreamV1 *self,
                                           const gchar *rpm)
 {
   if (!rpm)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -620,7 +644,9 @@ modulemd_module_stream_v1_add_rpm_artifact (ModulemdModuleStreamV1 *self,
                                             const gchar *nevr)
 {
   if (!nevr)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -643,7 +669,9 @@ modulemd_module_stream_v1_remove_rpm_artifact (ModulemdModuleStreamV1 *self,
                                                const gchar *nevr)
 {
   if (!nevr)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -675,7 +703,9 @@ modulemd_module_stream_v1_add_rpm_filter (ModulemdModuleStreamV1 *self,
                                           const gchar *rpm)
 {
   if (!rpm)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -698,7 +728,9 @@ modulemd_module_stream_v1_remove_rpm_filter (ModulemdModuleStreamV1 *self,
                                              const gchar *rpm)
 {
   if (!rpm)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
 
@@ -730,7 +762,9 @@ modulemd_module_stream_v1_add_servicelevel (ModulemdModuleStreamV1 *self,
                                             ModulemdServiceLevel *servicelevel)
 {
   if (!servicelevel)
-    return;
+    {
+      return;
+    }
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (self));
   g_return_if_fail (MODULEMD_IS_SERVICE_LEVEL (servicelevel));
 
@@ -951,7 +985,9 @@ modulemd_module_stream_v1_set_xmd (ModulemdModuleStreamV1 *self, GVariant *xmd)
 
   /* Do nothing if we were passed the same pointer */
   if (self->xmd == xmd)
-    return;
+    {
+      return;
+    }
 
   g_clear_pointer (&self->xmd, g_variant_unref);
   self->xmd = modulemd_variant_deep_copy (xmd);
@@ -986,22 +1022,34 @@ modulemd_module_stream_v1_equals (ModulemdModuleStream *self_1,
 
   /*Check property equality*/
   if (g_strcmp0 (v1_self_1->community, v1_self_2->community) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (v1_self_1->description, v1_self_2->description) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (v1_self_1->documentation, v1_self_2->documentation) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (v1_self_1->summary, v1_self_2->summary) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (v1_self_1->tracker, v1_self_2->tracker) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!modulemd_buildopts_equals (v1_self_1->buildopts, v1_self_2->buildopts))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!modulemd_hash_table_equals (v1_self_1->rpm_components,
                                    v1_self_2->rpm_components,
@@ -1074,13 +1122,19 @@ modulemd_module_stream_v1_equals (ModulemdModuleStream *self_1,
     }
 
   if (v1_self_1->xmd == NULL && v1_self_2->xmd == NULL)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   if (v1_self_1->xmd == NULL || v1_self_2->xmd == NULL)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!g_variant_equal (v1_self_1->xmd, v1_self_2->xmd))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -1090,7 +1144,8 @@ static gboolean
 modulemd_module_stream_v1_validate (ModulemdModuleStream *self, GError **error)
 {
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
   gchar *nevra = NULL;
   ModulemdModuleStreamV1 *v1_self = NULL;
   g_autoptr (GError) nested_error = NULL;
@@ -1468,9 +1523,7 @@ modulemd_module_stream_v1_parse_components (
   GError **error);
 
 static GVariant *
-modulemd_module_stream_v1_parse_raw (yaml_parser_t *parser,
-                                     ModulemdModuleStreamV1 *modulestream,
-                                     GError **error);
+modulemd_module_stream_v1_parse_raw (yaml_parser_t *parser, GError **error);
 
 
 ModulemdModuleStreamV1 *
@@ -1492,7 +1545,9 @@ modulemd_module_stream_v1_parse_yaml (ModulemdSubdocumentInfo *subdoc,
 
   if (!modulemd_subdocument_info_get_data_parser (
         subdoc, &parser, strict, error))
-    return NULL;
+    {
+      return NULL;
+    }
 
   guint64 version;
 
@@ -1626,8 +1681,8 @@ modulemd_module_stream_v1_parse_yaml (ModulemdSubdocumentInfo *subdoc,
           /* Extensible Metadata */
           else if (g_str_equal ((const gchar *)event.data.scalar.value, "xmd"))
             {
-              xmd = modulemd_module_stream_v1_parse_raw (
-                &parser, modulestream, &nested_error);
+              xmd =
+                modulemd_module_stream_v1_parse_raw (&parser, &nested_error);
               if (!xmd)
                 {
                   g_propagate_error (error, g_steal_pointer (&nested_error));
@@ -2450,9 +2505,7 @@ modulemd_module_stream_v1_parse_module_components (
 
 
 static GVariant *
-modulemd_module_stream_v1_parse_raw (yaml_parser_t *parser,
-                                     ModulemdModuleStreamV1 *modulestream,
-                                     GError **error)
+modulemd_module_stream_v1_parse_raw (yaml_parser_t *parser, GError **error)
 {
   MODULEMD_INIT_TRACE ();
   MMD_INIT_YAML_EVENT (event);
@@ -2498,7 +2551,9 @@ modulemd_module_stream_v1_emit_yaml (ModulemdModuleStreamV1 *self,
   MODULEMD_INIT_TRACE ();
   if (!modulemd_module_stream_emit_yaml_base (
         MODULEMD_MODULE_STREAM (self), emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   EMIT_KEY_VALUE_IF_SET (
     emitter, error, "arch", modulemd_module_stream_v1_get_arch (self));
@@ -2535,7 +2590,9 @@ modulemd_module_stream_v1_emit_yaml (ModulemdModuleStreamV1 *self,
     {
       EMIT_SCALAR (emitter, error, "xmd");
       if (!modulemd_yaml_emit_variant (emitter, self->xmd, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   if (NON_EMPTY_TABLE (self->buildtime_deps) ||
@@ -2585,7 +2642,9 @@ modulemd_module_stream_v1_emit_yaml (ModulemdModuleStreamV1 *self,
       EMIT_SCALAR (emitter, error, "buildopts");
       EMIT_MAPPING_START (emitter, error);
       if (!modulemd_buildopts_emit_yaml (self->buildopts, emitter, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
       EMIT_MAPPING_END (emitter, error);
     }
 
@@ -2620,7 +2679,9 @@ modulemd_module_stream_v1_emit_yaml (ModulemdModuleStreamV1 *self,
   /* The overall document mapping */
   EMIT_MAPPING_END (emitter, error);
   if (!mmd_emitter_end_document (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }

--- a/modulemd/modulemd-module-stream-v2.c
+++ b/modulemd/modulemd-module-stream-v2.c
@@ -12,20 +12,20 @@
  */
 
 #include "modulemd-buildopts.h"
-#include "modulemd-component.h"
 #include "modulemd-component-module.h"
 #include "modulemd-component-rpm.h"
+#include "modulemd-component.h"
 #include "modulemd-errors.h"
-#include "modulemd-module-stream.h"
 #include "modulemd-module-stream-v2.h"
-#include "modulemd-translation-entry.h"
-#include "modulemd-rpm-map-entry.h"
+#include "modulemd-module-stream.h"
 #include "modulemd-profile.h"
+#include "modulemd-rpm-map-entry.h"
 #include "modulemd-service-level.h"
+#include "modulemd-translation-entry.h"
 #include "private/modulemd-buildopts-private.h"
+#include "private/modulemd-component-module-private.h"
 #include "private/modulemd-component-private.h"
 #include "private/modulemd-component-rpm-private.h"
-#include "private/modulemd-component-module-private.h"
 #include "private/modulemd-dependencies-private.h"
 #include "private/modulemd-module-stream-private.h"
 #include "private/modulemd-module-stream-v2-private.h"
@@ -127,22 +127,34 @@ modulemd_module_stream_v2_equals (ModulemdModuleStream *self_1,
 
   /*Check property equality*/
   if (g_strcmp0 (v2_self_1->community, v2_self_2->community) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (v2_self_1->description, v2_self_2->description) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (v2_self_1->documentation, v2_self_2->documentation) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (v2_self_1->summary, v2_self_2->summary) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (v2_self_1->tracker, v2_self_2->tracker) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!modulemd_buildopts_equals (v2_self_1->buildopts, v2_self_2->buildopts))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!modulemd_hash_table_equals (v2_self_1->rpm_components,
                                    v2_self_2->rpm_components,
@@ -214,7 +226,9 @@ modulemd_module_stream_v2_equals (ModulemdModuleStream *self_1,
 
 
   if (v2_self_1->dependencies->len != v2_self_2->dependencies->len)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   for (guint i = 0; i < v2_self_1->dependencies->len; i++)
     {
@@ -223,17 +237,25 @@ modulemd_module_stream_v2_equals (ModulemdModuleStream *self_1,
       if (!modulemd_dependencies_equals (
             g_ptr_array_index (v2_self_1->dependencies, i),
             g_ptr_array_index (v2_self_2->dependencies, i)))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   if (v2_self_1->xmd == NULL && v2_self_2->xmd == NULL)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   if (v2_self_1->xmd == NULL || v2_self_2->xmd == NULL)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!g_variant_equal (v2_self_1->xmd, v2_self_2->xmd))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -333,7 +355,9 @@ modulemd_module_stream_v2_get_description (ModulemdModuleStreamV2 *self,
       MODULEMD_MODULE_STREAM (self), locale);
   if (entry != NULL &&
       modulemd_translation_entry_get_description (entry) != NULL)
-    return modulemd_translation_entry_get_description (entry);
+    {
+      return modulemd_translation_entry_get_description (entry);
+    }
 
   return self->description;
 }
@@ -382,7 +406,9 @@ modulemd_module_stream_v2_get_summary (ModulemdModuleStreamV2 *self,
     modulemd_module_stream_get_translation_entry (
       MODULEMD_MODULE_STREAM (self), locale);
   if (entry != NULL && modulemd_translation_entry_get_summary (entry) != NULL)
-    return modulemd_translation_entry_get_summary (entry);
+    {
+      return modulemd_translation_entry_get_summary (entry);
+    }
 
   return self->summary;
 }
@@ -420,7 +446,9 @@ modulemd_module_stream_v2_add_component (ModulemdModuleStreamV2 *self,
 
   /* Do nothing if we were passed a NULL component */
   if (!component)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
   g_return_if_fail (MODULEMD_IS_COMPONENT (component));
@@ -454,7 +482,9 @@ modulemd_module_stream_v2_remove_module_component (
 {
   /* Do nothing if we were passed a NULL component_name */
   if (!component_name)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -478,7 +508,9 @@ modulemd_module_stream_v2_remove_rpm_component (ModulemdModuleStreamV2 *self,
 {
   /* Do nothing if we were passed a NULL component_name */
   if (!component_name)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -540,7 +572,9 @@ modulemd_module_stream_v2_add_content_license (ModulemdModuleStreamV2 *self,
                                                const gchar *license)
 {
   if (!license)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -563,7 +597,9 @@ modulemd_module_stream_v2_add_module_license (ModulemdModuleStreamV2 *self,
                                               const gchar *license)
 {
   if (!license)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -586,7 +622,9 @@ modulemd_module_stream_v2_remove_content_license (ModulemdModuleStreamV2 *self,
                                                   const gchar *license)
 {
   if (!license)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -599,7 +637,9 @@ modulemd_module_stream_v2_remove_module_license (ModulemdModuleStreamV2 *self,
                                                  const gchar *license)
 {
   if (!license)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -650,7 +690,9 @@ modulemd_module_stream_v2_add_profile (ModulemdModuleStreamV2 *self,
                                        ModulemdProfile *profile)
 {
   if (!profile)
-    return;
+    {
+      return;
+    }
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
   g_return_if_fail (MODULEMD_IS_PROFILE (profile));
 
@@ -697,7 +739,9 @@ modulemd_module_stream_v2_add_rpm_api (ModulemdModuleStreamV2 *self,
                                        const gchar *rpm)
 {
   if (!rpm)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -720,7 +764,9 @@ modulemd_module_stream_v2_remove_rpm_api (ModulemdModuleStreamV2 *self,
                                           const gchar *rpm)
 {
   if (!rpm)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -751,7 +797,9 @@ modulemd_module_stream_v2_add_rpm_artifact (ModulemdModuleStreamV2 *self,
                                             const gchar *nevr)
 {
   if (!nevr)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -774,7 +822,9 @@ modulemd_module_stream_v2_remove_rpm_artifact (ModulemdModuleStreamV2 *self,
                                                const gchar *nevr)
 {
   if (!nevr)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -847,7 +897,9 @@ modulemd_module_stream_v2_get_rpm_artifact_map_entry (
 
   digest_table = g_hash_table_lookup (self->rpm_artifact_map, digest);
   if (!digest_table)
-    return NULL;
+    {
+      return NULL;
+    }
 
   return g_hash_table_lookup (digest_table, checksum);
 }
@@ -858,7 +910,9 @@ modulemd_module_stream_v2_add_rpm_filter (ModulemdModuleStreamV2 *self,
                                           const gchar *rpm)
 {
   if (!rpm)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -881,7 +935,9 @@ modulemd_module_stream_v2_remove_rpm_filter (ModulemdModuleStreamV2 *self,
                                              const gchar *rpm)
 {
   if (!rpm)
-    return;
+    {
+      return;
+    }
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
 
@@ -913,7 +969,9 @@ modulemd_module_stream_v2_add_servicelevel (ModulemdModuleStreamV2 *self,
                                             ModulemdServiceLevel *servicelevel)
 {
   if (!servicelevel)
-    return;
+    {
+      return;
+    }
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
   g_return_if_fail (MODULEMD_IS_SERVICE_LEVEL (servicelevel));
 
@@ -1026,7 +1084,9 @@ modulemd_module_stream_v2_set_xmd (ModulemdModuleStreamV2 *self, GVariant *xmd)
 
   /* Do nothing if we were passed the same pointer */
   if (self->xmd == xmd)
-    return;
+    {
+      return;
+    }
 
   g_clear_pointer (&self->xmd, g_variant_unref);
   self->xmd = modulemd_variant_deep_copy (xmd);
@@ -1044,7 +1104,8 @@ static gboolean
 modulemd_module_stream_v2_validate (ModulemdModuleStream *self, GError **error)
 {
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
   gchar *nevra = NULL;
   ModulemdModuleStreamV2 *v2_self = NULL;
   ModulemdDependencies *deps = NULL;
@@ -1211,9 +1272,12 @@ static void
 copy_rpm_artifact_map (ModulemdModuleStreamV2 *from,
                        ModulemdModuleStreamV2 *to)
 {
-  GHashTableIter outer, inner;
-  gpointer outer_key, outer_value;
-  gpointer inner_key, inner_value;
+  GHashTableIter outer;
+  GHashTableIter inner;
+  gpointer outer_key;
+  gpointer outer_value;
+  gpointer inner_key;
+  gpointer inner_value;
   GHashTable *to_digest_table = NULL;
 
   g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (from));
@@ -1300,13 +1364,17 @@ depends_on_stream (ModulemdModuleStreamV2 *self,
         {
           if (modulemd_dependencies_buildrequires_module_and_stream (
                 dep, module_name, stream_name))
-            return TRUE;
+            {
+              return TRUE;
+            }
         }
       else
         {
           if (modulemd_dependencies_requires_module_and_stream (
                 dep, module_name, stream_name))
-            return TRUE;
+            {
+              return TRUE;
+            }
         }
     }
 
@@ -1486,9 +1554,7 @@ modulemd_module_stream_v2_parse_artifacts (
   GError **error);
 
 static GVariant *
-modulemd_module_stream_v2_parse_raw (yaml_parser_t *parser,
-                                     ModulemdModuleStreamV2 *modulestream,
-                                     GError **error);
+modulemd_module_stream_v2_parse_raw (yaml_parser_t *parser, GError **error);
 
 
 ModulemdModuleStreamV2 *
@@ -1509,7 +1575,9 @@ modulemd_module_stream_v2_parse_yaml (ModulemdSubdocumentInfo *subdoc,
 
   if (!modulemd_subdocument_info_get_data_parser (
         subdoc, &parser, strict, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
@@ -1641,8 +1709,8 @@ modulemd_module_stream_v2_parse_yaml (ModulemdSubdocumentInfo *subdoc,
           /* Extensible Metadata */
           else if (g_str_equal ((const gchar *)event.data.scalar.value, "xmd"))
             {
-              xmd = modulemd_module_stream_v2_parse_raw (
-                &parser, modulestream, &nested_error);
+              xmd =
+                modulemd_module_stream_v2_parse_raw (&parser, &nested_error);
               if (!xmd)
                 {
                   g_propagate_error (error, g_steal_pointer (&nested_error));
@@ -2633,9 +2701,7 @@ modulemd_module_stream_v2_parse_rpm_map_digest (
 
 
 static GVariant *
-modulemd_module_stream_v2_parse_raw (yaml_parser_t *parser,
-                                     ModulemdModuleStreamV2 *modulestream,
-                                     GError **error)
+modulemd_module_stream_v2_parse_raw (yaml_parser_t *parser, GError **error)
 {
   MODULEMD_INIT_TRACE ();
   MMD_INIT_YAML_EVENT (event);
@@ -2687,7 +2753,9 @@ modulemd_module_stream_v2_emit_yaml (ModulemdModuleStreamV2 *self,
 
   if (!modulemd_module_stream_emit_yaml_base (
         MODULEMD_MODULE_STREAM (self), emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   EMIT_KEY_VALUE_IF_SET (
     emitter, error, "arch", modulemd_module_stream_v2_get_arch (self));
@@ -2724,7 +2792,9 @@ modulemd_module_stream_v2_emit_yaml (ModulemdModuleStreamV2 *self,
     {
       EMIT_SCALAR (emitter, error, "xmd");
       if (!modulemd_yaml_emit_variant (emitter, self->xmd, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   EMIT_ARRAY_VALUES_IF_NON_EMPTY (emitter,
@@ -2768,7 +2838,9 @@ modulemd_module_stream_v2_emit_yaml (ModulemdModuleStreamV2 *self,
       EMIT_SCALAR (emitter, error, "buildopts");
       EMIT_MAPPING_START (emitter, error);
       if (!modulemd_buildopts_emit_yaml (self->buildopts, emitter, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
       EMIT_MAPPING_END (emitter, error);
     }
 
@@ -2802,7 +2874,9 @@ modulemd_module_stream_v2_emit_yaml (ModulemdModuleStreamV2 *self,
 
       /* Emit the rpm-map */
       if (!modulemd_module_stream_v2_emit_rpm_map (self, emitter, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       EMIT_MAPPING_END (emitter, error);
     }
@@ -2812,7 +2886,9 @@ modulemd_module_stream_v2_emit_yaml (ModulemdModuleStreamV2 *self,
   /* The overall document mapping */
   EMIT_MAPPING_END (emitter, error);
   if (!mmd_emitter_end_document (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -2862,7 +2938,9 @@ modulemd_module_stream_v2_emit_rpm_map (ModulemdModuleStreamV2 *self,
           entry = g_hash_table_lookup (digest_table, checksum);
 
           if (!modulemd_rpm_map_entry_emit_yaml (entry, emitter, error))
-            return FALSE;
+            {
+              return FALSE;
+            }
         }
 
       EMIT_MAPPING_END (emitter, error);

--- a/modulemd/modulemd-module-stream.c
+++ b/modulemd/modulemd-module-stream.c
@@ -11,12 +11,10 @@
  * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
  */
 
-#include <errno.h>
-#include <inttypes.h>
 #include "modulemd-errors.h"
-#include "modulemd-module-stream.h"
 #include "modulemd-module-stream-v1.h"
 #include "modulemd-module-stream-v2.h"
+#include "modulemd-module-stream.h"
 #include "private/modulemd-component-private.h"
 #include "private/modulemd-module-stream-private.h"
 #include "private/modulemd-module-stream-v1-private.h"
@@ -24,6 +22,8 @@
 #include "private/modulemd-subdocument-info-private.h"
 #include "private/modulemd-util.h"
 #include "private/modulemd-yaml.h"
+#include <errno.h>
+#include <inttypes.h>
 
 typedef struct
 {
@@ -98,7 +98,7 @@ modulemd_module_stream_read_file (const gchar *path,
   g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
   errno = 0;
-  yaml_stream = g_fopen (path, "rb");
+  yaml_stream = g_fopen (path, "rbe");
   err = errno;
 
   if (!yaml_stream)
@@ -321,23 +321,33 @@ modulemd_module_stream_default_equals (ModulemdModuleStream *self_1,
 {
   if (modulemd_module_stream_get_version (self_1) !=
       modulemd_module_stream_get_version (self_2))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (modulemd_module_stream_get_module_name (self_1),
                  modulemd_module_stream_get_module_name (self_2)) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (modulemd_module_stream_get_stream_name (self_1),
                  modulemd_module_stream_get_stream_name (self_2)) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (modulemd_module_stream_get_context (self_1),
                  modulemd_module_stream_get_context (self_2)) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (modulemd_module_stream_get_arch (self_1),
                  modulemd_module_stream_get_arch (self_2)) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -350,10 +360,14 @@ modulemd_module_stream_equals (ModulemdModuleStream *self_1,
   ModulemdModuleStreamClass *klass;
 
   if (!self_1 && !self_2)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   if (!self_1 || !self_2)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self_1), FALSE);
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self_2), FALSE);
@@ -375,7 +389,9 @@ modulemd_module_stream_default_copy (ModulemdModuleStream *self,
   const gchar *stream = NULL;
 
   if (!self)
-    return NULL;
+    {
+      return NULL;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self), NULL);
 
@@ -422,7 +438,9 @@ modulemd_module_stream_copy (ModulemdModuleStream *self,
   ModulemdModuleStreamClass *klass;
 
   if (!self)
-    return NULL;
+    {
+      return NULL;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self), NULL);
 
@@ -520,7 +538,8 @@ modulemd_module_stream_upgrade_to_v2 (ModulemdModuleStream *from)
   g_autoptr (ModulemdModuleStreamV2) copy = NULL;
   g_autoptr (ModulemdDependencies) deps = NULL;
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM_V1 (from), NULL);
   v1_stream = MODULEMD_MODULE_STREAM_V1 (from);
@@ -573,7 +592,9 @@ modulemd_module_stream_upgrade_to_v2 (ModulemdModuleStream *from)
 
 
   if (v1_stream->xmd != NULL)
-    modulemd_module_stream_v2_set_xmd (copy, v1_stream->xmd);
+    {
+      modulemd_module_stream_v2_set_xmd (copy, v1_stream->xmd);
+    }
 
 
   /* Upgrade the Dependencies */
@@ -620,7 +641,7 @@ modulemd_module_stream_default_validate (ModulemdModuleStream *self,
                            "Metadata version is unset.");
       return FALSE;
     }
-  else if (mdversion > MD_MODULESTREAM_VERSION_LATEST)
+  if (mdversion > MD_MODULESTREAM_VERSION_LATEST)
     {
       g_set_error_literal (error,
                            MODULEMD_ERROR,
@@ -637,9 +658,12 @@ gboolean
 modulemd_module_stream_validate_components (GHashTable *components,
                                             GError **error)
 {
-  GHashTableIter iter, buildafter_iter;
-  gpointer key, value;
-  gpointer ba_key, ba_value;
+  GHashTableIter iter;
+  GHashTableIter buildafter_iter;
+  gpointer key;
+  gpointer value;
+  gpointer ba_key;
+  gpointer ba_value;
   gboolean has_buildorder = FALSE;
   gboolean has_buildafter = FALSE;
 
@@ -720,7 +744,9 @@ modulemd_module_stream_validate (ModulemdModuleStream *self, GError **error)
   ModulemdModuleStreamClass *klass;
 
   if (!self)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self), FALSE);
 
@@ -737,7 +763,9 @@ modulemd_module_stream_get_mdversion (ModulemdModuleStream *self)
   ModulemdModuleStreamClass *klass;
 
   if (!self)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self), 0);
 
@@ -1155,7 +1183,9 @@ modulemd_module_stream_associate_translation (ModulemdModuleStream *self,
 
   g_clear_pointer (&priv->translation, g_object_unref);
   if (translation != NULL)
-    priv->translation = g_object_ref (translation);
+    {
+      priv->translation = g_object_ref (translation);
+    }
 }
 
 
@@ -1178,16 +1208,22 @@ modulemd_module_stream_get_translation_entry (ModulemdModuleStream *self,
   g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self), NULL);
 
   if (locale == NULL)
-    return NULL;
+    {
+      return NULL;
+    }
 
   if (g_str_equal (locale, "C"))
-    return NULL;
+    {
+      return NULL;
+    }
 
   ModulemdModuleStreamPrivate *priv =
     modulemd_module_stream_get_instance_private (self);
 
   if (priv->translation == NULL)
-    return NULL;
+    {
+      return NULL;
+    }
 
   return modulemd_translation_get_translation_entry (priv->translation,
                                                      locale);
@@ -1214,7 +1250,9 @@ modulemd_module_stream_emit_yaml_base (ModulemdModuleStream *self,
         MODULEMD_YAML_DOC_MODULESTREAM,
         modulemd_module_stream_get_mdversion (self),
         error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   /* Start data: */
   EMIT_MAPPING_START (emitter, error);

--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -66,7 +66,9 @@ modulemd_module_copy (ModulemdModule *self)
   m->defaults = modulemd_defaults_copy (self->defaults);
 
   for (i = 0; i < self->streams->len; i++)
-    g_ptr_array_add (m->streams, g_ptr_array_index (self->streams, i));
+    {
+      g_ptr_array_add (m->streams, g_ptr_array_index (self->streams, i));
+    }
 
   return g_steal_pointer (&m);
 }
@@ -396,7 +398,9 @@ modulemd_module_get_stream_names_as_strv (ModulemdModule *self)
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
 
   if (!self->streams)
-    return NULL;
+    {
+      return NULL;
+    }
 
   g_autoptr (GHashTable) stream_names =
     g_hash_table_new (g_str_hash, g_str_equal);
@@ -425,7 +429,8 @@ static gint
 compare_streams (gconstpointer a, gconstpointer b)
 {
   int cmp = 0;
-  guint64 a_ver, b_ver;
+  guint64 a_ver;
+  guint64 b_ver;
   ModulemdModuleStream *a_ = *(ModulemdModuleStream **)a;
   ModulemdModuleStream *b_ = *(ModulemdModuleStream **)b;
 
@@ -433,21 +438,29 @@ compare_streams (gconstpointer a, gconstpointer b)
   cmp = g_strcmp0 (modulemd_module_stream_get_stream_name (a_),
                    modulemd_module_stream_get_stream_name (b_));
   if (cmp != 0)
-    return cmp;
+    {
+      return cmp;
+    }
 
   /* Sort by the version, highest first */
   a_ver = modulemd_module_stream_get_version (a_);
   b_ver = modulemd_module_stream_get_version (b_);
   if (b_ver > a_ver)
-    return 1;
+    {
+      return 1;
+    }
   if (a_ver > b_ver)
-    return -1;
+    {
+      return -1;
+    }
 
   /* Sort alphabetically by context */
   cmp = g_strcmp0 (modulemd_module_stream_get_context (a_),
                    modulemd_module_stream_get_context (b_));
   if (cmp != 0)
-    return cmp;
+    {
+      return cmp;
+    }
 
   /* Sort alphabetically by architecture */
   cmp = g_strcmp0 (modulemd_module_stream_get_arch (a_),
@@ -505,7 +518,9 @@ modulemd_module_search_streams (ModulemdModule *self,
       if (g_strcmp0 (
             modulemd_module_stream_get_stream_name (under_consideration),
             stream_name) != 0)
-        continue;
+        {
+          continue;
+        }
 
       /* Skip this one unless the stream version matches OR the version is zero
        * which indicates that it shouldn't prevent the other cases from
@@ -513,17 +528,23 @@ modulemd_module_search_streams (ModulemdModule *self,
        */
       if (version &&
           modulemd_module_stream_get_version (under_consideration) != version)
-        continue;
+        {
+          continue;
+        }
 
       if (context &&
           g_strcmp0 (modulemd_module_stream_get_context (under_consideration),
                      context) != 0)
-        continue;
+        {
+          continue;
+        }
 
       if (arch &&
           g_strcmp0 (modulemd_module_stream_get_arch (under_consideration),
                      arch) != 0)
-        continue;
+        {
+          continue;
+        }
 
       g_ptr_array_add (matching_streams, under_consideration);
     }
@@ -557,7 +578,7 @@ modulemd_module_get_stream_by_NSVCA (ModulemdModule *self,
                    "No streams matched");
       return NULL;
     }
-  else if (matching_streams->len > 1)
+  if (matching_streams->len > 1)
     {
       g_set_error (error,
                    MODULEMD_ERROR,
@@ -601,25 +622,33 @@ match_nsvca (gconstpointer haystraw, gconstpointer needle)
 
   if (!g_str_equal (nsvca->stream_name,
                     modulemd_module_stream_get_stream_name (stream)))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (nsvca->version)
     {
       if (nsvca->version != modulemd_module_stream_get_version (stream))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   if (nsvca->context)
     {
       if (!g_str_equal (nsvca->context,
                         modulemd_module_stream_get_context (stream)))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   if (nsvca->arch)
     {
       if (!g_str_equal (nsvca->arch, modulemd_module_stream_get_arch (stream)))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   return TRUE;
@@ -650,7 +679,9 @@ modulemd_module_remove_streams_by_NSVCA (ModulemdModule *self,
       found = g_ptr_array_find_with_equal_func (
         self->streams, nsvca, match_nsvca, &index);
       if (found)
-        g_ptr_array_remove_index (self->streams, index);
+        {
+          g_ptr_array_remove_index (self->streams, index);
+        }
     }
   while (found);
 }
@@ -681,7 +712,9 @@ modulemd_module_add_translation (ModulemdModule *self,
 
       if (!g_str_equal (modulemd_translation_get_module_stream (newtrans),
                         modulemd_module_stream_get_stream_name (stream)))
-        continue;
+        {
+          continue;
+        }
 
       modulemd_module_stream_associate_translation (stream, newtrans);
     }

--- a/modulemd/modulemd-profile.c
+++ b/modulemd/modulemd-profile.c
@@ -68,15 +68,21 @@ modulemd_profile_equals (ModulemdProfile *self_1, ModulemdProfile *self_2)
 
   if (g_strcmp0 (modulemd_profile_get_name (self_1),
                  modulemd_profile_get_name (self_2)) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_strcmp0 (modulemd_profile_get_description (self_1, NULL),
                  modulemd_profile_get_description (self_2, NULL)))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   //Check rpms: size, set values
   if (!modulemd_hash_table_sets_are_equal (self_1->rpms, self_2->rpms))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -172,7 +178,9 @@ modulemd_profile_get_description (ModulemdProfile *self, const gchar *locale)
                                                                 self->name);
 
           if (translation != NULL)
-            return translation;
+            {
+              return translation;
+            }
         }
     }
 
@@ -322,8 +330,10 @@ modulemd_profile_parse_yaml (yaml_parser_t *parser,
 
         case YAML_SCALAR_EVENT:
           if (!in_map)
-            MMD_YAML_ERROR_EVENT_EXIT (
-              error, event, "Missing mapping in profile entry");
+            {
+              MMD_YAML_ERROR_EVENT_EXIT (
+                error, event, "Missing mapping in profile entry");
+            }
           if (g_str_equal (event.data.scalar.value, "rpms"))
             {
               g_hash_table_unref (p->rpms);
@@ -341,11 +351,13 @@ modulemd_profile_parse_yaml (yaml_parser_t *parser,
             {
               value = modulemd_yaml_parse_string (parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse description in profile: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse description in profile: %s",
+                    nested_error->message);
+                }
               modulemd_profile_set_description (p, value);
               g_clear_pointer (&value, g_free);
             }

--- a/modulemd/modulemd-rpm-map-entry.c
+++ b/modulemd/modulemd-rpm-map-entry.c
@@ -11,8 +11,8 @@
  * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
  */
 
-#include <inttypes.h>
 #include "yaml.h"
+#include <inttypes.h>
 
 #include "modulemd-errors.h"
 #include "modulemd-rpm-map-entry.h"
@@ -118,7 +118,9 @@ modulemd_rpm_map_entry_equals (ModulemdRpmMapEntry *self,
   g_return_val_if_fail (MODULEMD_IS_RPM_MAP_ENTRY (other), FALSE);
 
   if (self == other)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   /* Since all of the public attributes of these entries are captured by the
    * NEVRA output, we can short-cut the comparison process and just compare
@@ -141,7 +143,7 @@ modulemd_rpm_map_entry_validate (ModulemdRpmMapEntry *self, GError **error)
                            "Missing name attribute");
       return FALSE;
     }
-  else if (!self->version)
+  if (!self->version)
     {
       g_set_error_literal (error,
                            MODULEMD_ERROR,
@@ -149,7 +151,7 @@ modulemd_rpm_map_entry_validate (ModulemdRpmMapEntry *self, GError **error)
                            "Missing version attribute");
       return FALSE;
     }
-  else if (!self->release)
+  if (!self->release)
     {
       g_set_error_literal (error,
                            MODULEMD_ERROR,
@@ -157,7 +159,7 @@ modulemd_rpm_map_entry_validate (ModulemdRpmMapEntry *self, GError **error)
                            "Missing release attribute");
       return FALSE;
     }
-  else if (!self->arch)
+  if (!self->arch)
     {
       g_set_error_literal (error,
                            MODULEMD_ERROR,
@@ -402,10 +404,13 @@ modulemd_rpm_map_entry_parse_yaml (yaml_parser_t *parser,
             {
               scalar = modulemd_yaml_parse_string (parser, &nested_error);
               if (!scalar)
-                MMD_YAML_ERROR_EVENT_EXIT (error,
-                                           event,
-                                           "Failed to parse package name: %s",
-                                           nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse package name: %s",
+                    nested_error->message);
+                }
               modulemd_rpm_map_entry_set_name (entry, scalar);
               g_clear_pointer (&scalar, g_free);
             }
@@ -413,10 +418,13 @@ modulemd_rpm_map_entry_parse_yaml (yaml_parser_t *parser,
             {
               epoch = modulemd_yaml_parse_uint64 (parser, &nested_error);
               if (nested_error)
-                MMD_YAML_ERROR_EVENT_EXIT (error,
-                                           event,
-                                           "Failed to parse package epoch: %s",
-                                           nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse package epoch: %s",
+                    nested_error->message);
+                }
               modulemd_rpm_map_entry_set_epoch (entry, epoch);
               seen_epoch = TRUE;
             }
@@ -424,11 +432,13 @@ modulemd_rpm_map_entry_parse_yaml (yaml_parser_t *parser,
             {
               scalar = modulemd_yaml_parse_string (parser, &nested_error);
               if (!scalar)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse package version: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse package version: %s",
+                    nested_error->message);
+                }
               modulemd_rpm_map_entry_set_version (entry, scalar);
               g_clear_pointer (&scalar, g_free);
             }
@@ -436,11 +446,13 @@ modulemd_rpm_map_entry_parse_yaml (yaml_parser_t *parser,
             {
               scalar = modulemd_yaml_parse_string (parser, &nested_error);
               if (!scalar)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse package release: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse package release: %s",
+                    nested_error->message);
+                }
               modulemd_rpm_map_entry_set_release (entry, scalar);
               g_clear_pointer (&scalar, g_free);
             }
@@ -448,11 +460,13 @@ modulemd_rpm_map_entry_parse_yaml (yaml_parser_t *parser,
             {
               scalar = modulemd_yaml_parse_string (parser, &nested_error);
               if (!scalar)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse package architecture: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse package architecture: %s",
+                    nested_error->message);
+                }
               modulemd_rpm_map_entry_set_arch (entry, scalar);
               g_clear_pointer (&scalar, g_free);
             }
@@ -460,10 +474,13 @@ modulemd_rpm_map_entry_parse_yaml (yaml_parser_t *parser,
             {
               nevra = modulemd_yaml_parse_string (parser, &nested_error);
               if (!nevra)
-                MMD_YAML_ERROR_EVENT_EXIT (error,
-                                           event,
-                                           "Failed to parse package nevra: %s",
-                                           nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse package nevra: %s",
+                    nested_error->message);
+                }
             }
           else
             {

--- a/modulemd/modulemd-service-level.c
+++ b/modulemd/modulemd-service-level.c
@@ -73,27 +73,39 @@ modulemd_service_level_equals (ModulemdServiceLevel *self_1,
                                ModulemdServiceLevel *self_2)
 {
   if (!self_1 && !self_2)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   if (!self_1 || !self_2)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_return_val_if_fail (MODULEMD_IS_SERVICE_LEVEL (self_1), FALSE);
   g_return_val_if_fail (MODULEMD_IS_SERVICE_LEVEL (self_2), FALSE);
 
   if (g_strcmp0 (modulemd_service_level_get_name (self_1),
                  modulemd_service_level_get_name (self_2)) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   /*if both eols are invalid, its equivalent*/
   if (!g_date_valid (self_1->eol) && !g_date_valid (self_2->eol))
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   if (!g_date_valid (self_1->eol) || !g_date_valid (self_2->eol))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_date_compare (self_1->eol, self_2->eol) != 0)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }

--- a/modulemd/modulemd-subdocument-info.c
+++ b/modulemd/modulemd-subdocument-info.c
@@ -228,14 +228,16 @@ modulemd_subdocument_info_get_data_parser (ModulemdSubdocumentInfo *self,
                   /* We have arrived at the "data". Return. */
                   return TRUE;
                 }
-              else if (g_str_equal (event.data.scalar.value, "document") ||
-                       g_str_equal (event.data.scalar.value, "version"))
+              if (g_str_equal (event.data.scalar.value, "document") ||
+                  g_str_equal (event.data.scalar.value, "version"))
                 {
                   /* Always kip over the contents of document and version,
                    * since it was already parsed when we created this subdoc.
                    */
                   if (!skip_unknown_yaml (parser, error))
-                    return FALSE;
+                    {
+                      return FALSE;
+                    }
                 }
               else
                 {

--- a/modulemd/modulemd-subdocument-info.c
+++ b/modulemd/modulemd-subdocument-info.c
@@ -79,14 +79,14 @@ modulemd_subdocument_info_finalize (GObject *object)
 
 void
 modulemd_subdocument_info_set_yaml (ModulemdSubdocumentInfo *self,
-                                    const gchar *yaml)
+                                    const gchar *contents)
 {
   g_return_if_fail (MODULEMD_IS_SUBDOCUMENT_INFO (self));
 
-  g_debug ("Setting YAML: %s\n", yaml);
+  g_debug ("Setting YAML: %s\n", contents);
 
   g_clear_pointer (&self->contents, g_free);
-  self->contents = g_strdup (yaml);
+  self->contents = g_strdup (contents);
 }
 
 

--- a/modulemd/modulemd-translation-entry.c
+++ b/modulemd/modulemd-translation-entry.c
@@ -500,7 +500,8 @@ modulemd_translation_entry_emit_yaml_profiles (ModulemdTranslationEntry *self,
   int ret;
   g_autoptr (GError) nested_error = NULL;
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
   MMD_INIT_YAML_EVENT (event);
 
   ret = mmd_emitter_scalar (

--- a/modulemd/modulemd-translation.c
+++ b/modulemd/modulemd-translation.c
@@ -16,12 +16,12 @@
 #include <yaml.h>
 
 #include "modulemd-errors.h"
-#include "modulemd-translation.h"
 #include "modulemd-translation-entry.h"
+#include "modulemd-translation.h"
 #include "private/glib-extensions.h"
-#include "private/modulemd-translation-private.h"
-#include "private/modulemd-translation-entry-private.h"
 #include "private/modulemd-subdocument-info-private.h"
+#include "private/modulemd-translation-entry-private.h"
+#include "private/modulemd-translation-private.h"
 #include "private/modulemd-util.h"
 #include "private/modulemd-yaml.h"
 
@@ -78,7 +78,8 @@ ModulemdTranslation *
 modulemd_translation_copy (ModulemdTranslation *self)
 {
   g_autoptr (ModulemdTranslation) t = NULL;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
   GHashTableIter iter;
 
   g_return_val_if_fail (MODULEMD_IS_TRANSLATION (self), NULL);
@@ -430,10 +431,13 @@ modulemd_translation_parse_yaml_entries (yaml_parser_t *parser,
             strict,
             &nested_error);
           if (te == NULL)
-            MMD_YAML_ERROR_EVENT_EXIT (error,
-                                       event,
-                                       "Failed to parse translation entry: %s",
-                                       nested_error->message);
+            {
+              MMD_YAML_ERROR_EVENT_EXIT (
+                error,
+                event,
+                "Failed to parse translation entry: %s",
+                nested_error->message);
+            }
 
 
           locale = g_strdup (modulemd_translation_entry_get_locale (te));
@@ -485,7 +489,9 @@ modulemd_translation_parse_yaml (ModulemdSubdocumentInfo *subdoc,
 
   if (!modulemd_subdocument_info_get_data_parser (
         subdoc, &parser, strict, error))
-    return NULL;
+    {
+      return NULL;
+    }
 
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
@@ -519,11 +525,13 @@ modulemd_translation_parse_yaml (ModulemdSubdocumentInfo *subdoc,
                 }
               value = modulemd_yaml_parse_string (&parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse module name in translation data: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse module name in translation data: %s",
+                    nested_error->message);
+                }
 
               modulemd_translation_set_module_name (t, value);
               g_clear_pointer (&value, g_free);
@@ -538,11 +546,13 @@ modulemd_translation_parse_yaml (ModulemdSubdocumentInfo *subdoc,
                 }
               value = modulemd_yaml_parse_string (&parser, &nested_error);
               if (!value)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse module stream in translation data: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse module stream in translation data: %s",
+                    nested_error->message);
+                }
 
               modulemd_translation_set_module_stream (t, value);
               g_clear_pointer (&value, g_free);
@@ -551,11 +561,13 @@ modulemd_translation_parse_yaml (ModulemdSubdocumentInfo *subdoc,
             {
               modified = modulemd_yaml_parse_uint64 (&parser, &nested_error);
               if (nested_error)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse modified in translation data: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse modified in translation data: %s",
+                    nested_error->message);
+                }
 
               modulemd_translation_set_modified (t, modified);
             }
@@ -564,11 +576,13 @@ modulemd_translation_parse_yaml (ModulemdSubdocumentInfo *subdoc,
               entries = modulemd_translation_parse_yaml_entries (
                 &parser, strict, &nested_error);
               if (!entries)
-                MMD_YAML_ERROR_EVENT_EXIT (
-                  error,
-                  event,
-                  "Failed to parse translations in translation data: %s",
-                  nested_error->message);
+                {
+                  MMD_YAML_ERROR_EVENT_EXIT (
+                    error,
+                    event,
+                    "Failed to parse translations in translation data: %s",
+                    nested_error->message);
+                }
 
               g_hash_table_unref (t->translation_entries);
               t->translation_entries = g_steal_pointer (&entries);
@@ -596,10 +610,12 @@ modulemd_translation_parse_yaml (ModulemdSubdocumentInfo *subdoc,
     }
 
   if (!modulemd_translation_validate (t, &nested_error))
-    MMD_YAML_ERROR_EVENT_EXIT (error,
-                               event,
-                               "Unable to validate translation object: %s",
-                               nested_error->message);
+    {
+      MMD_YAML_ERROR_EVENT_EXIT (error,
+                                 event,
+                                 "Unable to validate translation object: %s",
+                                 nested_error->message);
+    }
 
   return g_steal_pointer (&t);
 }
@@ -611,10 +627,13 @@ modulemd_translation_emit_yaml_entries (ModulemdTranslation *self,
 {
   GHashTableIter iter;
   g_autoptr (GError) nested_error = NULL;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
 
   if (!mmd_emitter_start_mapping (emitter, YAML_BLOCK_MAPPING_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   g_hash_table_iter_init (&iter, self->translation_entries);
   while (g_hash_table_iter_next (&iter, &key, &value))
@@ -630,7 +649,9 @@ modulemd_translation_emit_yaml_entries (ModulemdTranslation *self,
     }
 
   if (!mmd_emitter_end_mapping (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -661,59 +682,85 @@ modulemd_translation_emit_yaml (ModulemdTranslation *self,
         MODULEMD_YAML_DOC_TRANSLATIONS,
         modulemd_translation_get_version (self),
         error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   /* Start data: */
   if (!mmd_emitter_start_mapping (emitter, YAML_BLOCK_MAPPING_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (emitter, "module", YAML_PLAIN_SCALAR_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (emitter,
                            modulemd_translation_get_module_name (self),
                            YAML_PLAIN_SCALAR_STYLE,
                            error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (emitter, "stream", YAML_PLAIN_SCALAR_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (emitter,
                            modulemd_translation_get_module_stream (self),
                            YAML_PLAIN_SCALAR_STYLE,
                            error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (
         emitter, "modified", YAML_PLAIN_SCALAR_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (
         emitter, modified_string, YAML_PLAIN_SCALAR_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (g_hash_table_size (self->translation_entries) != 0)
     {
       if (!mmd_emitter_scalar (
             emitter, "translations", YAML_PLAIN_SCALAR_STYLE, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
 
       if (!modulemd_translation_emit_yaml_entries (self, emitter, error))
-        return FALSE;
+        {
+          return FALSE;
+        }
     }
 
   /* Close the data: mapping */
   if (!mmd_emitter_end_mapping (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   /* Close top-level mapping */
   if (!mmd_emitter_end_mapping (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   /* Close document */
   if (!mmd_emitter_end_document (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }

--- a/modulemd/modulemd-util.c
+++ b/modulemd/modulemd-util.c
@@ -49,7 +49,8 @@ modulemd_hash_table_deep_str_copy (GHashTable *orig)
 {
   GHashTable *new;
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
 
   g_return_val_if_fail (orig, NULL);
 
@@ -71,7 +72,8 @@ modulemd_hash_table_deep_set_copy (GHashTable *orig)
 {
   GHashTable *new;
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
 
   g_return_val_if_fail (orig, NULL);
 
@@ -92,7 +94,8 @@ modulemd_hash_table_deep_str_set_copy (GHashTable *orig)
 {
   GHashTable *new;
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
 
   g_return_val_if_fail (orig, NULL);
 
@@ -116,7 +119,8 @@ modulemd_hash_table_deep_str_str_set_copy (GHashTable *orig)
 {
   GHashTable *new;
   GHashTableIter iter;
-  gpointer key, value;
+  gpointer key;
+  gpointer value;
 
   g_return_val_if_fail (orig, NULL);
 
@@ -266,7 +270,9 @@ void
 modulemd_hash_table_unref (void *table)
 {
   if (!table)
-    return;
+    {
+      return;
+    }
 
   g_hash_table_unref ((GHashTable *)table);
 }
@@ -400,7 +406,9 @@ modulemd_boolean_equals (gboolean a, gboolean b)
    * be canonicalized before comparing for equality.
    */
   if (!!a == !!b)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   return FALSE;
 }

--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -16,9 +16,9 @@
 #include "private/modulemd-module-index-private.h"
 #include "private/modulemd-yaml.h"
 
+#include <errno.h>
 #include <glib.h>
 #include <locale.h>
-#include <errno.h>
 
 enum mmd_verbosity
 {
@@ -112,7 +112,7 @@ parse_file (const gchar *filename, GPtrArray **failures, GError **error)
     }
 
   /* Parse documents */
-  yaml_stream = g_fopen (filename, "rb");
+  yaml_stream = g_fopen (filename, "rbe");
   saved_errno = errno;
 
   if (yaml_stream == NULL)

--- a/modulemd/modulemd-yaml-util.c
+++ b/modulemd/modulemd-yaml-util.c
@@ -11,13 +11,13 @@
  * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
  */
 
-#include <glib.h>
-#include <yaml.h>
-#include <inttypes.h>
 #include "modulemd-errors.h"
 #include "private/modulemd-subdocument-info-private.h"
 #include "private/modulemd-util.h"
 #include "private/modulemd-yaml.h"
+#include <glib.h>
+#include <inttypes.h>
+#include <yaml.h>
 
 
 GQuark
@@ -409,7 +409,7 @@ modulemd_yaml_parse_bool (yaml_parser_t *parser, GError **error)
     {
       return FALSE;
     }
-  else if (g_str_equal ((const gchar *)event.data.scalar.value, "true"))
+  if (g_str_equal ((const gchar *)event.data.scalar.value, "true"))
     {
       return TRUE;
     }
@@ -473,7 +473,10 @@ modulemd_yaml_parse_string_set (yaml_parser_t *parser, GError **error)
 
         case YAML_SEQUENCE_END_EVENT:
           if (!in_list)
-            MMD_YAML_ERROR_EVENT_EXIT (error, event, "Unexpected end of list");
+            {
+              MMD_YAML_ERROR_EVENT_EXIT (
+                error, event, "Unexpected end of list");
+            }
           in_list = FALSE;
           done = TRUE;
           break;
@@ -527,15 +530,20 @@ modulemd_yaml_parse_string_set_from_map (yaml_parser_t *parser,
 
         case YAML_MAPPING_END_EVENT:
           if (!in_map)
-            MMD_YAML_ERROR_EVENT_EXIT (error, event, "Unexpected end of map");
+            {
+              MMD_YAML_ERROR_EVENT_EXIT (
+                error, event, "Unexpected end of map");
+            }
           in_map = FALSE;
           done = TRUE;
           break;
 
         case YAML_SCALAR_EVENT:
           if (!in_map)
-            MMD_YAML_ERROR_EVENT_EXIT (
-              error, event, "Unexpected scalar outside of map.");
+            {
+              MMD_YAML_ERROR_EVENT_EXIT (
+                error, event, "Unexpected scalar outside of map.");
+            }
 
           if (g_str_equal ((const gchar *)event.data.scalar.value, key))
             {
@@ -654,7 +662,9 @@ modulemd_yaml_parse_document_type_internal (
    * But we still emit it.
    */
   if (!mmd_emitter_start_document (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   /* The second event must be the mapping start */
   YAML_PARSER_PARSE_WITH_EXIT_BOOL (parser, &event, error);
@@ -677,7 +687,9 @@ modulemd_yaml_parse_document_type_internal (
         {
         case YAML_MAPPING_END_EVENT:
           if (!mmd_emitter_end_mapping (emitter, error))
-            return FALSE;
+            {
+              return FALSE;
+            }
           depth--;
           if (depth == 0)
             {
@@ -688,7 +700,9 @@ modulemd_yaml_parse_document_type_internal (
         case YAML_MAPPING_START_EVENT:
           if (!mmd_emitter_start_mapping (
                 emitter, event.data.mapping_start.style, error))
-            return FALSE;
+            {
+              return FALSE;
+            }
           depth++;
           break;
 
@@ -697,7 +711,9 @@ modulemd_yaml_parse_document_type_internal (
                                    (const gchar *)event.data.scalar.value,
                                    event.data.scalar.style,
                                    error))
-            return FALSE;
+            {
+              return FALSE;
+            }
 
           if (depth == 1 && g_str_equal (event.data.scalar.value, "document"))
             {
@@ -718,7 +734,9 @@ modulemd_yaml_parse_document_type_internal (
                                        (const gchar *)doctype_scalar,
                                        YAML_PLAIN_SCALAR_STYLE,
                                        error))
-                return FALSE;
+                {
+                  return FALSE;
+                }
 
               if (g_str_equal (doctype_scalar, "modulemd"))
                 {
@@ -761,7 +779,9 @@ modulemd_yaml_parse_document_type_internal (
               mdversion_string = g_strdup_printf ("%" PRIu64, mdversion);
               if (!mmd_emitter_scalar (
                     emitter, mdversion_string, YAML_PLAIN_SCALAR_STYLE, error))
-                return FALSE;
+                {
+                  return FALSE;
+                }
             }
           else if (depth == 1 && g_str_equal (event.data.scalar.value, "data"))
             {
@@ -793,7 +813,9 @@ modulemd_yaml_parse_document_type_internal (
   yaml_event_delete (&event);
 
   if (!mmd_emitter_end_stream (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (doctype == MODULEMD_YAML_DOC_UNKNOWN)
     {
@@ -880,28 +902,42 @@ modulemd_yaml_emit_document_headers (yaml_emitter_t *emitter,
   g_autofree gchar *mdversion_string = g_strdup_printf ("%" PRIu64, mdversion);
 
   if (!mmd_emitter_start_document (emitter, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_start_mapping (emitter, YAML_BLOCK_MAPPING_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (
         emitter, "document", YAML_PLAIN_SCALAR_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (
         emitter, doctype_string, YAML_PLAIN_SCALAR_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (emitter, "version", YAML_PLAIN_SCALAR_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (
         emitter, mdversion_string, YAML_PLAIN_SCALAR_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   if (!mmd_emitter_scalar (emitter, "data", YAML_PLAIN_SCALAR_STYLE, error))
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return TRUE;
 }
@@ -925,9 +961,13 @@ modulemd_yaml_emit_variant (yaml_emitter_t *emitter,
   else if (g_variant_is_of_type (variant, G_VARIANT_TYPE_BOOLEAN))
     {
       if (g_variant_get_boolean (variant))
-        EMIT_SCALAR (emitter, error, "TRUE");
+        {
+          EMIT_SCALAR (emitter, error, "TRUE");
+        }
       else
-        EMIT_SCALAR (emitter, error, "FALSE");
+        {
+          EMIT_SCALAR (emitter, error, "FALSE");
+        }
     }
   else if (g_variant_is_of_type (variant, G_VARIANT_TYPE_DICTIONARY))
     {
@@ -963,7 +1003,9 @@ modulemd_yaml_emit_variant (yaml_emitter_t *emitter,
             }
           EMIT_SCALAR (emitter, error, g_ptr_array_index (keys, i));
           if (!modulemd_yaml_emit_variant (emitter, value, error))
-            return FALSE;
+            {
+              return FALSE;
+            }
 
           g_clear_pointer (&value, g_variant_unref);
         }
@@ -978,7 +1020,9 @@ modulemd_yaml_emit_variant (yaml_emitter_t *emitter,
       while ((value = g_variant_iter_next_value (&iter)))
         {
           if (!modulemd_yaml_emit_variant (emitter, value, error))
-            return FALSE;
+            {
+              return FALSE;
+            }
           g_clear_pointer (&value, g_variant_unref);
         }
       EMIT_SEQUENCE_END (emitter, error);

--- a/modulemd/tests/ModulemdTests/base.py
+++ b/modulemd/tests/ModulemdTests/base.py
@@ -19,7 +19,6 @@ import unittest
 
 
 class TestBase(unittest.TestCase):
-
     def __init__(self, *args, **kwargs):
         super(TestBase, self).__init__(*args, **kwargs)
         self._caught_signal = False
@@ -39,9 +38,8 @@ class TestBase(unittest.TestCase):
 
     @contextmanager
     def expect_signal(
-            self,
-            expected_signal=signal.SIGTRAP,
-            only_on_fatal_warnings=False):
+        self, expected_signal=signal.SIGTRAP, only_on_fatal_warnings=False
+    ):
         expect_signal = (not only_on_fatal_warnings) or self.warnings_fatal
 
         self._caught_signal = False

--- a/modulemd/tests/ModulemdTests/buildopts.py
+++ b/modulemd/tests/ModulemdTests/buildopts.py
@@ -13,10 +13,12 @@
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 import sys
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
 except ImportError:
     # Return error 77 to skip this test on platforms without the necessary
@@ -27,7 +29,6 @@ from base import TestBase
 
 
 class TestBuildopts(TestBase):
-
     def test_constructor(self):
         # Test that the new() function works
         b = Modulemd.Buildopts.new()
@@ -37,10 +38,10 @@ class TestBuildopts(TestBase):
         assert b.get_rpm_whitelist() == []
 
         # Test that init works with rpm_macros
-        b = Modulemd.Buildopts(rpm_macros='Test macros')
+        b = Modulemd.Buildopts(rpm_macros="Test macros")
         assert b
-        assert b.props.rpm_macros == 'Test macros'
-        assert b.get_rpm_macros() == 'Test macros'
+        assert b.props.rpm_macros == "Test macros"
+        assert b.get_rpm_macros() == "Test macros"
         assert b.get_rpm_whitelist() == []
 
     def test_copy(self):
@@ -51,16 +52,16 @@ class TestBuildopts(TestBase):
         assert b.get_rpm_macros() is None
         assert b.get_rpm_whitelist() == []
 
-        b_orig.set_rpm_macros('Test macros')
-        b.add_rpm_to_whitelist('test2')
-        b.add_rpm_to_whitelist('test3')
-        b.add_rpm_to_whitelist('test1')
+        b_orig.set_rpm_macros("Test macros")
+        b.add_rpm_to_whitelist("test2")
+        b.add_rpm_to_whitelist("test3")
+        b.add_rpm_to_whitelist("test1")
 
         b = b_orig.copy()
         assert b
-        assert b.props.rpm_macros == 'Test macros'
-        assert b.get_rpm_macros() == 'Test macros'
-        assert b.get_rpm_whitelist() == ['test1', 'test2', 'test3']
+        assert b.props.rpm_macros == "Test macros"
+        assert b.get_rpm_macros() == "Test macros"
+        assert b.get_rpm_whitelist() == ["test1", "test2", "test3"]
 
     def test_get_set_rpm_macros(self):
         b = Modulemd.Buildopts()
@@ -68,13 +69,13 @@ class TestBuildopts(TestBase):
         assert b.props.rpm_macros is None
         assert b.get_rpm_macros() is None
 
-        b.set_rpm_macros('foobar')
-        assert b.props.rpm_macros == 'foobar'
-        assert b.get_rpm_macros() == 'foobar'
+        b.set_rpm_macros("foobar")
+        assert b.props.rpm_macros == "foobar"
+        assert b.get_rpm_macros() == "foobar"
 
-        b.props.rpm_macros = 'barfoo'
-        assert b.props.rpm_macros == 'barfoo'
-        assert b.get_rpm_macros() == 'barfoo'
+        b.props.rpm_macros = "barfoo"
+        assert b.props.rpm_macros == "barfoo"
+        assert b.get_rpm_macros() == "barfoo"
 
         b.props.rpm_macros = None
         assert b.props.rpm_macros is None
@@ -85,19 +86,19 @@ class TestBuildopts(TestBase):
 
         assert b.get_rpm_whitelist() == []
 
-        b.add_rpm_to_whitelist('test2')
-        assert b.get_rpm_whitelist() == ['test2']
+        b.add_rpm_to_whitelist("test2")
+        assert b.get_rpm_whitelist() == ["test2"]
 
-        b.add_rpm_to_whitelist('test3')
-        b.add_rpm_to_whitelist('test1')
-        assert b.get_rpm_whitelist() == ['test1', 'test2', 'test3']
+        b.add_rpm_to_whitelist("test3")
+        b.add_rpm_to_whitelist("test1")
+        assert b.get_rpm_whitelist() == ["test1", "test2", "test3"]
 
-        b.add_rpm_to_whitelist('test2')
-        assert b.get_rpm_whitelist() == ['test1', 'test2', 'test3']
+        b.add_rpm_to_whitelist("test2")
+        assert b.get_rpm_whitelist() == ["test1", "test2", "test3"]
 
-        b.remove_rpm_from_whitelist('test1')
-        assert b.get_rpm_whitelist() == ['test2', 'test3']
+        b.remove_rpm_from_whitelist("test1")
+        assert b.get_rpm_whitelist() == ["test2", "test3"]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/componentrpm.py
+++ b/modulemd/tests/ModulemdTests/componentrpm.py
@@ -13,10 +13,12 @@
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 import sys
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository.Modulemd import ComponentRpm
 except ImportError:
     # Return error 77 to skip this test on platforms without the necessary
@@ -27,7 +29,6 @@ from base import TestBase
 
 
 class TestComponentRpm(TestBase):
-
     def test_constructors(self):
         # Test that the new() function works
         rpm = ComponentRpm.new("testrpm")
@@ -53,26 +54,27 @@ class TestComponentRpm(TestBase):
         rpm = ComponentRpm(
             buildorder=42,
             buildonly=True,
-            name='testrpm',
-            rationale='Testing all the things',
-            ref='someref',
-            repository='somerepo',
-            cache='somecache')
+            name="testrpm",
+            rationale="Testing all the things",
+            ref="someref",
+            repository="somerepo",
+            cache="somecache",
+        )
         assert rpm
         assert rpm.props.buildorder == 42
         assert rpm.get_buildorder() == 42
         assert rpm.props.buildonly is True
         assert rpm.get_buildonly() is True
-        assert rpm.props.name == 'testrpm'
-        assert rpm.get_name() == 'testrpm'
-        assert rpm.props.rationale == 'Testing all the things'
-        assert rpm.get_rationale() == 'Testing all the things'
-        assert rpm.props.ref == 'someref'
-        assert rpm.get_ref() == 'someref'
-        assert rpm.props.repository == 'somerepo'
-        assert rpm.get_repository() == 'somerepo'
-        assert rpm.props.cache == 'somecache'
-        assert rpm.get_cache() == 'somecache'
+        assert rpm.props.name == "testrpm"
+        assert rpm.get_name() == "testrpm"
+        assert rpm.props.rationale == "Testing all the things"
+        assert rpm.get_rationale() == "Testing all the things"
+        assert rpm.props.ref == "someref"
+        assert rpm.get_ref() == "someref"
+        assert rpm.props.repository == "somerepo"
+        assert rpm.get_repository() == "somerepo"
+        assert rpm.props.cache == "somecache"
+        assert rpm.get_cache() == "somecache"
         assert rpm.get_arches() == []
         assert rpm.get_multilib_arches() == []
 
@@ -80,15 +82,16 @@ class TestComponentRpm(TestBase):
         rpm_orig = ComponentRpm(
             buildorder=42,
             buildonly=True,
-            name='testrpm',
-            rationale='Testing all the things',
-            ref='someref',
-            repository='somerepo',
-            cache='somecache')
-        rpm_orig.add_restricted_arch('x86_64')
-        rpm_orig.add_restricted_arch('i386')
-        rpm_orig.add_multilib_arch('ppc64le')
-        rpm_orig.add_multilib_arch('s390x')
+            name="testrpm",
+            rationale="Testing all the things",
+            ref="someref",
+            repository="somerepo",
+            cache="somecache",
+        )
+        rpm_orig.add_restricted_arch("x86_64")
+        rpm_orig.add_restricted_arch("i386")
+        rpm_orig.add_multilib_arch("ppc64le")
+        rpm_orig.add_multilib_arch("s390x")
 
         rpm = rpm_orig.copy()
         assert rpm
@@ -96,28 +99,26 @@ class TestComponentRpm(TestBase):
         assert rpm.get_buildorder() == 42
         assert rpm.props.buildonly is True
         assert rpm.get_buildonly() is True
-        assert rpm.props.name == 'testrpm'
-        assert rpm.get_name() == 'testrpm'
-        assert rpm.props.rationale == 'Testing all the things'
-        assert rpm.get_rationale() == 'Testing all the things'
-        assert rpm.props.ref == 'someref'
-        assert rpm.get_ref() == 'someref'
-        assert rpm.props.repository == 'somerepo'
-        assert rpm.get_repository() == 'somerepo'
-        assert rpm.props.cache == 'somecache'
-        assert rpm.get_cache() == 'somecache'
-        self.assertListEqual(rpm.get_arches(), ['i386', 'x86_64'])
-        self.assertListEqual(
-            rpm.get_multilib_arches(), [
-                'ppc64le', 's390x'])
+        assert rpm.props.name == "testrpm"
+        assert rpm.get_name() == "testrpm"
+        assert rpm.props.rationale == "Testing all the things"
+        assert rpm.get_rationale() == "Testing all the things"
+        assert rpm.props.ref == "someref"
+        assert rpm.get_ref() == "someref"
+        assert rpm.props.repository == "somerepo"
+        assert rpm.get_repository() == "somerepo"
+        assert rpm.props.cache == "somecache"
+        assert rpm.get_cache() == "somecache"
+        self.assertListEqual(rpm.get_arches(), ["i386", "x86_64"])
+        self.assertListEqual(rpm.get_multilib_arches(), ["ppc64le", "s390x"])
 
     def test_arches(self):
         rpm = ComponentRpm.new("testrpm")
         assert rpm
 
-        rpm.add_restricted_arch('x86_64')
-        rpm.add_restricted_arch('i386')
-        self.assertListEqual(rpm.get_arches(), ['i386', 'x86_64'])
+        rpm.add_restricted_arch("x86_64")
+        rpm.add_restricted_arch("i386")
+        self.assertListEqual(rpm.get_arches(), ["i386", "x86_64"])
 
         rpm.reset_arches()
         self.assertListEqual(rpm.get_arches(), [])
@@ -126,15 +127,13 @@ class TestComponentRpm(TestBase):
         rpm = ComponentRpm.new("testrpm")
         assert rpm
 
-        rpm.add_multilib_arch('ppc64le')
-        rpm.add_multilib_arch('s390x')
-        self.assertListEqual(
-            rpm.get_multilib_arches(), [
-                'ppc64le', 's390x'])
+        rpm.add_multilib_arch("ppc64le")
+        rpm.add_multilib_arch("s390x")
+        self.assertListEqual(rpm.get_multilib_arches(), ["ppc64le", "s390x"])
 
         rpm.reset_multilib_arches()
         self.assertListEqual(rpm.get_multilib_arches(), [])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/defaults.py
+++ b/modulemd/tests/ModulemdTests/defaults.py
@@ -18,7 +18,8 @@ import sys
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
 except ImportError:
     # Return error 77 to skip this test on platforms without the necessary
@@ -29,42 +30,45 @@ from base import TestBase
 
 
 class TestDefaults(TestBase):
-
     def test_constructors(self):
         # Test that the new() function works
-        defs = Modulemd.Defaults.new(
-            Modulemd.DefaultsVersionEnum.ONE, 'foo')
+        defs = Modulemd.Defaults.new(Modulemd.DefaultsVersionEnum.ONE, "foo")
         assert defs
 
         assert defs.props.mdversion == Modulemd.DefaultsVersionEnum.ONE
         assert defs.get_mdversion() == Modulemd.DefaultsVersionEnum.ONE
 
-        assert defs.props.module_name == 'foo'
-        assert defs.get_module_name() == 'foo'
+        assert defs.props.module_name == "foo"
+        assert defs.get_module_name() == "foo"
 
         # Test that we cannot instantiate directly
-        with self.assertRaisesRegexp(TypeError, 'cannot create instance of abstract'):
+        with self.assertRaisesRegexp(
+            TypeError, "cannot create instance of abstract"
+        ):
             Modulemd.Defaults()
 
         # Test with a zero mdversion
-        with self.assertRaisesRegexp(TypeError, 'constructor returned NULL'):
+        with self.assertRaisesRegexp(TypeError, "constructor returned NULL"):
             with self.expect_signal():
-                defs = Modulemd.Defaults.new(0, 'foo')
+                defs = Modulemd.Defaults.new(0, "foo")
 
         # Test with an unknown mdversion
-        with self.assertRaisesRegexp(TypeError, 'constructor returned NULL'):
+        with self.assertRaisesRegexp(TypeError, "constructor returned NULL"):
             with self.expect_signal():
                 defs = Modulemd.Defaults.new(
-                    Modulemd.DefaultsVersionEnum.LATEST + 1, 'foo')
+                    Modulemd.DefaultsVersionEnum.LATEST + 1, "foo"
+                )
 
         # Test with no name
-        with self.assertRaisesRegexp(TypeError, 'does not allow None as a value'):
+        with self.assertRaisesRegexp(
+            TypeError, "does not allow None as a value"
+        ):
             defs = Modulemd.Defaults.new(
-                Modulemd.DefaultsVersionEnum.ONE, None)
+                Modulemd.DefaultsVersionEnum.ONE, None
+            )
 
     def test_copy(self):
-        defs = Modulemd.Defaults.new(
-            Modulemd.DefaultsVersionEnum.ONE, 'foo')
+        defs = Modulemd.Defaults.new(Modulemd.DefaultsVersionEnum.ONE, "foo")
         assert defs
 
         copied_defs = defs.copy()
@@ -74,23 +78,25 @@ class TestDefaults(TestBase):
 
     def test_mdversion(self):
         defs = Modulemd.Defaults.new(
-            Modulemd.DefaultsVersionEnum.LATEST, 'foo')
+            Modulemd.DefaultsVersionEnum.LATEST, "foo"
+        )
         assert defs
 
         assert defs.props.mdversion == Modulemd.DefaultsVersionEnum.ONE
         assert defs.get_mdversion() == Modulemd.DefaultsVersionEnum.ONE
 
         # Ensure we cannot set the mdversion
-        with self.assertRaisesRegexp(TypeError, 'is not writable'):
+        with self.assertRaisesRegexp(TypeError, "is not writable"):
             defs.props.mdversion = 0
 
     def test_module_name(self):
         defs = Modulemd.Defaults.new(
-            Modulemd.DefaultsVersionEnum.LATEST, 'foo')
+            Modulemd.DefaultsVersionEnum.LATEST, "foo"
+        )
         assert defs
 
-        assert defs.props.module_name == 'foo'
-        assert defs.get_module_name() == 'foo'
+        assert defs.props.module_name == "foo"
+        assert defs.get_module_name() == "foo"
 
         # Ensure we cannot set the module_name
         with self.expect_signal():
@@ -98,7 +104,8 @@ class TestDefaults(TestBase):
 
     def test_modified(self):
         defs = Modulemd.Defaults.new(
-            Modulemd.DefaultsVersionEnum.LATEST, 'foo')
+            Modulemd.DefaultsVersionEnum.LATEST, "foo"
+        )
         self.assertIsNotNone(defs)
 
         self.assertEqual(defs.get_modified(), 0)
@@ -109,8 +116,10 @@ class TestDefaults(TestBase):
 
         # Load a defaults object into an Index
         index = Modulemd.ModuleIndex.new()
-        index.update_from_file("%s/mod-defaults/spec.v1.yaml" % (
-            os.getenv('MESON_SOURCE_ROOT')), True)
+        index.update_from_file(
+            "%s/mod-defaults/spec.v1.yaml" % (os.getenv("MESON_SOURCE_ROOT")),
+            True,
+        )
         module_names = index.get_module_names()
         self.assertEqual(len(module_names), 1)
 
@@ -121,28 +130,28 @@ class TestDefaults(TestBase):
 
     def test_validate(self):
         defs = Modulemd.Defaults.new(
-            Modulemd.DefaultsVersionEnum.LATEST, 'foo')
+            Modulemd.DefaultsVersionEnum.LATEST, "foo"
+        )
         assert defs
 
         assert defs.validate()
 
     def test_upgrade(self):
-        defs = Modulemd.Defaults.new(
-            Modulemd.DefaultsVersionEnum.ONE, 'foo')
+        defs = Modulemd.Defaults.new(Modulemd.DefaultsVersionEnum.ONE, "foo")
         assert defs
 
         # test upgrading to the same version
         upgraded_defs = defs.upgrade(Modulemd.DefaultsVersionEnum.ONE)
         assert upgraded_defs
         assert defs.props.mdversion == Modulemd.DefaultsVersionEnum.ONE
-        assert defs.props.module_name == 'foo'
+        assert defs.props.module_name == "foo"
 
         # test upgrading to the latest version
         upgraded_defs = defs.upgrade(Modulemd.DefaultsVersionEnum.LATEST)
         assert upgraded_defs
         assert defs.props.mdversion == Modulemd.DefaultsVersionEnum.LATEST
-        assert defs.props.module_name == 'foo'
+        assert defs.props.module_name == "foo"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/defaultsv1.py
+++ b/modulemd/tests/ModulemdTests/defaultsv1.py
@@ -13,10 +13,12 @@
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 import sys
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
 except ImportError:
     # Return error 77 to skip this test on platforms without the necessary
@@ -27,30 +29,31 @@ from base import TestBase
 
 
 class TestDefaults(TestBase):
-
     def test_constructors(self):
         # Test that the new() function works
-        defs = Modulemd.DefaultsV1.new('foo')
+        defs = Modulemd.DefaultsV1.new("foo")
         assert defs
         assert defs.props.mdversion == Modulemd.DefaultsVersionEnum.ONE
         assert defs.get_mdversion() == Modulemd.DefaultsVersionEnum.ONE
-        assert defs.props.module_name == 'foo'
-        assert defs.get_module_name() == 'foo'
+        assert defs.props.module_name == "foo"
+        assert defs.get_module_name() == "foo"
 
         # Test gobject instantiation
-        defs = Modulemd.DefaultsV1(module_name='foo')
+        defs = Modulemd.DefaultsV1(module_name="foo")
         assert defs
         assert defs.props.mdversion == Modulemd.DefaultsVersionEnum.ONE
         assert defs.get_mdversion() == Modulemd.DefaultsVersionEnum.ONE
-        assert defs.props.module_name == 'foo'
-        assert defs.get_module_name() == 'foo'
+        assert defs.props.module_name == "foo"
+        assert defs.get_module_name() == "foo"
 
         # Test with no name
-        with self.assertRaisesRegexp(TypeError, 'does not allow None as a value'):
+        with self.assertRaisesRegexp(
+            TypeError, "does not allow None as a value"
+        ):
             defs = Modulemd.DefaultsV1.new(None)
 
     def test_copy(self):
-        defs = Modulemd.DefaultsV1.new('foo')
+        defs = Modulemd.DefaultsV1.new("foo")
         assert defs
 
         copied_defs = defs.copy()
@@ -68,10 +71,11 @@ class TestDefaults(TestBase):
         assert copied_defs.props.module_name == defs.props.module_name
         assert copied_defs.get_default_stream() == defs.get_default_stream()
         assert copied_defs.get_default_stream(
-            "server_intent") == defs.get_default_stream("server_intent")
+            "server_intent"
+        ) == defs.get_default_stream("server_intent")
 
     def test_get_set_default_stream(self):
-        defs = Modulemd.DefaultsV1.new('foo')
+        defs = Modulemd.DefaultsV1.new("foo")
         assert defs
         defs.set_default_stream("latest")
         assert defs.get_default_stream() == "latest"
@@ -86,25 +90,25 @@ class TestDefaults(TestBase):
         assert defs.get_default_stream("minimal_intent") is None
 
     def test_get_set_profiles(self):
-        defs = Modulemd.DefaultsV1.new('foo')
+        defs = Modulemd.DefaultsV1.new("foo")
 
         defs.add_default_profile_for_stream("latest", "client")
         defs.add_default_profile_for_stream("latest", "server")
         defs.add_default_profile_for_stream(
-            "latest", "server", "server_intent")
+            "latest", "server", "server_intent"
+        )
 
-        assert "client" in defs.get_default_profiles_for_stream(
-            "latest")
-        assert "client" in defs.get_default_profiles_for_stream(
-            "latest")
+        assert "client" in defs.get_default_profiles_for_stream("latest")
+        assert "client" in defs.get_default_profiles_for_stream("latest")
 
     def test_validate(self):
         defs = Modulemd.Defaults.new(
-            Modulemd.DefaultsVersionEnum.LATEST, 'foo')
+            Modulemd.DefaultsVersionEnum.LATEST, "foo"
+        )
         assert defs
 
         assert defs.validate()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/dependencies.py
+++ b/modulemd/tests/ModulemdTests/dependencies.py
@@ -13,10 +13,12 @@
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 import sys
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
 except ImportError:
     # Return error 77 to skip this test on platforms without the necessary
@@ -27,7 +29,6 @@ from base import TestBase
 
 
 class TestDependencies(TestBase):
-
     def test_constructor(self):
         # Test that the new() function works
         d = Modulemd.Dependencies.new()
@@ -69,15 +70,13 @@ class TestDependencies(TestBase):
 
         d = d_orig.copy()
         assert d
-        assert d.get_buildtime_modules() == ['builddef', 'buildmod1']
-        assert d.get_buildtime_streams('builddef') == []
-        assert d.get_buildtime_streams(
-            'buildmod1') == ['stream1', 'stream2']
-        assert d.get_runtime_modules() == ['rundef', 'runmod1']
-        assert d.get_runtime_streams('rundef') == []
-        assert d.get_runtime_streams(
-            'runmod1') == ['stream3', 'stream4']
+        assert d.get_buildtime_modules() == ["builddef", "buildmod1"]
+        assert d.get_buildtime_streams("builddef") == []
+        assert d.get_buildtime_streams("buildmod1") == ["stream1", "stream2"]
+        assert d.get_runtime_modules() == ["rundef", "runmod1"]
+        assert d.get_runtime_streams("rundef") == []
+        assert d.get_runtime_streams("runmod1") == ["stream3", "stream4"]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/merger.py
+++ b/modulemd/tests/ModulemdTests/merger.py
@@ -15,10 +15,12 @@
 from os import path
 import sys
 import logging
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
     from gi.repository import GLib
 except ImportError:
@@ -31,7 +33,6 @@ import random
 
 
 class TestModuleIndexMerger(TestBase):
-
     def test_constructors(self):
         merger = Modulemd.ModuleIndexMerger()
         self.assertIsNotNone(merger)
@@ -44,13 +45,15 @@ class TestModuleIndexMerger(TestBase):
         idx1 = Modulemd.ModuleIndex()
         idx2 = Modulemd.ModuleIndex()
 
-        res, failures = idx1.update_from_file(path.join(
-            self.test_data_path, "long-valid.yaml"), True)
+        res, failures = idx1.update_from_file(
+            path.join(self.test_data_path, "long-valid.yaml"), True
+        )
         self.assertTrue(res)
         self.assertEqual(len(failures), 0)
 
-        res, failures = idx2.update_from_file(path.join(
-            self.test_data_path, "long-valid.yaml"), True)
+        res, failures = idx2.update_from_file(
+            path.join(self.test_data_path, "long-valid.yaml"), True
+        )
         self.assertTrue(res)
         self.assertEqual(len(failures), 0)
 
@@ -70,47 +73,65 @@ class TestModuleIndexMerger(TestBase):
         # Get a set of objects in a ModuleIndex
         base_index = Modulemd.ModuleIndex()
         base_index.update_from_file(
-            path.join(
-                self.test_data_path,
-                "merging-base.yaml"), True)
+            path.join(self.test_data_path, "merging-base.yaml"), True
+        )
 
         # Baseline
-        httpd_defaults = base_index.get_module('httpd').get_defaults()
+        httpd_defaults = base_index.get_module("httpd").get_defaults()
         self.assertIsNotNone(httpd_defaults)
-        self.assertEqual(httpd_defaults.get_default_stream(), '2.2')
-        httpd_profile_streams = httpd_defaults.get_streams_with_default_profiles()
+        self.assertEqual(httpd_defaults.get_default_stream(), "2.2")
+        httpd_profile_streams = (
+            httpd_defaults.get_streams_with_default_profiles()
+        )
         self.assertEqual(len(httpd_profile_streams), 2)
-        self.assertTrue('2.2' in httpd_profile_streams)
-        self.assertTrue('2.8' in httpd_profile_streams)
+        self.assertTrue("2.2" in httpd_profile_streams)
+        self.assertTrue("2.8" in httpd_profile_streams)
         self.assertEqual(
-            len(httpd_defaults.get_default_profiles_for_stream('2.2')), 2)
+            len(httpd_defaults.get_default_profiles_for_stream("2.2")), 2
+        )
         self.assertTrue(
-            'client' in httpd_defaults.get_default_profiles_for_stream('2.2'))
+            "client" in httpd_defaults.get_default_profiles_for_stream("2.2")
+        )
         self.assertTrue(
-            'server' in httpd_defaults.get_default_profiles_for_stream('2.2'))
+            "server" in httpd_defaults.get_default_profiles_for_stream("2.2")
+        )
         self.assertTrue(
-            'notreal' in httpd_defaults.get_default_profiles_for_stream('2.8'))
+            "notreal" in httpd_defaults.get_default_profiles_for_stream("2.8")
+        )
 
         self.assertEqual(
-            httpd_defaults.get_default_stream('workstation'), '2.4')
+            httpd_defaults.get_default_stream("workstation"), "2.4"
+        )
         httpd_profile_streams = httpd_defaults.get_streams_with_default_profiles(
-            'workstation')
+            "workstation"
+        )
         self.assertEqual(len(httpd_profile_streams), 2)
-        self.assertTrue('2.4' in httpd_profile_streams)
-        self.assertTrue('2.6' in httpd_profile_streams)
+        self.assertTrue("2.4" in httpd_profile_streams)
+        self.assertTrue("2.6" in httpd_profile_streams)
 
         self.assertEqual(
-            len(httpd_defaults.get_default_profiles_for_stream('2.4', 'workstation')), 1)
+            len(
+                httpd_defaults.get_default_profiles_for_stream(
+                    "2.4", "workstation"
+                )
+            ),
+            1,
+        )
         self.assertEqual(
-            len(httpd_defaults.get_default_profiles_for_stream('2.6', 'workstation')), 3)
+            len(
+                httpd_defaults.get_default_profiles_for_stream(
+                    "2.6", "workstation"
+                )
+            ),
+            3,
+        )
 
         # Get another set of objects that will override the default stream for
         # nodejs
         override_nodejs_index = Modulemd.ModuleIndex()
         override_nodejs_index.update_from_file(
-            path.join(
-                self.test_data_path,
-                "overriding-nodejs.yaml"), True)
+            path.join(self.test_data_path, "overriding-nodejs.yaml"), True
+        )
 
         # Test that adding both of these at the same priority level results in
         # the no default stream
@@ -121,7 +142,7 @@ class TestModuleIndexMerger(TestBase):
         merged_index = merger.resolve()
         self.assertIsNotNone(merged_index)
 
-        nodejs = merged_index.get_module('nodejs')
+        nodejs = merged_index.get_module("nodejs")
         self.assertIsNotNone(nodejs)
 
         nodejs_defaults = nodejs.get_defaults()
@@ -131,9 +152,8 @@ class TestModuleIndexMerger(TestBase):
         # Get another set of objects that will override the above
         override_index = Modulemd.ModuleIndex()
         override_index.update_from_file(
-            path.join(
-                self.test_data_path,
-                "overriding.yaml"), True)
+            path.join(self.test_data_path, "overriding.yaml"), True
+        )
 
         # Test that override_index at a higher priority level succeeds
         # Test that adding both of these at the same priority level fails
@@ -144,8 +164,8 @@ class TestModuleIndexMerger(TestBase):
         random_low = random.randint(1, 100)
         random_high = random.randint(101, 999)
         print(
-            "Low priority: %d, High priority: %d" %
-            (random_low, random_high))
+            "Low priority: %d, High priority: %d" % (random_low, random_high)
+        )
         merger.associate_index(base_index, random_low)
         merger.associate_index(override_index, random_high)
 
@@ -155,51 +175,76 @@ class TestModuleIndexMerger(TestBase):
         # Validate merged results
 
         # HTTPD
-        httpd_defaults = merged_index.get_module('httpd').get_defaults()
+        httpd_defaults = merged_index.get_module("httpd").get_defaults()
         self.assertIsNotNone(httpd_defaults)
-        self.assertEqual(httpd_defaults.get_default_stream(), '2.4')
-        httpd_profile_streams = httpd_defaults.get_streams_with_default_profiles()
+        self.assertEqual(httpd_defaults.get_default_stream(), "2.4")
+        httpd_profile_streams = (
+            httpd_defaults.get_streams_with_default_profiles()
+        )
         self.assertEqual(len(httpd_profile_streams), 2)
-        self.assertTrue('2.2' in httpd_profile_streams)
-        self.assertTrue('2.4' in httpd_profile_streams)
+        self.assertTrue("2.2" in httpd_profile_streams)
+        self.assertTrue("2.4" in httpd_profile_streams)
         self.assertEqual(
-            len(httpd_defaults.get_default_profiles_for_stream('2.2')), 2)
+            len(httpd_defaults.get_default_profiles_for_stream("2.2")), 2
+        )
         self.assertTrue(
-            'client' in httpd_defaults.get_default_profiles_for_stream('2.2'))
+            "client" in httpd_defaults.get_default_profiles_for_stream("2.2")
+        )
         self.assertTrue(
-            'server' in httpd_defaults.get_default_profiles_for_stream('2.2'))
+            "server" in httpd_defaults.get_default_profiles_for_stream("2.2")
+        )
         self.assertTrue(
-            'client' in httpd_defaults.get_default_profiles_for_stream('2.4'))
+            "client" in httpd_defaults.get_default_profiles_for_stream("2.4")
+        )
         self.assertTrue(
-            'server' in httpd_defaults.get_default_profiles_for_stream('2.4'))
+            "server" in httpd_defaults.get_default_profiles_for_stream("2.4")
+        )
 
         self.assertEqual(
-            httpd_defaults.get_default_stream('workstation'), '2.8')
+            httpd_defaults.get_default_stream("workstation"), "2.8"
+        )
         httpd_profile_streams = httpd_defaults.get_streams_with_default_profiles(
-            'workstation')
+            "workstation"
+        )
         self.assertEqual(len(httpd_profile_streams), 3)
-        self.assertTrue('2.4' in httpd_profile_streams)
-        self.assertTrue('2.6' in httpd_profile_streams)
-        self.assertTrue('2.8' in httpd_profile_streams)
+        self.assertTrue("2.4" in httpd_profile_streams)
+        self.assertTrue("2.6" in httpd_profile_streams)
+        self.assertTrue("2.8" in httpd_profile_streams)
         self.assertEqual(
-            len(httpd_defaults.get_default_profiles_for_stream('2.4', 'workstation')), 1)
+            len(
+                httpd_defaults.get_default_profiles_for_stream(
+                    "2.4", "workstation"
+                )
+            ),
+            1,
+        )
         self.assertEqual(
-            len(httpd_defaults.get_default_profiles_for_stream('2.6', 'workstation')), 3)
+            len(
+                httpd_defaults.get_default_profiles_for_stream(
+                    "2.6", "workstation"
+                )
+            ),
+            3,
+        )
         self.assertEqual(
-            len(httpd_defaults.get_default_profiles_for_stream('2.8', 'workstation')), 4)
+            len(
+                httpd_defaults.get_default_profiles_for_stream(
+                    "2.8", "workstation"
+                )
+            ),
+            4,
+        )
 
     def test_merger_with_real_world_data(self):
         fedora_index = Modulemd.ModuleIndex()
         fedora_index.update_from_file(
-            path.join(
-                self.test_data_path,
-                "f29.yaml"), True)
+            path.join(self.test_data_path, "f29.yaml"), True
+        )
 
         updates_index = Modulemd.ModuleIndex()
         updates_index.update_from_file(
-            path.join(
-                self.test_data_path,
-                "f29-updates.yaml"), True)
+            path.join(self.test_data_path, "f29-updates.yaml"), True
+        )
 
         merger = Modulemd.ModuleIndexMerger()
         merger.associate_index(fedora_index, 0)
@@ -223,29 +268,34 @@ data:
     module: python
     stream: %s
 ...
-""" % (stream)
+""" % (
+                stream
+            )
 
             index = Modulemd.ModuleIndex()
             index.update_from_string(default, strict=True)
             merger.associate_index(index, 0)
 
-        with self.assertRaisesRegexp(gi.repository.GLib.GError, "Default stream mismatch in module python"):
+        with self.assertRaisesRegexp(
+            gi.repository.GLib.GError,
+            "Default stream mismatch in module python",
+        ):
             merger.resolve_ext(True)
 
     def test_merge_add_only(self):
         base_idx = Modulemd.ModuleIndex()
-        self.assertTrue(base_idx.update_from_file(
-            path.join(
-                self.test_data_path,
-                "merger",
-                "base.yaml"), True))
+        self.assertTrue(
+            base_idx.update_from_file(
+                path.join(self.test_data_path, "merger", "base.yaml"), True
+            )
+        )
 
         add_only_idx = Modulemd.ModuleIndex()
-        self.assertTrue(add_only_idx.update_from_file(
-            path.join(
-                self.test_data_path,
-                "merger",
-                "add_only.yaml"), True))
+        self.assertTrue(
+            add_only_idx.update_from_file(
+                path.join(self.test_data_path, "merger", "add_only.yaml"), True
+            )
+        )
 
         merger = Modulemd.ModuleIndexMerger()
         merger.associate_index(base_idx, 0)
@@ -254,37 +304,44 @@ data:
         merged_idx = merger.resolve()
         self.assertIsNotNone(merged_idx)
 
-        httpd = merged_idx.get_module('httpd')
+        httpd = merged_idx.get_module("httpd")
         self.assertIsNotNone(httpd)
         httpd_defs = httpd.get_defaults()
 
         self.assertEqual(httpd_defs.get_default_stream(), "2.8")
         expected_profile_defs = {
-            '2.2': set(['client', 'server']),
-            '2.8': set(['notreal', ]),
-            '2.10': set(['notreal', ])
+            "2.2": set(["client", "server"]),
+            "2.8": set(["notreal"]),
+            "2.10": set(["notreal"]),
         }
 
         for stream in expected_profile_defs.keys():
-            self.assertEqual(set(httpd_defs.get_default_profiles_for_stream(
-                stream)), expected_profile_defs[stream])
+            self.assertEqual(
+                set(httpd_defs.get_default_profiles_for_stream(stream)),
+                expected_profile_defs[stream],
+            )
 
         self.assertEqual(httpd_defs.get_default_stream("workstation"), "2.4")
 
     def test_merge_add_conflicting_stream(self):
         base_idx = Modulemd.ModuleIndex()
-        self.assertTrue(base_idx.update_from_file(
-            path.join(
-                self.test_data_path,
-                "merger",
-                "base.yaml"), True))
+        self.assertTrue(
+            base_idx.update_from_file(
+                path.join(self.test_data_path, "merger", "base.yaml"), True
+            )
+        )
 
         add_only_idx = Modulemd.ModuleIndex()
-        self.assertTrue(add_only_idx.update_from_file(
-            path.join(
-                self.test_data_path,
-                "merger",
-                "add_conflicting_stream.yaml"), True))
+        self.assertTrue(
+            add_only_idx.update_from_file(
+                path.join(
+                    self.test_data_path,
+                    "merger",
+                    "add_conflicting_stream.yaml",
+                ),
+                True,
+            )
+        )
 
         merger = Modulemd.ModuleIndexMerger()
         merger.associate_index(base_idx, 0)
@@ -293,7 +350,7 @@ data:
         merged_idx = merger.resolve()
         self.assertIsNotNone(merged_idx)
 
-        psql = merged_idx.get_module('postgresql')
+        psql = merged_idx.get_module("postgresql")
         self.assertIsNotNone(psql)
 
         psql_defs = psql.get_defaults()
@@ -302,28 +359,35 @@ data:
         self.assertIsNone(psql_defs.get_default_stream())
 
         expected_profile_defs = {
-            '8.1': set(['client', 'server', 'foo']),
-            '8.2': set(['client', 'server', 'foo']),
+            "8.1": set(["client", "server", "foo"]),
+            "8.2": set(["client", "server", "foo"]),
         }
 
         for stream in expected_profile_defs.keys():
-            self.assertEqual(set(psql_defs.get_default_profiles_for_stream(
-                stream)), expected_profile_defs[stream])
+            self.assertEqual(
+                set(psql_defs.get_default_profiles_for_stream(stream)),
+                expected_profile_defs[stream],
+            )
 
     def test_merge_add_conflicting_stream_and_profile_modified(self):
         base_idx = Modulemd.ModuleIndex()
-        self.assertTrue(base_idx.update_from_file(
-            path.join(
-                self.test_data_path,
-                "merger",
-                "base.yaml"), True))
+        self.assertTrue(
+            base_idx.update_from_file(
+                path.join(self.test_data_path, "merger", "base.yaml"), True
+            )
+        )
 
         add_conflicting_idx = Modulemd.ModuleIndex()
-        self.assertTrue(add_conflicting_idx.update_from_file(
-            path.join(
-                self.test_data_path,
-                "merger",
-                "add_conflicting_stream_and_profile_modified.yaml"), True))
+        self.assertTrue(
+            add_conflicting_idx.update_from_file(
+                path.join(
+                    self.test_data_path,
+                    "merger",
+                    "add_conflicting_stream_and_profile_modified.yaml",
+                ),
+                True,
+            )
+        )
 
         merger = Modulemd.ModuleIndexMerger()
         merger.associate_index(base_idx, 0)
@@ -332,24 +396,26 @@ data:
         merged_idx = merger.resolve()
         self.assertIsNotNone(merged_idx)
 
-        psql = merged_idx.get_module('postgresql')
+        psql = merged_idx.get_module("postgresql")
         self.assertIsNotNone(psql)
 
         psql_defs = psql.get_defaults()
         self.assertIsNotNone(psql_defs)
 
-        self.assertEqual(psql_defs.get_default_stream(), '8.2')
+        self.assertEqual(psql_defs.get_default_stream(), "8.2")
 
         expected_profile_defs = {
-            '8.1': set(['client', 'server']),
-            '8.2': set(['client', 'server', 'foo']),
-            '8.3': set(['client', 'server']),
+            "8.1": set(["client", "server"]),
+            "8.2": set(["client", "server", "foo"]),
+            "8.3": set(["client", "server"]),
         }
 
         for stream in expected_profile_defs:
-            self.assertEqual(set(psql_defs.get_default_profiles_for_stream(
-                stream)), expected_profile_defs[stream])
+            self.assertEqual(
+                set(psql_defs.get_default_profiles_for_stream(stream)),
+                expected_profile_defs[stream],
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/module.py
+++ b/modulemd/tests/ModulemdTests/module.py
@@ -14,10 +14,12 @@
 
 from os import path
 import sys
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
     from gi.repository.Modulemd import ModuleIndex
     from gi.repository import GLib
@@ -30,16 +32,14 @@ from base import TestBase
 
 
 class TestModule(TestBase):
-
     def test_search_streams(self):
         idx = Modulemd.ModuleIndex.new()
-        idx.update_from_file(path.join(self.test_data_path, "f29.yaml"),
-                             True)
-        module = idx.get_module('nodejs')
+        idx.update_from_file(path.join(self.test_data_path, "f29.yaml"), True)
+        module = idx.get_module("nodejs")
 
-        self.assertEquals(len(module.search_streams('8', 0)), 1)
-        self.assertEquals(len(module.search_streams('10', 0)), 1)
+        self.assertEquals(len(module.search_streams("8", 0)), 1)
+        self.assertEquals(len(module.search_streams("10", 0)), 1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/moduleindex.py
+++ b/modulemd/tests/ModulemdTests/moduleindex.py
@@ -14,10 +14,12 @@
 
 from os import path
 import sys
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
     from gi.repository.Modulemd import ModuleIndex
     from gi.repository import GLib
@@ -30,7 +32,6 @@ from base import TestBase
 
 
 class TestModuleIndex(TestBase):
-
     def test_constructors(self):
         # Test that the new() function works
         idx = ModuleIndex.new()
@@ -41,41 +42,49 @@ class TestModuleIndex(TestBase):
     def test_read(self):
         idx = ModuleIndex.new()
 
-        with open(path.join(self.source_root, "spec.v1.yaml"), 'r') as v1:
+        with open(path.join(self.source_root, "spec.v1.yaml"), "r") as v1:
             res, failures = idx.update_from_string(v1.read(), True)
             self.assertTrue(res)
             self.assertListEqual(failures, [])
 
         for fname in [
-                "spec.v2.yaml",
-                "translations/spec.v1.yaml",
-                "mod-defaults/spec.v1.yaml"]:
+            "spec.v2.yaml",
+            "translations/spec.v1.yaml",
+            "mod-defaults/spec.v1.yaml",
+        ]:
             res, failures = idx.update_from_file(
-                path.join(self.source_root, fname), True)
+                path.join(self.source_root, fname), True
+            )
             self.assertTrue(res)
             self.assertListEqual(failures, [])
 
-        res, failures = idx.update_from_file(path.join(
-            self.test_data_path, "te.yaml"), True)
+        res, failures = idx.update_from_file(
+            path.join(self.test_data_path, "te.yaml"), True
+        )
         self.assertFalse(res)
         self.assertEqual(len(failures), 1)
         self.assertIn(
-            "No document type specified", str(
-                failures[0].get_gerror()))
-        self.assertMultiLineEqual(failures[0].get_yaml(), """---
+            "No document type specified", str(failures[0].get_gerror())
+        )
+        self.assertMultiLineEqual(
+            failures[0].get_yaml(),
+            """---
 summary: An example module
 description: An example module.
 profiles:
   profile_a: An example profile
 ...
-""")
+""",
+        )
 
         self.assertListEqual(idx.get_module_names(), ["foo"])
 
         mod_foo = idx.get_module("foo")
         self.assertTrue(mod_foo.validate())
         self.assertEqual(mod_foo.get_module_name(), "foo")
-        with self.assertRaisesRegexp(gi.repository.GLib.GError, "No streams matched"):
+        with self.assertRaisesRegexp(
+            gi.repository.GLib.GError, "No streams matched"
+        ):
             mod_foo.get_stream_by_NSVCA("a", 5, "c")
         self.assertEqual(len(mod_foo.get_all_streams()), 2)
         self.assertIsNotNone(mod_foo.get_defaults())
@@ -85,24 +94,27 @@ profiles:
         self.assertEqual(defaults.get_default_stream(), "x.y")
 
         stream = mod_foo.get_stream_by_NSVCA(
-            "latest", 20160927144203, "c0ffee43")
+            "latest", 20160927144203, "c0ffee43"
+        )
         self.assertIsNotNone(stream)
-        self.assertEqual(stream.get_nsvc(),
-                         "foo:latest:20160927144203:c0ffee43")
+        self.assertEqual(
+            stream.get_nsvc(), "foo:latest:20160927144203:c0ffee43"
+        )
         self.assertEqual(
             stream.get_description(None),
             "A module for the demonstration of the metadata format. Also, the "
-            "obligatory lorem ipsum dolor sit amet goes right here.")
+            "obligatory lorem ipsum dolor sit amet goes right here.",
+        )
         self.assertEqual(
             stream.get_description("C"),
             "A module for the demonstration of the metadata format. Also, the "
-            "obligatory lorem ipsum dolor sit amet goes right here.")
+            "obligatory lorem ipsum dolor sit amet goes right here.",
+        )
         self.assertEqual(stream.get_description("en_GB"), "An example module.")
 
     def test_get_default_streams(self):
         idx = Modulemd.ModuleIndex.new()
-        idx.update_from_file(path.join(self.test_data_path, "f29.yaml"),
-                             True)
+        idx.update_from_file(path.join(self.test_data_path, "f29.yaml"), True)
 
         default_streams = idx.get_default_streams()
         self.assertIsNotNone(default_streams)
@@ -118,7 +130,9 @@ profiles:
     def test_dump_empty_index(self):
         idx = Modulemd.ModuleIndex.new()
 
-        with self.assertRaisesRegexp(gi.repository.GLib.GError, "Index contains no modules."):
+        with self.assertRaisesRegexp(
+            gi.repository.GLib.GError, "Index contains no modules."
+        ):
             yaml = idx.dump_to_string()
             self.assertIsNone(yaml)
 
@@ -128,66 +142,71 @@ profiles:
 
         # First, verify that it works without overrides
         ret = idx.update_from_defaults_directory(
-            path=path.join(self.test_data_path, 'defaults'),
-            strict=True)
+            path=path.join(self.test_data_path, "defaults"), strict=True
+        )
         self.assertTrue(ret)
 
         # There should be three modules here: meson, ninja and nodejs
         self.assertEqual(len(idx.get_module_names()), 3)
-        self.assertIn('meson', idx.get_module_names())
-        self.assertIn('ninja', idx.get_module_names())
-        self.assertIn('nodejs', idx.get_module_names())
+        self.assertIn("meson", idx.get_module_names())
+        self.assertIn("ninja", idx.get_module_names())
+        self.assertIn("nodejs", idx.get_module_names())
 
         # Check default streams
         defs = idx.get_default_streams()
-        self.assertIn('meson', defs)
-        self.assertEqual('latest', defs['meson'])
-        self.assertIn('ninja', defs)
-        self.assertEqual('latest', defs['ninja'])
-        self.assertNotIn('nodejs', defs)
+        self.assertIn("meson", defs)
+        self.assertEqual("latest", defs["meson"])
+        self.assertIn("ninja", defs)
+        self.assertEqual("latest", defs["ninja"])
+        self.assertNotIn("nodejs", defs)
 
         # Now add overrides too
         # First, verify that it works without overrides
         ret = idx.update_from_defaults_directory(
-            path=path.join(
-                self.test_data_path, 'defaults'), overrides_path=path.join(
-                self.test_data_path, 'defaults', 'overrides'), strict=True)
+            path=path.join(self.test_data_path, "defaults"),
+            overrides_path=path.join(
+                self.test_data_path, "defaults", "overrides"
+            ),
+            strict=True,
+        )
         self.assertTrue(ret)
 
         # There should be four modules here: meson, ninja, nodejs and
         # testmodule
         self.assertEqual(len(idx.get_module_names()), 4)
-        self.assertIn('meson', idx.get_module_names())
-        self.assertIn('ninja', idx.get_module_names())
-        self.assertIn('nodejs', idx.get_module_names())
-        self.assertIn('testmodule', idx.get_module_names())
+        self.assertIn("meson", idx.get_module_names())
+        self.assertIn("ninja", idx.get_module_names())
+        self.assertIn("nodejs", idx.get_module_names())
+        self.assertIn("testmodule", idx.get_module_names())
 
         # Check default streams
         defs = idx.get_default_streams()
-        self.assertIn('meson', defs)
-        self.assertEqual('latest', defs['meson'])
-        self.assertIn('ninja', defs)
-        self.assertEqual('latest', defs['ninja'])
-        self.assertIn('nodejs', defs)
-        self.assertEqual('12', defs['nodejs'])
-        self.assertIn('testmodule', defs)
-        self.assertIn('teststream', defs['testmodule'])
+        self.assertIn("meson", defs)
+        self.assertEqual("latest", defs["meson"])
+        self.assertIn("ninja", defs)
+        self.assertEqual("latest", defs["ninja"])
+        self.assertIn("nodejs", defs)
+        self.assertEqual("12", defs["nodejs"])
+        self.assertIn("testmodule", defs)
+        self.assertIn("teststream", defs["testmodule"])
 
         # Nonexistent defaults dir
-        with self.assertRaisesRegexp(GLib.Error, 'No such file or directory'):
+        with self.assertRaisesRegexp(GLib.Error, "No such file or directory"):
             ret = idx.update_from_defaults_directory(
-                path=path.join(self.test_data_path, 'defaults_nonexistent'),
-                strict=True)
+                path=path.join(self.test_data_path, "defaults_nonexistent"),
+                strict=True,
+            )
             self.assertFalse(ret)
 
         # Nonexistent override dir
-        with self.assertRaisesRegexp(GLib.Error, 'No such file or directory'):
+        with self.assertRaisesRegexp(GLib.Error, "No such file or directory"):
             ret = idx.update_from_defaults_directory(
-                path=path.join(self.test_data_path, 'defaults'),
-                overrides_path='overrides_nonexistent',
-                strict=True)
+                path=path.join(self.test_data_path, "defaults"),
+                overrides_path="overrides_nonexistent",
+                strict=True,
+            )
             self.assertFalse(ret)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/modulestream.py
+++ b/modulemd/tests/ModulemdTests/modulestream.py
@@ -15,11 +15,12 @@
 
 import os
 import sys
+
 try:
     import unittest
     import gi
 
-    gi.require_version('Modulemd', '2.0')
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import GLib
     from gi.repository import Modulemd
 except ImportError:
@@ -31,40 +32,40 @@ from base import TestBase
 
 modulestream_versions = [
     Modulemd.ModuleStreamVersionEnum.ONE,
-    Modulemd.ModuleStreamVersionEnum.TWO]
+    Modulemd.ModuleStreamVersionEnum.TWO,
+]
 
 
 class TestModuleStream(TestBase):
-
     def test_constructors(self):
         for version in modulestream_versions:
 
             # Test that the new() function works
-            stream = Modulemd.ModuleStream.new(version, 'foo', 'latest')
+            stream = Modulemd.ModuleStream.new(version, "foo", "latest")
             assert stream
             assert isinstance(stream, Modulemd.ModuleStream)
 
             assert stream.props.mdversion == version
             assert stream.get_mdversion() == version
-            assert stream.props.module_name == 'foo'
-            assert stream.get_module_name() == 'foo'
-            assert stream.props.stream_name == 'latest'
-            assert stream.get_stream_name() == 'latest'
+            assert stream.props.module_name == "foo"
+            assert stream.get_module_name() == "foo"
+            assert stream.props.stream_name == "latest"
+            assert stream.get_stream_name() == "latest"
 
             # Test that the new() function works without a stream name
-            stream = Modulemd.ModuleStream.new(version, 'foo')
+            stream = Modulemd.ModuleStream.new(version, "foo")
             assert stream
             assert isinstance(stream, Modulemd.ModuleStream)
 
             assert stream.props.mdversion == version
             assert stream.get_mdversion() == version
-            assert stream.props.module_name == 'foo'
-            assert stream.get_module_name() == 'foo'
+            assert stream.props.module_name == "foo"
+            assert stream.get_module_name() == "foo"
             assert stream.props.stream_name is None
             assert stream.get_stream_name() is None
 
             # Test that the new() function works with no module name
-            stream = Modulemd.ModuleStream.new(version, None, 'latest')
+            stream = Modulemd.ModuleStream.new(version, None, "latest")
             assert stream
             assert isinstance(stream, Modulemd.ModuleStream)
 
@@ -72,8 +73,8 @@ class TestModuleStream(TestBase):
             assert stream.get_mdversion() == version
             assert stream.props.module_name is None
             assert stream.get_module_name() is None
-            assert stream.props.stream_name == 'latest'
-            assert stream.get_stream_name() == 'latest'
+            assert stream.props.stream_name == "latest"
+            assert stream.get_stream_name() == "latest"
 
             # Test that the new() function works with no module or stream
             stream = Modulemd.ModuleStream.new(version)
@@ -88,25 +89,28 @@ class TestModuleStream(TestBase):
             assert stream.get_stream_name() is None
 
         # Test that we cannot instantiate directly
-        with self.assertRaisesRegexp(TypeError, 'cannot create instance of abstract'):
+        with self.assertRaisesRegexp(
+            TypeError, "cannot create instance of abstract"
+        ):
             Modulemd.ModuleStream()
 
         # Test with a zero mdversion
-        with self.assertRaisesRegexp(TypeError, 'constructor returned NULL'):
+        with self.assertRaisesRegexp(TypeError, "constructor returned NULL"):
             with self.expect_signal():
                 defs = Modulemd.ModuleStream.new(0)
 
         # Test with an unknown mdversion
-        with self.assertRaisesRegexp(TypeError, 'constructor returned NULL'):
+        with self.assertRaisesRegexp(TypeError, "constructor returned NULL"):
             with self.expect_signal():
                 defs = Modulemd.ModuleStream.new(
-                    Modulemd.ModuleStreamVersionEnum.LATEST + 1)
+                    Modulemd.ModuleStreamVersionEnum.LATEST + 1
+                )
 
     def test_copy(self):
         for version in modulestream_versions:
 
             # Test that copying a stream with a stream name works
-            stream = Modulemd.ModuleStream.new(version, 'foo', 'stable')
+            stream = Modulemd.ModuleStream.new(version, "foo", "stable")
             copied_stream = stream.copy()
 
             assert copied_stream.props.module_name == stream.props.module_name
@@ -115,7 +119,7 @@ class TestModuleStream(TestBase):
             assert copied_stream.get_stream_name() == stream.get_stream_name()
 
             # Test that copying a stream without a stream name works
-            stream = Modulemd.ModuleStream.new(version, 'foo')
+            stream = Modulemd.ModuleStream.new(version, "foo")
             copied_stream = stream.copy()
 
             assert copied_stream.props.module_name == stream.props.module_name
@@ -124,18 +128,18 @@ class TestModuleStream(TestBase):
             assert copied_stream.get_stream_name() == stream.get_stream_name()
 
             # Test that copying a stream and changing the stream works
-            stream = Modulemd.ModuleStream.new(version, 'foo', 'stable')
-            copied_stream = stream.copy(module_stream='latest')
+            stream = Modulemd.ModuleStream.new(version, "foo", "stable")
+            copied_stream = stream.copy(module_stream="latest")
 
             assert copied_stream.props.module_name == stream.props.module_name
             assert copied_stream.get_module_name() == stream.get_module_name()
             assert copied_stream.props.stream_name != stream.props.stream_name
             assert copied_stream.get_stream_name() != stream.get_stream_name()
-            assert copied_stream.props.stream_name == 'latest'
-            assert copied_stream.get_stream_name() == 'latest'
+            assert copied_stream.props.stream_name == "latest"
+            assert copied_stream.get_stream_name() == "latest"
 
             # Test that copying a stream without a module name works
-            stream = Modulemd.ModuleStream.new(version, None, 'stable')
+            stream = Modulemd.ModuleStream.new(version, None, "stable")
             copied_stream = stream.copy()
 
             assert copied_stream.props.module_name == stream.props.module_name
@@ -144,11 +148,11 @@ class TestModuleStream(TestBase):
             assert copied_stream.get_stream_name() == stream.get_stream_name()
 
             # Test that copying a stream and changing the name works
-            stream = Modulemd.ModuleStream.new(version, 'foo', 'stable')
-            copied_stream = stream.copy(module_name='bar')
+            stream = Modulemd.ModuleStream.new(version, "foo", "stable")
+            copied_stream = stream.copy(module_name="bar")
 
-            assert copied_stream.props.module_name == 'bar'
-            assert copied_stream.get_module_name() == 'bar'
+            assert copied_stream.props.module_name == "bar"
+            assert copied_stream.get_module_name() == "bar"
             assert copied_stream.props.stream_name == stream.props.stream_name
             assert copied_stream.get_stream_name() == stream.get_stream_name()
 
@@ -177,21 +181,22 @@ class TestModuleStream(TestBase):
             assert stream.get_nsvc() is None
 
             # Next, test for no stream name
-            stream = Modulemd.ModuleStream.new(version, 'modulename')
+            stream = Modulemd.ModuleStream.new(version, "modulename")
             assert stream.get_nsvc() is None
 
             # Now with valid module and stream names
             stream = Modulemd.ModuleStream.new(
-                version, 'modulename', 'streamname')
-            assert stream.get_nsvc() == 'modulename:streamname:0'
+                version, "modulename", "streamname"
+            )
+            assert stream.get_nsvc() == "modulename:streamname:0"
 
             # Add a version number
             stream.props.version = 42
-            assert stream.get_nsvc() == 'modulename:streamname:42'
+            assert stream.get_nsvc() == "modulename:streamname:42"
 
             # Add a context
-            stream.props.context = 'deadbeef'
-            assert stream.get_nsvc() == 'modulename:streamname:42:deadbeef'
+            stream.props.context = "deadbeef"
+            assert stream.get_nsvc() == "modulename:streamname:42:deadbeef"
 
     def test_nsvca(self):
         for version in modulestream_versions:
@@ -200,47 +205,48 @@ class TestModuleStream(TestBase):
             self.assertIsNone(stream.get_NSVCA())
 
             # Next, test for no stream name
-            stream = Modulemd.ModuleStream.new(version, 'modulename')
+            stream = Modulemd.ModuleStream.new(version, "modulename")
             self.assertEqual(stream.get_NSVCA(), "modulename")
 
             # Now with valid module and stream names
             stream = Modulemd.ModuleStream.new(
-                version, 'modulename', 'streamname')
-            self.assertEqual(stream.get_NSVCA(), 'modulename:streamname')
+                version, "modulename", "streamname"
+            )
+            self.assertEqual(stream.get_NSVCA(), "modulename:streamname")
 
             # Add a version number
             stream.props.version = 42
-            self.assertEqual(stream.get_NSVCA(), 'modulename:streamname:42')
+            self.assertEqual(stream.get_NSVCA(), "modulename:streamname:42")
 
             # Add a context
-            stream.props.context = 'deadbeef'
+            stream.props.context = "deadbeef"
             self.assertEqual(
-                stream.get_NSVCA(),
-                'modulename:streamname:42:deadbeef')
+                stream.get_NSVCA(), "modulename:streamname:42:deadbeef"
+            )
 
             # Add an architecture
-            stream.props.arch = 'x86_64'
-            self.assertEqual(stream.get_NSVCA(),
-                             'modulename:streamname:42:deadbeef:x86_64')
+            stream.props.arch = "x86_64"
+            self.assertEqual(
+                stream.get_NSVCA(), "modulename:streamname:42:deadbeef:x86_64"
+            )
 
             # Now try removing some of the bits in the middle
             stream.props.context = None
-            self.assertEqual(stream.get_NSVCA(),
-                             'modulename:streamname:42::x86_64')
+            self.assertEqual(
+                stream.get_NSVCA(), "modulename:streamname:42::x86_64"
+            )
 
-            stream = Modulemd.ModuleStream.new(version, 'modulename')
-            stream.props.arch = 'x86_64'
-            self.assertEqual(stream.get_NSVCA(),
-                             'modulename::::x86_64')
+            stream = Modulemd.ModuleStream.new(version, "modulename")
+            stream.props.arch = "x86_64"
+            self.assertEqual(stream.get_NSVCA(), "modulename::::x86_64")
 
             stream.props.version = 2019
-            self.assertEqual(stream.get_NSVCA(),
-                             'modulename::2019::x86_64')
+            self.assertEqual(stream.get_NSVCA(), "modulename::2019::x86_64")
             # Add a context
-            stream.props.context = 'feedfeed'
+            stream.props.context = "feedfeed"
             self.assertEqual(
-                stream.get_NSVCA(),
-                'modulename::2019:feedfeed:x86_64')
+                stream.get_NSVCA(), "modulename::2019:feedfeed:x86_64"
+            )
 
     def test_arch(self):
         for version in modulestream_versions:
@@ -251,14 +257,14 @@ class TestModuleStream(TestBase):
             assert stream.get_arch() is None
 
             # Test property setting
-            stream.props.arch = 'x86_64'
-            assert stream.props.arch == 'x86_64'
-            assert stream.get_arch() == 'x86_64'
+            stream.props.arch = "x86_64"
+            assert stream.props.arch == "x86_64"
+            assert stream.get_arch() == "x86_64"
 
             # Test set_arch()
-            stream.set_arch('ppc64le')
-            assert stream.props.arch == 'ppc64le'
-            assert stream.get_arch() == 'ppc64le'
+            stream.set_arch("ppc64le")
+            assert stream.props.arch == "ppc64le"
+            assert stream.get_arch() == "ppc64le"
 
             # Test setting it to None
             stream.props.arch = None
@@ -274,12 +280,12 @@ class TestModuleStream(TestBase):
             assert stream.get_buildopts() is None
 
             buildopts = Modulemd.Buildopts()
-            buildopts.props.rpm_macros = '%demomacro 1'
+            buildopts.props.rpm_macros = "%demomacro 1"
             stream.set_buildopts(buildopts)
 
             assert stream.props.buildopts is not None
             assert stream.props.buildopts is not None
-            assert stream.props.buildopts.props.rpm_macros == '%demomacro 1'
+            assert stream.props.buildopts.props.rpm_macros == "%demomacro 1"
 
     def test_community(self):
         for version in modulestream_versions:
@@ -290,14 +296,14 @@ class TestModuleStream(TestBase):
             assert stream.get_community() is None
 
             # Test property setting
-            stream.props.community = 'http://example.com'
-            assert stream.props.community == 'http://example.com'
-            assert stream.get_community() == 'http://example.com'
+            stream.props.community = "http://example.com"
+            assert stream.props.community == "http://example.com"
+            assert stream.get_community() == "http://example.com"
 
             # Test set_community()
-            stream.set_community('http://redhat.com')
-            assert stream.props.community == 'http://redhat.com'
-            assert stream.get_community() == 'http://redhat.com'
+            stream.set_community("http://redhat.com")
+            assert stream.props.community == "http://redhat.com"
+            assert stream.get_community() == "http://redhat.com"
 
             # Test setting it to None
             stream.props.community = None
@@ -312,9 +318,10 @@ class TestModuleStream(TestBase):
             assert stream.get_description(locale="C") is None
 
             # Test set_description()
-            stream.set_description('A different description')
-            assert stream.get_description(
-                locale="C") == 'A different description'
+            stream.set_description("A different description")
+            assert (
+                stream.get_description(locale="C") == "A different description"
+            )
 
             # Test setting it to None
             stream.set_description(None)
@@ -329,14 +336,14 @@ class TestModuleStream(TestBase):
             assert stream.get_documentation() is None
 
             # Test property setting
-            stream.props.documentation = 'http://example.com'
-            assert stream.props.documentation == 'http://example.com'
-            assert stream.get_documentation() == 'http://example.com'
+            stream.props.documentation = "http://example.com"
+            assert stream.props.documentation == "http://example.com"
+            assert stream.get_documentation() == "http://example.com"
 
             # Test set_documentation()
-            stream.set_documentation('http://redhat.com')
-            assert stream.props.documentation == 'http://redhat.com'
-            assert stream.get_documentation() == 'http://redhat.com'
+            stream.set_documentation("http://redhat.com")
+            assert stream.props.documentation == "http://redhat.com"
+            assert stream.get_documentation() == "http://redhat.com"
 
             # Test setting it to None
             stream.props.documentation = None
@@ -351,8 +358,8 @@ class TestModuleStream(TestBase):
             assert stream.get_summary(locale="C") is None
 
             # Test set_summary()
-            stream.set_summary('A different summary')
-            assert stream.get_summary(locale="C") == 'A different summary'
+            stream.set_summary("A different summary")
+            assert stream.get_summary(locale="C") == "A different summary"
 
             # Test setting it to None
             stream.set_summary(None)
@@ -367,14 +374,14 @@ class TestModuleStream(TestBase):
             assert stream.get_tracker() is None
 
             # Test property setting
-            stream.props.tracker = 'http://example.com'
-            assert stream.props.tracker == 'http://example.com'
-            assert stream.get_tracker() == 'http://example.com'
+            stream.props.tracker = "http://example.com"
+            assert stream.props.tracker == "http://example.com"
+            assert stream.get_tracker() == "http://example.com"
 
             # Test set_tracker()
-            stream.set_tracker('http://redhat.com')
-            assert stream.props.tracker == 'http://redhat.com'
-            assert stream.get_tracker() == 'http://redhat.com'
+            stream.set_tracker("http://redhat.com")
+            assert stream.props.tracker == "http://redhat.com"
+            assert stream.get_tracker() == "http://redhat.com"
 
             # Test setting it to None
             stream.props.tracker = None
@@ -386,99 +393,101 @@ class TestModuleStream(TestBase):
             stream = Modulemd.ModuleStream.new(version)
 
             # Add an RPM component to a stream
-            rpm_comp = Modulemd.ComponentRpm(name='rpmcomponent')
+            rpm_comp = Modulemd.ComponentRpm(name="rpmcomponent")
             stream.add_component(rpm_comp)
-            assert 'rpmcomponent' in stream.get_rpm_component_names()
-            retrieved_comp = stream.get_rpm_component('rpmcomponent')
+            assert "rpmcomponent" in stream.get_rpm_component_names()
+            retrieved_comp = stream.get_rpm_component("rpmcomponent")
             assert retrieved_comp
-            assert retrieved_comp.props.name == 'rpmcomponent'
+            assert retrieved_comp.props.name == "rpmcomponent"
 
             # Add a Module component to a stream
-            mod_comp = Modulemd.ComponentModule(name='modulecomponent')
+            mod_comp = Modulemd.ComponentModule(name="modulecomponent")
             stream.add_component(mod_comp)
-            assert 'modulecomponent' in stream.get_module_component_names()
-            retrieved_comp = stream.get_module_component('modulecomponent')
+            assert "modulecomponent" in stream.get_module_component_names()
+            retrieved_comp = stream.get_module_component("modulecomponent")
             assert retrieved_comp
-            assert retrieved_comp.props.name == 'modulecomponent'
+            assert retrieved_comp.props.name == "modulecomponent"
 
             # Remove an RPM component from a stream
-            stream.remove_rpm_component('rpmcomponent')
+            stream.remove_rpm_component("rpmcomponent")
 
             # Remove a Module component from a stream
-            stream.remove_module_component('modulecomponent')
+            stream.remove_module_component("modulecomponent")
 
     def test_licenses(self):
         for version in modulestream_versions:
             stream = Modulemd.ModuleStream.new(version)
 
-            stream.add_content_license('GPLv2+')
-            assert 'GPLv2+' in stream.get_content_licenses()
+            stream.add_content_license("GPLv2+")
+            assert "GPLv2+" in stream.get_content_licenses()
 
-            stream.add_module_license('MIT')
-            assert 'MIT' in stream.get_module_licenses()
+            stream.add_module_license("MIT")
+            assert "MIT" in stream.get_module_licenses()
 
-            stream.remove_content_license('GPLv2+')
-            stream.remove_module_license('MIT')
+            stream.remove_content_license("GPLv2+")
+            stream.remove_module_license("MIT")
 
     def test_profiles(self):
         for version in modulestream_versions:
-            stream = Modulemd.ModuleStream.new(version, 'sssd')
+            stream = Modulemd.ModuleStream.new(version, "sssd")
 
-            profile = Modulemd.Profile(name='client')
-            profile.add_rpm('sssd-client')
+            profile = Modulemd.Profile(name="client")
+            profile.add_rpm("sssd-client")
 
             stream.add_profile(profile)
             assert len(stream.get_profile_names()) == 1
-            assert 'client' in stream.get_profile_names()
-            assert 'sssd-client' in stream.get_profile(
-                'client').get_rpms()
+            assert "client" in stream.get_profile_names()
+            assert "sssd-client" in stream.get_profile("client").get_rpms()
 
             stream.clear_profiles()
             assert len(stream.get_profile_names()) == 0
 
     def test_rpm_api(self):
         for version in modulestream_versions:
-            stream = Modulemd.ModuleStream.new(version, 'sssd')
+            stream = Modulemd.ModuleStream.new(version, "sssd")
 
-            stream.add_rpm_api('sssd-common')
-            assert 'sssd-common' in stream.get_rpm_api()
+            stream.add_rpm_api("sssd-common")
+            assert "sssd-common" in stream.get_rpm_api()
 
-            stream.remove_rpm_api('sssd-common')
+            stream.remove_rpm_api("sssd-common")
             assert len(stream.get_rpm_api()) == 0
 
     def test_rpm_artifacts(self):
         for version in modulestream_versions:
             stream = Modulemd.ModuleStream.new(version)
 
-            stream.add_rpm_artifact('bar-0:1.23-1.module_deadbeef.x86_64')
-            assert 'bar-0:1.23-1.module_deadbeef.x86_64' in stream.get_rpm_artifacts()
+            stream.add_rpm_artifact("bar-0:1.23-1.module_deadbeef.x86_64")
+            assert (
+                "bar-0:1.23-1.module_deadbeef.x86_64"
+                in stream.get_rpm_artifacts()
+            )
 
-            stream.remove_rpm_artifact('bar-0:1.23-1.module_deadbeef.x86_64')
+            stream.remove_rpm_artifact("bar-0:1.23-1.module_deadbeef.x86_64")
             assert len(stream.get_rpm_artifacts()) == 0
 
     def test_rpm_filters(self):
         for version in modulestream_versions:
             stream = Modulemd.ModuleStream.new(version)
 
-            stream.add_rpm_filter('bar')
-            assert 'bar' in stream.get_rpm_filters()
+            stream.add_rpm_filter("bar")
+            assert "bar" in stream.get_rpm_filters()
 
-            stream.remove_rpm_filter('bar')
+            stream.remove_rpm_filter("bar")
             assert len(stream.get_rpm_filters()) == 0
 
     def test_servicelevels(self):
         for version in modulestream_versions:
             stream = Modulemd.ModuleStream.new(version)
-            sl = Modulemd.ServiceLevel.new('rawhide')
+            sl = Modulemd.ServiceLevel.new("rawhide")
             sl.set_eol_ymd(1980, 3, 2)
 
             stream.add_servicelevel(sl)
 
-            assert 'rawhide' in stream.get_servicelevel_names()
+            assert "rawhide" in stream.get_servicelevel_names()
 
-            retrieved_sl = stream.get_servicelevel('rawhide')
-            assert retrieved_sl.props.name == 'rawhide'
-            assert retrieved_sl.get_eol_as_string() == '1980-03-02'
+            retrieved_sl = stream.get_servicelevel("rawhide")
+            assert retrieved_sl.props.name == "rawhide"
+            assert retrieved_sl.get_eol_as_string() == "1980-03-02"
 
     def test_v1_eol(self):
         stream = Modulemd.ModuleStreamV1.new()
@@ -491,43 +500,43 @@ class TestModuleStream(TestBase):
         assert retrieved_eol.get_month() == 2
         assert retrieved_eol.get_year() == 1998
 
-        sl = stream.get_servicelevel('rawhide')
-        assert sl.get_eol_as_string() == '1998-02-03'
+        sl = stream.get_servicelevel("rawhide")
+        assert sl.get_eol_as_string() == "1998-02-03"
 
     def test_v1_dependencies(self):
         stream = Modulemd.ModuleStreamV1.new()
-        stream.add_buildtime_requirement('testmodule', 'stable')
+        stream.add_buildtime_requirement("testmodule", "stable")
 
         assert len(stream.get_buildtime_modules()) == 1
-        assert 'testmodule' in stream.get_buildtime_modules()
+        assert "testmodule" in stream.get_buildtime_modules()
 
-        assert stream.get_buildtime_requirement_stream('testmodule') == \
-            'stable'
+        assert (
+            stream.get_buildtime_requirement_stream("testmodule") == "stable"
+        )
 
-        stream.add_runtime_requirement('testmodule', 'latest')
+        stream.add_runtime_requirement("testmodule", "latest")
         assert len(stream.get_runtime_modules()) == 1
-        assert 'testmodule' in stream.get_runtime_modules()
-        assert stream.get_runtime_requirement_stream('testmodule') == 'latest'
+        assert "testmodule" in stream.get_runtime_modules()
+        assert stream.get_runtime_requirement_stream("testmodule") == "latest"
 
     def test_v2_dependencies(self):
         stream = Modulemd.ModuleStreamV2.new()
         deps = Modulemd.Dependencies()
 
-        deps.add_buildtime_stream('foo', 'stable')
-        deps.set_empty_runtime_dependencies_for_module('bar')
+        deps.add_buildtime_stream("foo", "stable")
+        deps.set_empty_runtime_dependencies_for_module("bar")
         stream.add_dependencies(deps)
 
         assert len(stream.get_dependencies()) == 1
         assert len(stream.get_dependencies()) == 1
 
-        assert 'foo' in stream.get_dependencies(
-        )[0].get_buildtime_modules()
+        assert "foo" in stream.get_dependencies()[0].get_buildtime_modules()
 
-        assert 'stable' in stream.get_dependencies(
-        )[0].get_buildtime_streams('foo')
+        assert "stable" in stream.get_dependencies()[0].get_buildtime_streams(
+            "foo"
+        )
 
-        assert 'bar' in stream.get_dependencies(
-        )[0].get_runtime_modules()
+        assert "bar" in stream.get_dependencies()[0].get_runtime_modules()
 
         retrieved_deps = stream.get_dependencies()
         stream.clear_dependencies()
@@ -541,7 +550,7 @@ class TestModuleStream(TestBase):
         self.assertEquals(len(stream.get_dependencies()), 0)
 
     def test_xmd(self):
-        if '_overrides_module' in dir(Modulemd):
+        if "_overrides_module" in dir(Modulemd):
             # The XMD python tests can only be run against the installed lib
             # because the overrides that translate between python and GVariant
             # must be installed in /usr/lib/python*/site-packages/gi/overrides
@@ -550,16 +559,16 @@ class TestModuleStream(TestBase):
             # An empty dictionary should be returned if no xmd value is set
             assert stream.get_xmd() == {}
 
-            xmd = {'outer_key': {'inner_key': ['scalar', 'another_scalar']}}
+            xmd = {"outer_key": {"inner_key": ["scalar", "another_scalar"]}}
 
             stream.set_xmd(xmd)
 
             xmd_copy = stream.get_xmd()
             assert xmd_copy
-            assert 'outer_key' in xmd_copy
-            assert 'inner_key' in xmd_copy['outer_key']
-            assert 'scalar' in xmd_copy['outer_key']['inner_key']
-            assert 'another_scalar' in xmd_copy['outer_key']['inner_key']
+            assert "outer_key" in xmd_copy
+            assert "inner_key" in xmd_copy["outer_key"]
+            assert "scalar" in xmd_copy["outer_key"]["inner_key"]
+            assert "another_scalar" in xmd_copy["outer_key"]["inner_key"]
 
             # Verify that we can add content and save it back
             xmd["something"] = ["foo", "bar"]
@@ -593,7 +602,9 @@ class TestModuleStream(TestBase):
         idx = Modulemd.ModuleIndex.new()
         idx.add_module_stream(v2_stream)
 
-        self.assertEquals(idx.dump_to_string(), """---
+        self.assertEquals(
+            idx.dump_to_string(),
+            """---
 document: modulemd
 version: 2
 data:
@@ -613,7 +624,8 @@ data:
       ModuleA: [streamZ]
       ModuleB: [streamY]
 ...
-""")
+""",
+        )
 
     def test_v2_yaml(self):
         yaml = """
@@ -756,58 +768,62 @@ data:
         stream = Modulemd.ModuleStream.read_string(yaml, True)
 
         assert stream is not None
-        assert stream.props.module_name == 'modulename'
-        assert stream.props.stream_name == 'streamname'
+        assert stream.props.module_name == "modulename"
+        assert stream.props.stream_name == "streamname"
         assert stream.props.version == 1
-        assert stream.props.context == 'c0ffe3'
-        assert stream.props.arch == 'x86_64'
+        assert stream.props.context == "c0ffe3"
+        assert stream.props.arch == "x86_64"
         assert stream.get_summary(locale="C") == "Module Summary"
-        assert stream.get_description(
-            locale="C") == "Module Description"
+        assert stream.get_description(locale="C") == "Module Description"
 
-        assert 'rpm_a' in stream.get_rpm_api()
-        assert 'rpm_b' in stream.get_rpm_api()
+        assert "rpm_a" in stream.get_rpm_api()
+        assert "rpm_b" in stream.get_rpm_api()
 
-        assert 'rpm_c' in stream.get_rpm_filters()
+        assert "rpm_c" in stream.get_rpm_filters()
 
-        assert 'bar-0:1.23-1.module_deadbeef.x86_64' in stream.get_rpm_artifacts()
+        assert (
+            "bar-0:1.23-1.module_deadbeef.x86_64" in stream.get_rpm_artifacts()
+        )
 
-        assert 'rawhide' in stream.get_servicelevel_names()
-        assert 'production' in stream.get_servicelevel_names()
+        assert "rawhide" in stream.get_servicelevel_names()
+        assert "production" in stream.get_servicelevel_names()
 
-        sl = stream.get_servicelevel('rawhide')
+        sl = stream.get_servicelevel("rawhide")
         assert sl is not None
-        assert sl.props.name == 'rawhide'
+        assert sl.props.name == "rawhide"
         assert sl.get_eol() is None
 
-        sl = stream.get_servicelevel('production')
+        sl = stream.get_servicelevel("production")
         assert sl is not None
-        assert sl.props.name == 'production'
+        assert sl.props.name == "production"
         assert sl.get_eol() is not None
-        assert sl.get_eol_as_string() == '2099-12-31'
+        assert sl.get_eol_as_string() == "2099-12-31"
 
-        assert 'BSD' in stream.get_content_licenses()
-        assert 'GPLv2+' in stream.get_content_licenses()
-        assert 'MIT' in stream.get_module_licenses()
+        assert "BSD" in stream.get_content_licenses()
+        assert "GPLv2+" in stream.get_content_licenses()
+        assert "MIT" in stream.get_module_licenses()
 
         assert len(stream.get_dependencies()) == 4
 
-        assert stream.props.community == 'http://www.example.com/'
-        assert stream.props.documentation == 'http://www.example.com/'
-        assert stream.props.tracker == 'http://www.example.com/'
+        assert stream.props.community == "http://www.example.com/"
+        assert stream.props.documentation == "http://www.example.com/"
+        assert stream.props.tracker == "http://www.example.com/"
 
         assert len(stream.get_profile_names()) == 5
 
         buildopts = stream.get_buildopts()
         assert buildopts is not None
 
-        assert '%demomacro 1\n%demomacro2 %{demomacro}23\n' == buildopts.props.rpm_macros
-        assert 'fooscl-1-bar' in buildopts.get_rpm_whitelist()
-        assert 'fooscl-1-baz' in buildopts.get_rpm_whitelist()
-        assert 'xxx' in buildopts.get_rpm_whitelist()
-        assert 'xyz' in buildopts.get_rpm_whitelist()
+        assert (
+            "%demomacro 1\n%demomacro2 %{demomacro}23\n"
+            == buildopts.props.rpm_macros
+        )
+        assert "fooscl-1-bar" in buildopts.get_rpm_whitelist()
+        assert "fooscl-1-baz" in buildopts.get_rpm_whitelist()
+        assert "xxx" in buildopts.get_rpm_whitelist()
+        assert "xyz" in buildopts.get_rpm_whitelist()
 
-        if os.getenv('MMD_TEST_INSTALLED_LIB'):
+        if os.getenv("MMD_TEST_INSTALLED_LIB"):
             # The XMD python tests can only be run against the installed
             # lib because the overrides that translate between python and
             # GVariant must be installed in
@@ -816,26 +832,27 @@ data:
             xmd = stream.get_xmd()
             assert xmd is not None
 
-            assert 'some_key' in xmd
-            assert xmd['some_key'] == 'some_data'
+            assert "some_key" in xmd
+            assert xmd["some_key"] == "some_data"
 
-            assert 'some_list' in xmd
+            assert "some_list" in xmd
 
-            assert 'a' in xmd['some_list']
-            assert 'b' in xmd['some_list']
+            assert "a" in xmd["some_list"]
+            assert "b" in xmd["some_list"]
 
-            assert 'some_dict' in xmd
-            assert 'a' in xmd['some_dict']
-            assert xmd['some_dict']['a'] == 'alpha'
+            assert "some_dict" in xmd
+            assert "a" in xmd["some_dict"]
+            assert xmd["some_dict"]["a"] == "alpha"
 
-            assert 'some_other_dict' in xmd['some_dict']
-            assert 'yet_another_key' in xmd[
-                'some_dict']['some_other_dict']
-            assert 'silly' in xmd['some_dict'][
-                'some_other_dict']['yet_another_key']
+            assert "some_other_dict" in xmd["some_dict"]
+            assert "yet_another_key" in xmd["some_dict"]["some_other_dict"]
+            assert (
+                "silly"
+                in xmd["some_dict"]["some_other_dict"]["yet_another_key"]
+            )
 
-            assert 'can_bool' in xmd
-            assert xmd['can_bool'] is True
+            assert "can_bool" in xmd
+            assert xmd["can_bool"] is True
 
         # Validate a trivial modulemd
         trivial_yaml = """
@@ -856,7 +873,8 @@ data:
 
         # Sanity check of spec.v2.yaml
         stream = Modulemd.ModuleStream.read_file(
-            os.path.join(self.source_root, "spec.v2.yaml"), True)
+            os.path.join(self.source_root, "spec.v2.yaml"), True
+        )
         assert stream
 
     def test_v1_yaml(self):
@@ -984,76 +1002,87 @@ data:
             stream = Modulemd.ModuleStream.read_string(yaml, True)
 
             assert stream is not None
-            assert stream.props.module_name == 'modulename'
-            assert stream.props.stream_name == 'streamname'
+            assert stream.props.module_name == "modulename"
+            assert stream.props.stream_name == "streamname"
             assert stream.props.version == 1
-            assert stream.props.context == 'c0ffe3'
-            assert stream.props.arch == 'x86_64'
+            assert stream.props.context == "c0ffe3"
+            assert stream.props.arch == "x86_64"
             assert stream.get_summary(locale="C") == "Module Summary"
-            assert stream.get_description(
-                locale="C") == "Module Description"
+            assert stream.get_description(locale="C") == "Module Description"
 
-            assert 'rpm_a' in stream.get_rpm_api()
-            assert 'rpm_b' in stream.get_rpm_api()
+            assert "rpm_a" in stream.get_rpm_api()
+            assert "rpm_b" in stream.get_rpm_api()
 
-            assert 'rpm_c' in stream.get_rpm_filters()
+            assert "rpm_c" in stream.get_rpm_filters()
 
-            assert 'bar-0:1.23-1.module_deadbeef.x86_64' in stream.get_rpm_artifacts()
+            assert (
+                "bar-0:1.23-1.module_deadbeef.x86_64"
+                in stream.get_rpm_artifacts()
+            )
 
-            assert 'rawhide' in stream.get_servicelevel_names()
-            assert 'production' in stream.get_servicelevel_names()
+            assert "rawhide" in stream.get_servicelevel_names()
+            assert "production" in stream.get_servicelevel_names()
 
-            sl = stream.get_servicelevel('rawhide')
+            sl = stream.get_servicelevel("rawhide")
             assert sl is not None
-            assert sl.props.name == 'rawhide'
-            assert sl.get_eol_as_string() == '2033-08-04'
+            assert sl.props.name == "rawhide"
+            assert sl.get_eol_as_string() == "2033-08-04"
 
-            sl = stream.get_servicelevel('foo')
+            sl = stream.get_servicelevel("foo")
             assert sl is not None
-            assert sl.props.name == 'foo'
+            assert sl.props.name == "foo"
             assert sl.get_eol() is None
 
-            sl = stream.get_servicelevel('production')
+            sl = stream.get_servicelevel("production")
             assert sl is not None
-            assert sl.props.name == 'production'
+            assert sl.props.name == "production"
             assert sl.get_eol() is not None
-            assert sl.get_eol_as_string() == '2099-12-31'
+            assert sl.get_eol_as_string() == "2099-12-31"
 
-            assert 'BSD' in stream.get_content_licenses()
-            assert 'GPLv2+' in stream.get_content_licenses()
-            assert 'MIT' in stream.get_module_licenses()
+            assert "BSD" in stream.get_content_licenses()
+            assert "GPLv2+" in stream.get_content_licenses()
+            assert "MIT" in stream.get_module_licenses()
 
             buildrequires = stream.get_buildtime_modules()
             assert len(buildrequires) == 2
-            assert 'platform' in buildrequires
-            assert stream.get_buildtime_requirement_stream(
-                'platform') == 'and-its-stream-name'
-            assert 'extra-build-env' in buildrequires
-            assert stream.get_buildtime_requirement_stream(
-                'extra-build-env') == 'and-its-stream-name-too'
+            assert "platform" in buildrequires
+            assert (
+                stream.get_buildtime_requirement_stream("platform")
+                == "and-its-stream-name"
+            )
+            assert "extra-build-env" in buildrequires
+            assert (
+                stream.get_buildtime_requirement_stream("extra-build-env")
+                == "and-its-stream-name-too"
+            )
 
             requires = stream.get_runtime_modules()
             assert len(requires) == 1
-            assert 'runtimeplatform' in requires
-            assert stream.get_runtime_requirement_stream(
-                'runtimeplatform') == 'and-its-stream-name-2'
+            assert "runtimeplatform" in requires
+            assert (
+                stream.get_runtime_requirement_stream("runtimeplatform")
+                == "and-its-stream-name-2"
+            )
 
-            assert stream.props.community == 'http://www.example.com/'
-            assert stream.props.documentation == 'http://www.example.com/'
-            assert stream.props.tracker == 'http://www.example.com/'
+            assert stream.props.community == "http://www.example.com/"
+            assert stream.props.documentation == "http://www.example.com/"
+            assert stream.props.tracker == "http://www.example.com/"
 
             assert len(stream.get_profile_names()) == 5
 
             buildopts = stream.get_buildopts()
             assert buildopts is not None
 
-            assert '%demomacro 1\n%demomacro2 %{demomacro}23\n' == buildopts.props.rpm_macros
-            assert 'fooscl-1-bar' in buildopts.get_rpm_whitelist()
-            assert 'fooscl-1-baz' in buildopts.get_rpm_whitelist()
-            assert 'xxx' in buildopts.get_rpm_whitelist()
-            assert 'xyz' in buildopts.get_rpm_whitelist()
+            assert (
+                "%demomacro 1\n%demomacro2 %{demomacro}23\n"
+                == buildopts.props.rpm_macros
+            )
+            assert "fooscl-1-bar" in buildopts.get_rpm_whitelist()
+            assert "fooscl-1-baz" in buildopts.get_rpm_whitelist()
+            assert "xxx" in buildopts.get_rpm_whitelist()
+            assert "xyz" in buildopts.get_rpm_whitelist()
 
-            if os.getenv('MMD_TEST_INSTALLED_LIB'):
+            if os.getenv("MMD_TEST_INSTALLED_LIB"):
                 # The XMD python tests can only be run against the installed
                 # lib because the overrides that translate between python and
                 # GVariant must be installed in
@@ -1062,26 +1091,27 @@ data:
                 xmd = stream.get_xmd()
                 assert xmd is not None
 
-                assert 'some_key' in xmd
-                assert xmd['some_key'] == 'some_data'
+                assert "some_key" in xmd
+                assert xmd["some_key"] == "some_data"
 
-                assert 'some_list' in xmd
+                assert "some_list" in xmd
 
-                assert 'a' in xmd['some_list']
-                assert 'b' in xmd['some_list']
+                assert "a" in xmd["some_list"]
+                assert "b" in xmd["some_list"]
 
-                assert 'some_dict' in xmd
-                assert 'a' in xmd['some_dict']
-                assert xmd['some_dict']['a'] == 'alpha'
+                assert "some_dict" in xmd
+                assert "a" in xmd["some_dict"]
+                assert xmd["some_dict"]["a"] == "alpha"
 
-                assert 'some_other_dict' in xmd['some_dict']
-                assert 'yet_another_key' in xmd[
-                    'some_dict']['some_other_dict']
-                assert 'silly' in xmd['some_dict'][
-                    'some_other_dict']['yet_another_key']
+                assert "some_other_dict" in xmd["some_dict"]
+                assert "yet_another_key" in xmd["some_dict"]["some_other_dict"]
+                assert (
+                    "silly"
+                    in xmd["some_dict"]["some_other_dict"]["yet_another_key"]
+                )
 
-                assert 'can_bool' in xmd
-                assert xmd['can_bool'] is True
+                assert "can_bool" in xmd
+                assert xmd["can_bool"] is True
 
             # Validate a trivial modulemd
             trivial_yaml = """
@@ -1102,43 +1132,44 @@ data:
 
             # Sanity check of spec.v1.yaml
             stream = Modulemd.ModuleStream.read_file(
-                "%s/spec.v1.yaml" % os.getenv('MESON_SOURCE_ROOT'), True)
+                "%s/spec.v1.yaml" % os.getenv("MESON_SOURCE_ROOT"), True
+            )
             assert stream
 
     def test_depends_on_stream(self):
 
         for version in modulestream_versions:
             stream = Modulemd.ModuleStream.read_file(
-                "%s/dependson_v%d.yaml" % (
-                    os.getenv('TEST_DATA_PATH'),
-                    version),
-                True)
+                "%s/dependson_v%d.yaml"
+                % (os.getenv("TEST_DATA_PATH"), version),
+                True,
+            )
             self.assertIsNotNone(stream)
 
-            self.assertEqual(stream.depends_on_stream('platform', 'f30'), True)
+            self.assertEqual(stream.depends_on_stream("platform", "f30"), True)
             self.assertEqual(
-                stream.build_depends_on_stream(
-                    'platform', 'f30'), True)
+                stream.build_depends_on_stream("platform", "f30"), True
+            )
 
             self.assertEqual(
-                stream.depends_on_stream(
-                    'platform', 'f28'), False)
+                stream.depends_on_stream("platform", "f28"), False
+            )
             self.assertEqual(
-                stream.build_depends_on_stream(
-                    'platform', 'f28'), False)
+                stream.build_depends_on_stream("platform", "f28"), False
+            )
 
-            self.assertEqual(stream.depends_on_stream('base', 'f30'), False)
+            self.assertEqual(stream.depends_on_stream("base", "f30"), False)
             self.assertEqual(
-                stream.build_depends_on_stream(
-                    'base', 'f30'), False)
+                stream.build_depends_on_stream("base", "f30"), False
+            )
 
             if version >= Modulemd.ModuleStreamVersionEnum.TWO:
                 self.assertEqual(
-                    stream.depends_on_stream(
-                        'streamname', 'f30'), True)
+                    stream.depends_on_stream("streamname", "f30"), True
+                )
                 self.assertEqual(
-                    stream.build_depends_on_stream(
-                        'streamname', 'f30'), True)
+                    stream.build_depends_on_stream("streamname", "f30"), True
+                )
 
     def test_validate_buildafter(self):
         # buildafter is supported only on v2
@@ -1146,39 +1177,58 @@ data:
         # Test a valid module stream with buildafter set
         stream = Modulemd.ModuleStream.read_file(
             os.path.join(
-                self.test_data_path,
-                'buildafter/good_buildafter.yaml'),
-            True)
+                self.test_data_path, "buildafter/good_buildafter.yaml"
+            ),
+            True,
+        )
 
         self.assertIsNotNone(stream)
         self.assertTrue(stream.validate())
 
         # Should fail validation if both buildorder and buildafter are set for
         # the same component.
-        with self.assertRaisesRegexp(gi.repository.GLib.GError, "Cannot mix buildorder and buildafter"):
+        with self.assertRaisesRegexp(
+            gi.repository.GLib.GError, "Cannot mix buildorder and buildafter"
+        ):
             stream = Modulemd.ModuleStream.read_file(
                 os.path.join(
-                    self.test_data_path,
-                    'buildafter/both_same_component.yaml'),
-                True)
+                    self.test_data_path, "buildafter/both_same_component.yaml"
+                ),
+                True,
+            )
 
         # Should fail validation if both buildorder and buildafter are set in
         # different components of the same stream.
-        with self.assertRaisesRegexp(gi.repository.GLib.GError, "Cannot mix buildorder and buildafter"):
-            stream = Modulemd.ModuleStream.read_file(os.path.join(
-                self.test_data_path, 'buildafter/mixed_buildorder.yaml'), True)
+        with self.assertRaisesRegexp(
+            gi.repository.GLib.GError, "Cannot mix buildorder and buildafter"
+        ):
+            stream = Modulemd.ModuleStream.read_file(
+                os.path.join(
+                    self.test_data_path, "buildafter/mixed_buildorder.yaml"
+                ),
+                True,
+            )
 
         # Should fail if a key specified in a buildafter set does not exist
         # for this module stream.
-        with self.assertRaisesRegexp(gi.repository.GLib.GError, "not found in components list"):
-            stream = Modulemd.ModuleStream.read_file(os.path.join(
-                self.test_data_path, 'buildafter/invalid_key.yaml'), True)
+        with self.assertRaisesRegexp(
+            gi.repository.GLib.GError, "not found in components list"
+        ):
+            stream = Modulemd.ModuleStream.read_file(
+                os.path.join(
+                    self.test_data_path, "buildafter/invalid_key.yaml"
+                ),
+                True,
+            )
 
     def test_unicode_desc(self):
         # Test a valid module stream with unicode in the description
         stream = Modulemd.ModuleStream.read_file(
-            "%s/stream_unicode.yaml" %
-            (os.getenv('TEST_DATA_PATH')), True, '', '')
+            "%s/stream_unicode.yaml" % (os.getenv("TEST_DATA_PATH")),
+            True,
+            "",
+            "",
+        )
 
         self.assertIsNotNone(stream)
         self.assertTrue(stream.validate())
@@ -1186,31 +1236,34 @@ data:
     def test_xmd_issue_274(self):
         # Test a valid module stream with unicode in the description
         stream = Modulemd.ModuleStream.read_file(
-            "%s/stream_unicode.yaml" %
-            (os.getenv('TEST_DATA_PATH')), True, '', '')
+            "%s/stream_unicode.yaml" % (os.getenv("TEST_DATA_PATH")),
+            True,
+            "",
+            "",
+        )
 
         # In this bug, we were getting a traceback attemping to call
         # get_xmd() more than once on the same stream. There were subtle
         # memory issues at play here.
-        if '_overrides_module' in dir(Modulemd):
+        if "_overrides_module" in dir(Modulemd):
             # The XMD python tests can only be run against the installed lib
             # because the overrides that translate between python and GVariant
             # must be installed in /usr/lib/python*/site-packages/gi/overrides
             # or they are not included when importing Modulemd
 
             xmd = stream.get_xmd()
-            mbs_xmd = stream.get_xmd()['mbs']
-            mbs_xmd2 = stream.get_xmd()['mbs']
+            mbs_xmd = stream.get_xmd()["mbs"]
+            mbs_xmd2 = stream.get_xmd()["mbs"]
 
         else:
             stream.get_xmd()
             stream.get_xmd()
 
     def test_xmd_issue_290(self):
-        if '_overrides_module' in dir(Modulemd):
+        if "_overrides_module" in dir(Modulemd):
             stream = Modulemd.ModuleStream.read_file(
-                "%s/290.yaml" %
-                (os.getenv('TEST_DATA_PATH')), True, '', '')
+                "%s/290.yaml" % (os.getenv("TEST_DATA_PATH")), True, "", ""
+            )
 
             self.assertIsNotNone(stream)
 
@@ -1227,5 +1280,5 @@ data:
         pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/profile.py
+++ b/modulemd/tests/ModulemdTests/profile.py
@@ -13,10 +13,12 @@
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 import sys
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
 except ImportError:
     # Return error 77 to skip this test on platforms without the necessary
@@ -27,28 +29,27 @@ from base import TestBase
 
 
 class TestProfile(TestBase):
-
     def test_constructor(self):
         # Test that the new() function works
-        p = Modulemd.Profile.new('testprofile')
+        p = Modulemd.Profile.new("testprofile")
         assert p
-        assert p.props.name == 'testprofile'
-        assert p.get_name() == 'testprofile'
+        assert p.props.name == "testprofile"
+        assert p.get_name() == "testprofile"
         assert p.get_description() is None
         assert p.get_rpms() == []
 
         # Test that keywork name is accepted
-        p = Modulemd.Profile(name='testprofile')
+        p = Modulemd.Profile(name="testprofile")
         assert p
-        assert p.props.name == 'testprofile'
-        assert p.get_name() == 'testprofile'
+        assert p.props.name == "testprofile"
+        assert p.get_name() == "testprofile"
         assert p.get_description() is None
         assert p.get_rpms() == []
 
         # Test that we fail without name
         with self.assertRaises(TypeError) as cm:
             Modulemd.Profile.new(None)
-        assert 'does not allow None as a value' in cm.exception.__str__()
+        assert "does not allow None as a value" in cm.exception.__str__()
 
         with self.expect_signal():
             Modulemd.Profile()
@@ -57,64 +58,64 @@ class TestProfile(TestBase):
             Modulemd.Profile(name=None)
 
     def test_copy(self):
-        p_orig = Modulemd.Profile(name='testprofile')
+        p_orig = Modulemd.Profile(name="testprofile")
         p = p_orig.copy()
         assert p
-        assert p.props.name == 'testprofile'
-        assert p.get_name() == 'testprofile'
+        assert p.props.name == "testprofile"
+        assert p.get_name() == "testprofile"
         assert p.get_description() is None
         assert p.get_rpms() == []
 
-        p_orig.set_description('Test profile')
-        p.add_rpm('test2')
-        p.add_rpm('test3')
-        p.add_rpm('test1')
+        p_orig.set_description("Test profile")
+        p.add_rpm("test2")
+        p.add_rpm("test3")
+        p.add_rpm("test1")
 
         p = p_orig.copy()
         assert p
-        assert p.props.name == 'testprofile'
-        assert p.get_name() == 'testprofile'
-        assert p.get_description() == 'Test profile'
-        assert p.get_rpms() == ['test1', 'test2', 'test3']
+        assert p.props.name == "testprofile"
+        assert p.get_name() == "testprofile"
+        assert p.get_description() == "Test profile"
+        assert p.get_rpms() == ["test1", "test2", "test3"]
 
     def test_get_name(self):
-        p = Modulemd.Profile(name='testprofile')
+        p = Modulemd.Profile(name="testprofile")
 
-        assert p.get_name() == 'testprofile'
-        assert p.props.name == 'testprofile'
+        assert p.get_name() == "testprofile"
+        assert p.props.name == "testprofile"
 
         with self.expect_signal():
-            p.props.name = 'notadrill'
+            p.props.name = "notadrill"
 
     def test_get_set_description(self):
-        p = Modulemd.Profile(name='testprofile')
+        p = Modulemd.Profile(name="testprofile")
 
         assert p.get_description() is None
 
-        p.set_description('foobar')
-        assert p.get_description() == 'foobar'
+        p.set_description("foobar")
+        assert p.get_description() == "foobar"
 
         p.set_description(None)
         assert p.get_description() is None
 
     def test_rpms(self):
-        p = Modulemd.Profile(name='testprofile')
+        p = Modulemd.Profile(name="testprofile")
 
         assert p.get_rpms() == []
 
-        p.add_rpm('test2')
-        assert p.get_rpms() == ['test2']
+        p.add_rpm("test2")
+        assert p.get_rpms() == ["test2"]
 
-        p.add_rpm('test3')
-        p.add_rpm('test1')
-        assert p.get_rpms() == ['test1', 'test2', 'test3']
+        p.add_rpm("test3")
+        p.add_rpm("test1")
+        assert p.get_rpms() == ["test1", "test2", "test3"]
 
-        p.add_rpm('test2')
-        assert p.get_rpms() == ['test1', 'test2', 'test3']
+        p.add_rpm("test2")
+        assert p.get_rpms() == ["test1", "test2", "test3"]
 
-        p.remove_rpm('test1')
-        assert p.get_rpms() == ['test2', 'test3']
+        p.remove_rpm("test1")
+        assert p.get_rpms() == ["test2", "test3"]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/rpmmap.py
+++ b/modulemd/tests/ModulemdTests/rpmmap.py
@@ -15,11 +15,12 @@
 
 import os
 import sys
+
 try:
     import unittest
     import gi
 
-    gi.require_version('Modulemd', '2.0')
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import GLib
     from gi.repository import Modulemd
 except ImportError:
@@ -31,11 +32,11 @@ from base import TestBase
 
 
 class TestRpmMapEntry(TestBase):
-
     def test_basic(self):
         # Test that the new() function works
         entry = Modulemd.RpmMapEntry.new(
-            "bar", 0, "1.23", "1.module_deadbeef", "x86_64")
+            "bar", 0, "1.23", "1.module_deadbeef", "x86_64"
+        )
 
         self.assertIsNotNone(entry)
 
@@ -45,67 +46,76 @@ class TestRpmMapEntry(TestBase):
         self.assertEqual(entry.props.release, "1.module_deadbeef")
         self.assertEqual(entry.props.arch, "x86_64")
         self.assertEqual(
-            entry.props.nevra,
-            "bar-0:1.23-1.module_deadbeef.x86_64")
+            entry.props.nevra, "bar-0:1.23-1.module_deadbeef.x86_64"
+        )
 
         # Test that object instantiation with attributes works
-        entry2 = Modulemd.RpmMapEntry(name="bar",
-                                      version="1.23",
-                                      release="1.module_deadbeef",
-                                      arch="x86_64")
+        entry2 = Modulemd.RpmMapEntry(
+            name="bar",
+            version="1.23",
+            release="1.module_deadbeef",
+            arch="x86_64",
+        )
         self.assertEqual(
-            entry2.props.nevra,
-            "bar-0:1.23-1.module_deadbeef.x86_64")
+            entry2.props.nevra, "bar-0:1.23-1.module_deadbeef.x86_64"
+        )
 
         # Test that nevra returns NULL if attributes are missing
 
         # Remove name
         entry2.props.name = None
-        with self.assertRaisesRegexp(gi.repository.GLib.GError,
-                                     "Missing name attribute"):
+        with self.assertRaisesRegexp(
+            gi.repository.GLib.GError, "Missing name attribute"
+        ):
             entry2.validate()
         self.assertIsNone(entry2.props.nevra)
         entry2.props.name = "bar"
 
         # Remove the version
         entry2.props.version = None
-        with self.assertRaisesRegexp(gi.repository.GLib.GError,
-                                     "Missing version attribute"):
+        with self.assertRaisesRegexp(
+            gi.repository.GLib.GError, "Missing version attribute"
+        ):
             entry2.validate()
         self.assertIsNone(entry2.props.nevra)
         entry2.props.version = "1.23"
 
         # Remove the release
         entry2.props.release = None
-        with self.assertRaisesRegexp(gi.repository.GLib.GError,
-                                     "Missing release attribute"):
+        with self.assertRaisesRegexp(
+            gi.repository.GLib.GError, "Missing release attribute"
+        ):
             entry2.validate()
         self.assertIsNone(entry2.props.nevra)
         entry2.props.release = "1.module_deadbeef"
 
         # Remove the arch
         entry2.props.arch = None
-        with self.assertRaisesRegexp(gi.repository.GLib.GError,
-                                     "Missing arch attribute"):
+        with self.assertRaisesRegexp(
+            gi.repository.GLib.GError, "Missing arch attribute"
+        ):
             entry2.validate()
         self.assertIsNone(entry2.props.nevra)
         entry2.props.arch = "x86_64"
 
         self.assertEqual(
-            entry2.props.nevra,
-            "bar-0:1.23-1.module_deadbeef.x86_64")
+            entry2.props.nevra, "bar-0:1.23-1.module_deadbeef.x86_64"
+        )
 
     def test_compare(self):
         entry = Modulemd.RpmMapEntry.new(
-            "bar", 0, "1.23", "1.module_deadbeef", "x86_64")
+            "bar", 0, "1.23", "1.module_deadbeef", "x86_64"
+        )
         self.assertIsNotNone(entry)
 
         entry2 = Modulemd.RpmMapEntry.new(
-            "bar", 0, "1.23", "1.module_deadbeef", "x86_64")
+            "bar", 0, "1.23", "1.module_deadbeef", "x86_64"
+        )
         self.assertIsNotNone(entry2)
 
         entry3 = Modulemd.RpmMapEntry.new(
-            "foo", 0, "1.23", "1.module_deadbeef", "x86_64")
+            "foo", 0, "1.23", "1.module_deadbeef", "x86_64"
+        )
         self.assertIsNotNone(entry3)
 
         self.assertTrue(entry.equals(entry))
@@ -113,5 +123,5 @@ class TestRpmMapEntry(TestBase):
         self.assertFalse(entry.equals(entry3))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/servicelevel.py
+++ b/modulemd/tests/ModulemdTests/servicelevel.py
@@ -13,10 +13,12 @@
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 import sys
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
     from gi.repository import GLib
 except ImportError:
@@ -29,21 +31,20 @@ import datetime
 
 
 class TestServiceLevel(TestBase):
-
     def test_constructors(self):
         # Test that the new() function works
-        sl = Modulemd.ServiceLevel.new('foo')
+        sl = Modulemd.ServiceLevel.new("foo")
         assert sl
-        assert sl.props.name == 'foo'
-        assert sl.get_name() == 'foo'
+        assert sl.props.name == "foo"
+        assert sl.get_name() == "foo"
         assert sl.get_eol() is None
         assert sl.get_eol_as_string() is None
 
         # Test that standard object instatiation works with a name
-        sl = Modulemd.ServiceLevel(name='foo')
+        sl = Modulemd.ServiceLevel(name="foo")
         assert sl
-        assert sl.props.name == 'foo'
-        assert sl.get_name() == 'foo'
+        assert sl.props.name == "foo"
+        assert sl.get_name() == "foo"
         assert sl.get_eol() is None
         assert sl.get_eol_as_string() is None
 
@@ -52,7 +53,7 @@ class TestServiceLevel(TestBase):
             sl = Modulemd.ServiceLevel.new(None)
             assert False
         except TypeError as e:
-            assert 'does not allow None as a value' in e.__str__()
+            assert "does not allow None as a value" in e.__str__()
 
         # Test that we fail if object is instantiated without a name
         with self.expect_signal():
@@ -63,42 +64,42 @@ class TestServiceLevel(TestBase):
             sl = Modulemd.ServiceLevel(name=None)
 
     def test_copy(self):
-        sl = Modulemd.ServiceLevel.new('foo')
+        sl = Modulemd.ServiceLevel.new("foo")
         assert sl
-        assert sl.props.name == 'foo'
-        assert sl.get_name() == 'foo'
+        assert sl.props.name == "foo"
+        assert sl.get_name() == "foo"
         assert sl.get_eol() is None
         assert sl.get_eol_as_string() is None
 
         sl_copy = sl.copy()
         assert sl_copy
-        assert sl_copy.props.name == 'foo'
-        assert sl_copy.get_name() == 'foo'
+        assert sl_copy.props.name == "foo"
+        assert sl_copy.get_name() == "foo"
         assert sl_copy.get_eol() is None
         assert sl_copy.get_eol_as_string() is None
 
         sl.set_eol_ymd(2018, 11, 13)
         sl_copy = sl.copy()
         assert sl_copy
-        assert sl_copy.props.name == 'foo'
-        assert sl_copy.get_name() == 'foo'
+        assert sl_copy.props.name == "foo"
+        assert sl_copy.get_name() == "foo"
         assert sl_copy.get_eol() is not None
-        assert sl_copy.get_eol_as_string() == '2018-11-13'
+        assert sl_copy.get_eol_as_string() == "2018-11-13"
 
     def test_get_name(self):
-        sl = Modulemd.ServiceLevel.new('foo')
+        sl = Modulemd.ServiceLevel.new("foo")
 
-        assert sl.get_name() == 'foo'
-        assert sl.props.name == 'foo'
+        assert sl.get_name() == "foo"
+        assert sl.props.name == "foo"
 
         # This property is not writable, make sure it fails to attempt it
         with self.expect_signal():
-            sl.props.name = 'bar'
+            sl.props.name = "bar"
 
     def test_get_set_eol(self):
-        sl = Modulemd.ServiceLevel.new('foo')
+        sl = Modulemd.ServiceLevel.new("foo")
 
-        if '_overrides_module' in dir(Modulemd):
+        if "_overrides_module" in dir(Modulemd):
             # Test that EOL is initialized to None
             assert sl.get_eol() is None
 
@@ -109,7 +110,7 @@ class TestServiceLevel(TestBase):
             returned_eol = sl.get_eol()
             assert returned_eol is not None
             assert returned_eol == eol
-            assert sl.get_eol_as_string() == '2018-11-07'
+            assert sl.get_eol_as_string() == "2018-11-07"
 
             # Test the set_eol_ymd() method
             sl.set_eol_ymd(2019, 12, 3)
@@ -119,7 +120,7 @@ class TestServiceLevel(TestBase):
             assert returned_eol.day == 3
             assert returned_eol.month == 12
             assert returned_eol.year == 2019
-            assert sl.get_eol_as_string() == '2019-12-03'
+            assert sl.get_eol_as_string() == "2019-12-03"
 
             # There is no February 31
             sl.set_eol_ymd(2011, 2, 31)
@@ -138,7 +139,7 @@ class TestServiceLevel(TestBase):
             assert returned_eol.get_day() == eol.get_day()
             assert returned_eol.get_month() == eol.get_month()
             assert returned_eol.get_year() == eol.get_year()
-            assert sl.get_eol_as_string() == '2018-11-07'
+            assert sl.get_eol_as_string() == "2018-11-07"
 
             # Test the set_eol_ymd() method
             sl.set_eol_ymd(2019, 12, 3)
@@ -148,7 +149,7 @@ class TestServiceLevel(TestBase):
             assert returned_eol.get_day() == 3
             assert returned_eol.get_month() == 12
             assert returned_eol.get_year() == 2019
-            assert sl.get_eol_as_string() == '2019-12-03'
+            assert sl.get_eol_as_string() == "2019-12-03"
 
             # Try setting some invalid dates
             # An initialized but unset date
@@ -161,5 +162,5 @@ class TestServiceLevel(TestBase):
             assert sl.get_eol() is None
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/translation.py
+++ b/modulemd/tests/ModulemdTests/translation.py
@@ -13,10 +13,12 @@
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 import sys
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
 except ImportError:
     # Return error 77 to skip this test on platforms without the necessary
@@ -27,7 +29,6 @@ from base import TestBase
 
 
 class TestTranslation(TestBase):
-
     def test_constructors(self):
         # Test that the new() function works
         t = Modulemd.Translation.new(1, "testmodule", "teststream", 42)
@@ -36,9 +37,10 @@ class TestTranslation(TestBase):
         # Test that keywords are accepted
         t = Modulemd.Translation(
             version=1,
-            module_name='testmodule',
-            module_stream='teststream',
-            modified=42)
+            module_name="testmodule",
+            module_stream="teststream",
+            modified=42,
+        )
         assert t
         assert t.validate()
         assert t.get_locales() == []
@@ -51,5 +53,5 @@ class TestTranslation(TestBase):
         assert t.get_locales() == []
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/ModulemdTests/translationentry.py
+++ b/modulemd/tests/ModulemdTests/translationentry.py
@@ -14,10 +14,12 @@
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 import sys
+
 try:
     import unittest
     import gi
-    gi.require_version('Modulemd', '2.0')
+
+    gi.require_version("Modulemd", "2.0")
     from gi.repository import Modulemd
 except ImportError:
     # Return error 77 to skip this test on platforms without the necessary
@@ -28,13 +30,12 @@ from base import TestBase
 
 
 class TestTranslationEntry(TestBase):
-
     def test_constructors(self):
         # Test that the new() function works
-        te = Modulemd.TranslationEntry.new('en_US')
+        te = Modulemd.TranslationEntry.new("en_US")
         assert te
-        assert te.props.locale == 'en_US'
-        assert te.get_locale() == 'en_US'
+        assert te.props.locale == "en_US"
+        assert te.get_locale() == "en_US"
         assert te.props.summary is None
         assert te.get_summary() is None
         assert te.props.description is None
@@ -43,10 +44,10 @@ class TestTranslationEntry(TestBase):
         assert te.get_profile_description("test") is None
 
         # Test that keyword arg locale is accepted
-        te = Modulemd.TranslationEntry(locale='en_US')
+        te = Modulemd.TranslationEntry(locale="en_US")
         assert te
-        assert te.props.locale == 'en_US'
-        assert te.get_locale() == 'en_US'
+        assert te.props.locale == "en_US"
+        assert te.get_locale() == "en_US"
         assert te.props.summary is None
         assert te.get_summary() is None
         assert te.props.description is None
@@ -55,57 +56,57 @@ class TestTranslationEntry(TestBase):
         assert te.get_profile_description("test") is None
 
         # Test that init works with locale and summary
-        te = Modulemd.TranslationEntry(locale='en_US', summary='foobar')
+        te = Modulemd.TranslationEntry(locale="en_US", summary="foobar")
         assert te
-        assert te.props.locale == 'en_US'
-        assert te.get_locale() == 'en_US'
-        assert te.props.summary == 'foobar'
-        assert te.get_summary() == 'foobar'
+        assert te.props.locale == "en_US"
+        assert te.get_locale() == "en_US"
+        assert te.props.summary == "foobar"
+        assert te.get_summary() == "foobar"
         assert te.props.description is None
         assert te.get_description() is None
         assert te.get_profiles() == []
         assert te.get_profile_description("test") is None
 
         # Test that init works with locale and description
-        te = Modulemd.TranslationEntry(locale='en_US', description='barfoo')
+        te = Modulemd.TranslationEntry(locale="en_US", description="barfoo")
         assert te
-        assert te.props.locale == 'en_US'
-        assert te.get_locale() == 'en_US'
+        assert te.props.locale == "en_US"
+        assert te.get_locale() == "en_US"
         assert te.props.summary is None
         assert te.get_summary() is None
-        assert te.props.description == 'barfoo'
-        assert te.get_description() == 'barfoo'
+        assert te.props.description == "barfoo"
+        assert te.get_description() == "barfoo"
         assert te.get_profiles() == []
         assert te.get_profile_description("test") is None
 
         # Test that init works with locale, summary and description
         te = Modulemd.TranslationEntry(
-            locale='en_US',
-            summary='foobar',
-            description='barfoo')
+            locale="en_US", summary="foobar", description="barfoo"
+        )
         assert te
-        assert te.props.locale == 'en_US'
-        assert te.get_locale() == 'en_US'
-        assert te.props.summary == 'foobar'
-        assert te.get_summary() == 'foobar'
-        assert te.props.description == 'barfoo'
-        assert te.get_description() == 'barfoo'
+        assert te.props.locale == "en_US"
+        assert te.get_locale() == "en_US"
+        assert te.props.summary == "foobar"
+        assert te.get_summary() == "foobar"
+        assert te.props.description == "barfoo"
+        assert te.get_description() == "barfoo"
         assert te.get_profiles() == []
         assert te.get_profile_description("test") is None
 
         # Test that init works with locale, unicode summary and unicode
         # description
         te = Modulemd.TranslationEntry(
-            locale='ro_TA',  # robots_Tables
-            summary='(┛ಠ_ಠ)┛彡┻━┻',
-            description='(┛ಠ_ಠ)┛彡')
+            locale="ro_TA",  # robots_Tables
+            summary="(┛ಠ_ಠ)┛彡┻━┻",
+            description="(┛ಠ_ಠ)┛彡",
+        )
         assert te
-        assert te.props.locale == 'ro_TA'
-        assert te.get_locale() == 'ro_TA'
-        assert te.props.summary == '(┛ಠ_ಠ)┛彡┻━┻'
-        assert te.get_summary() == '(┛ಠ_ಠ)┛彡┻━┻'
-        assert te.props.description == '(┛ಠ_ಠ)┛彡'
-        assert te.get_description() == '(┛ಠ_ಠ)┛彡'
+        assert te.props.locale == "ro_TA"
+        assert te.get_locale() == "ro_TA"
+        assert te.props.summary == "(┛ಠ_ಠ)┛彡┻━┻"
+        assert te.get_summary() == "(┛ಠ_ಠ)┛彡┻━┻"
+        assert te.props.description == "(┛ಠ_ಠ)┛彡"
+        assert te.get_description() == "(┛ಠ_ಠ)┛彡"
         assert te.get_profiles() == []
         assert te.get_profile_description("test") is None
 
@@ -114,7 +115,7 @@ class TestTranslationEntry(TestBase):
             te = Modulemd.TranslationEntry.new(None)
             assert False
         except TypeError as e:
-            assert 'does not allow None as a value' in e.__str__()
+            assert "does not allow None as a value" in e.__str__()
 
         # Test that we fail if object is instantiated without a locale
         with self.expect_signal():
@@ -125,11 +126,11 @@ class TestTranslationEntry(TestBase):
             Modulemd.TranslationEntry(locale=None)
 
     def test_copy(self):
-        te_orig = Modulemd.TranslationEntry(locale='en_US')
+        te_orig = Modulemd.TranslationEntry(locale="en_US")
         te = te_orig.copy()
         assert te
-        assert te.props.locale == 'en_US'
-        assert te.get_locale() == 'en_US'
+        assert te.props.locale == "en_US"
+        assert te.get_locale() == "en_US"
         assert te.props.summary is None
         assert te.get_summary() is None
         assert te.props.description is None
@@ -137,23 +138,23 @@ class TestTranslationEntry(TestBase):
         assert te.get_profiles() == []
         assert te.get_profile_description("test") is None
 
-        te_orig.set_summary('foobar')
-        te_orig.set_description('barfoo')
-        te_orig.set_profile_description('test1', 'brown fox')
-        te_orig.set_profile_description('test2', 'jumped')
+        te_orig.set_summary("foobar")
+        te_orig.set_description("barfoo")
+        te_orig.set_profile_description("test1", "brown fox")
+        te_orig.set_profile_description("test2", "jumped")
 
         te = te_orig.copy()
         assert te
-        assert te.props.locale == 'en_US'
-        assert te.get_locale() == 'en_US'
-        assert te.props.summary == 'foobar'
-        assert te.get_summary() == 'foobar'
-        assert te.props.description == 'barfoo'
-        assert te.get_description() == 'barfoo'
-        assert te.get_profiles() == ['test1', 'test2']
-        assert te.get_profile_description('test') is None
-        assert te.get_profile_description('test1') == 'brown fox'
-        assert te.get_profile_description('test2') == 'jumped'
+        assert te.props.locale == "en_US"
+        assert te.get_locale() == "en_US"
+        assert te.props.summary == "foobar"
+        assert te.get_summary() == "foobar"
+        assert te.props.description == "barfoo"
+        assert te.get_description() == "barfoo"
+        assert te.get_profiles() == ["test1", "test2"]
+        assert te.get_profile_description("test") is None
+        assert te.get_profile_description("test1") == "brown fox"
+        assert te.get_profile_description("test2") == "jumped"
 
     def test_get_locale(self):
         te = Modulemd.TranslationEntry(locale="en_US")
@@ -167,8 +168,8 @@ class TestTranslationEntry(TestBase):
     def test_get_set_summary(self):
         te = Modulemd.TranslationEntry(locale="en_US")
 
-        assert te.props.locale == 'en_US'
-        assert te.get_locale() == 'en_US'
+        assert te.props.locale == "en_US"
+        assert te.get_locale() == "en_US"
         assert te.props.summary is None
         assert te.get_summary() is None
 
@@ -187,8 +188,8 @@ class TestTranslationEntry(TestBase):
     def test_get_set_description(self):
         te = Modulemd.TranslationEntry(locale="en_US")
 
-        assert te.props.locale == 'en_US'
-        assert te.get_locale() == 'en_US'
+        assert te.props.locale == "en_US"
+        assert te.get_locale() == "en_US"
         assert te.props.description is None
         assert te.get_description() is None
 
@@ -207,8 +208,8 @@ class TestTranslationEntry(TestBase):
     def test_profile_descriptions(self):
         te = Modulemd.TranslationEntry(locale="en_US")
 
-        assert te.props.locale == 'en_US'
-        assert te.get_locale() == 'en_US'
+        assert te.props.locale == "en_US"
+        assert te.get_locale() == "en_US"
         assert te.get_profiles() == []
         assert te.get_profile_description("test1") is None
         assert te.get_profile_description("test2") is None
@@ -216,25 +217,25 @@ class TestTranslationEntry(TestBase):
 
         # Add a profile
         te.set_profile_description("test1", "foobar")
-        assert te.get_profiles() == ['test1']
-        assert te.get_profile_description("test1") == 'foobar'
+        assert te.get_profiles() == ["test1"]
+        assert te.get_profile_description("test1") == "foobar"
         assert te.get_profile_description("test2") is None
         assert te.get_profile_description("test3") is None
 
         # Add a second profile
         te.set_profile_description("test2", "barfoo")
-        assert te.get_profiles() == ['test1', 'test2']
-        assert te.get_profile_description("test1") == 'foobar'
-        assert te.get_profile_description("test2") == 'barfoo'
+        assert te.get_profiles() == ["test1", "test2"]
+        assert te.get_profile_description("test1") == "foobar"
+        assert te.get_profile_description("test2") == "barfoo"
         assert te.get_profile_description("test3") is None
 
         # Add a third one that is supposed to go before the others
         te.set_profile_description("test3", "foobarfoo")
-        assert te.get_profiles() == ['test1', 'test2', 'test3']
-        assert te.get_profile_description("test1") == 'foobar'
-        assert te.get_profile_description("test2") == 'barfoo'
-        assert te.get_profile_description("test3") == 'foobarfoo'
+        assert te.get_profiles() == ["test1", "test2", "test3"]
+        assert te.get_profile_description("test1") == "foobar"
+        assert te.get_profile_description("test2") == "barfoo"
+        assert te.get_profile_description("test3") == "foobarfoo"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/modulemd/tests/test-dirty.py
+++ b/modulemd/tests/test-dirty.py
@@ -20,17 +20,18 @@ import subprocess
 script_dir = os.path.dirname(os.path.realpath(__file__))
 
 # Get the repo we're running in
-repo = git.Repo(script_dir,
-                search_parent_directories=True)
+repo = git.Repo(script_dir, search_parent_directories=True)
 
 # When running in CI, the only reason the git repo could
 # become "dirty" (files differ from their checkout) is if
 # the autoformatter made changes. This should be reported
 # back so the submitter can fix this.
-if (repo.is_dirty()):
-    print("Autoformatter was not run before submitting. Please run "
-          "`ninja test`, amend the commit and resubmit this pull request.")
-    res = subprocess.run(['git', 'diff'], capture_output=True, text=True)
+if repo.is_dirty():
+    print(
+        "Autoformatter was not run before submitting. Please run "
+        "`ninja test`, amend the commit and resubmit this pull request."
+    )
+    res = subprocess.run(["git", "diff"], capture_output=True, text=True)
     print(res.stdout, file=sys.stderr)
     sys.exit(os.EX_USAGE)
 

--- a/modulemd/tests/test-modulemd-buildopts.c
+++ b/modulemd/tests/test-modulemd-buildopts.c
@@ -315,7 +315,7 @@ buildopts_test_parse_yaml (BuildoptsFixture *fixture, gconstpointer user_data)
   yaml_path = g_strdup_printf ("%s/b.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);

--- a/modulemd/tests/test-modulemd-component-module.c
+++ b/modulemd/tests/test-modulemd-component-module.c
@@ -16,8 +16,8 @@
 #include <locale.h>
 #include <signal.h>
 
-#include "modulemd-component.h"
 #include "modulemd-component-module.h"
+#include "modulemd-component.h"
 #include "private/glib-extensions.h"
 #include "private/modulemd-component-module-private.h"
 #include "private/modulemd-util.h"
@@ -353,7 +353,7 @@ component_module_test_parse_yaml (ComponentModuleFixture *fixture,
   yaml_path = g_strdup_printf ("%s/cm.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);

--- a/modulemd/tests/test-modulemd-component-rpm.c
+++ b/modulemd/tests/test-modulemd-component-rpm.c
@@ -16,8 +16,8 @@
 #include <locale.h>
 #include <signal.h>
 
-#include "modulemd-component.h"
 #include "modulemd-component-rpm.h"
+#include "modulemd-component.h"
 #include "private/glib-extensions.h"
 #include "private/modulemd-component-rpm-private.h"
 #include "private/modulemd-util.h"
@@ -363,7 +363,7 @@ component_rpm_test_parse_yaml (ComponentRpmFixture *fixture,
   yaml_path = g_strdup_printf ("%s/cr.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);

--- a/modulemd/tests/test-modulemd-compression.c
+++ b/modulemd/tests/test-modulemd-compression.c
@@ -16,8 +16,8 @@
 
 #include "modulemd-compression.h"
 #include "private/modulemd-compression-private.h"
-#include "private/test-utils.h"
 #include "private/modulemd-yaml.h"
+#include "private/test-utils.h"
 
 
 /* == Public Functions == */
@@ -92,7 +92,7 @@ test_modulemd_detect_compression (void)
                                   g_getenv ("TEST_DATA_PATH"),
                                   expected[i].filename);
       g_debug ("Getting compression type for %s", filename);
-      filestream = g_fopen (filename, "rb");
+      filestream = g_fopen (filename, "rbe");
       g_assert_nonnull (filestream);
       fd = fileno (filestream);
       result = modulemd_detect_compression (filename, fd, &error);
@@ -140,7 +140,7 @@ test_modulemd_detect_compression (void)
       filename = g_strdup_printf ("%s/compression/%s",
                                   g_getenv ("TEST_DATA_PATH"),
                                   expected_magic[j].filename);
-      filestream = g_fopen (filename, "rb");
+      filestream = g_fopen (filename, "rbe");
       g_assert_nonnull (filestream);
       fd = fileno (filestream);
       g_assert_cmpint (modulemd_detect_compression (filename, fd, &error),

--- a/modulemd/tests/test-modulemd-compression.c
+++ b/modulemd/tests/test-modulemd-compression.c
@@ -69,6 +69,7 @@ test_modulemd_detect_compression (void)
   g_autofree gchar *filename = NULL;
   g_autoptr (FILE) filestream = NULL;
   g_autoptr (GError) error = NULL;
+  ModulemdCompressionTypeEnum result;
 
   struct expected_compression_t expected[] = {
     { .filename = "bzipped.yaml.bz2",
@@ -94,10 +95,9 @@ test_modulemd_detect_compression (void)
       filestream = g_fopen (filename, "rb");
       g_assert_nonnull (filestream);
       fd = fileno (filestream);
-      g_assert_cmpint (modulemd_detect_compression (filename, fd, &error),
-                       ==,
-                       expected[i].type);
+      result = modulemd_detect_compression (filename, fd, &error);
       g_assert_no_error (error);
+      g_assert_cmpint (result, ==, expected[i].type);
       g_clear_error (&error);
       g_clear_pointer (&filestream, fclose);
       g_clear_pointer (&filename, g_free);

--- a/modulemd/tests/test-modulemd-defaults-v1.c
+++ b/modulemd/tests/test-modulemd-defaults-v1.c
@@ -19,8 +19,8 @@
 #include "modulemd-defaults-v1.h"
 #include "private/glib-extensions.h"
 #include "private/modulemd-defaults-v1-private.h"
-#include "private/modulemd-translation-entry-private.h"
 #include "private/modulemd-subdocument-info-private.h"
+#include "private/modulemd-translation-entry-private.h"
 #include "private/modulemd-yaml.h"
 #include "private/test-utils.h"
 
@@ -477,7 +477,7 @@ defaults_test_parse_yaml (CommonMmdTestFixture *fixture,
                                g_getenv ("MESON_SOURCE_ROOT"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);

--- a/modulemd/tests/test-modulemd-defaults.c
+++ b/modulemd/tests/test-modulemd-defaults.c
@@ -16,8 +16,8 @@
 #include <locale.h>
 #include <signal.h>
 
-#include "modulemd-defaults.h"
 #include "modulemd-defaults-v1.h"
+#include "modulemd-defaults.h"
 #include "private/glib-extensions.h"
 #include "private/modulemd-translation-entry-private.h"
 #include "private/modulemd-yaml.h"

--- a/modulemd/tests/test-modulemd-dependencies.c
+++ b/modulemd/tests/test-modulemd-dependencies.c
@@ -404,7 +404,7 @@ dependencies_test_parse_yaml (DependenciesFixture *fixture,
   yaml_path = g_strdup_printf ("%s/d.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);
@@ -454,7 +454,7 @@ dependencies_test_parse_bad_yaml (DependenciesFixture *fixture,
     g_strdup_printf ("%s/mismatched-deps.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);

--- a/modulemd/tests/test-modulemd-merger.c
+++ b/modulemd/tests/test-modulemd-merger.c
@@ -14,10 +14,10 @@
 #include <glib.h>
 #include <yaml.h>
 
-#include "modulemd-defaults.h"
 #include "modulemd-defaults-v1.h"
-#include "modulemd-module-index.h"
+#include "modulemd-defaults.h"
 #include "modulemd-module-index-merger.h"
+#include "modulemd-module-index.h"
 #include "private/test-utils.h"
 
 

--- a/modulemd/tests/test-modulemd-module.c
+++ b/modulemd/tests/test-modulemd-module.c
@@ -17,11 +17,11 @@
 #include <signal.h>
 
 #include "modulemd-defaults.h"
-#include "modulemd-module.h"
-#include "modulemd-module-index.h"
 #include "modulemd-module-index-merger.h"
-#include "modulemd-module-stream.h"
+#include "modulemd-module-index.h"
 #include "modulemd-module-stream-v2.h"
+#include "modulemd-module-stream.h"
+#include "modulemd-module.h"
 #include "private/glib-extensions.h"
 #include "private/modulemd-defaults-v1-private.h"
 #include "private/modulemd-module-private.h"
@@ -33,7 +33,6 @@ typedef struct _ModuleFixture
 {
 } ModuleFixture;
 
-extern int modulemd_test_signal;
 
 static void
 module_test_construct (ModuleFixture *fixture, gconstpointer user_data)

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -19,10 +19,10 @@
 
 #include "config.h"
 #include "modulemd-defaults.h"
-#include "modulemd-module.h"
 #include "modulemd-module-index.h"
 #include "modulemd-module-stream-v1.h"
 #include "modulemd-module-stream-v2.h"
+#include "modulemd-module.h"
 #include "private/glib-extensions.h"
 #include "private/modulemd-module-private.h"
 #include "private/modulemd-util.h"

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -901,7 +901,7 @@ module_stream_v1_test_parse_dump (ModuleStreamFixture *fixture,
     g_strdup_printf ("%s/spec.v1.yaml", g_getenv ("MESON_SOURCE_ROOT"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   /* First parse it */
@@ -1071,7 +1071,7 @@ module_stream_v2_test_parse_dump (ModuleStreamFixture *fixture,
     g_strdup_printf ("%s/spec.v2.yaml", g_getenv ("MESON_SOURCE_ROOT"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   /* First parse it */

--- a/modulemd/tests/test-modulemd-profile.c
+++ b/modulemd/tests/test-modulemd-profile.c
@@ -403,7 +403,7 @@ profile_test_parse_yaml (ProfileFixture *fixture, gconstpointer user_data)
   yaml_path = g_strdup_printf ("%s/p.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);

--- a/modulemd/tests/test-modulemd-rpmmap.c
+++ b/modulemd/tests/test-modulemd-rpmmap.c
@@ -140,7 +140,7 @@ test_parse_yaml_valid (CommonMmdTestFixture *fixture, gconstpointer user_data)
     g_strdup_printf ("%s/rpm-map/valid.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);
@@ -170,7 +170,7 @@ test_parse_yaml_missing (CommonMmdTestFixture *fixture,
                                g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);
@@ -197,7 +197,7 @@ test_parse_yaml_mismatch (CommonMmdTestFixture *fixture,
                                g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);

--- a/modulemd/tests/test-modulemd-service-level.c
+++ b/modulemd/tests/test-modulemd-service-level.c
@@ -359,7 +359,7 @@ service_level_test_parse_yaml (ServiceLevelFixture *fixture,
     g_strdup_printf ("%s/sl_with_eol.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);

--- a/modulemd/tests/test-modulemd-translation-entry.c
+++ b/modulemd/tests/test-modulemd-translation-entry.c
@@ -494,7 +494,7 @@ translation_entry_test_parse_yaml (TranslationEntryFixture *fixture,
   yaml_path = g_strdup_printf ("%s/te.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);

--- a/modulemd/tests/test-modulemd-translation.c
+++ b/modulemd/tests/test-modulemd-translation.c
@@ -17,13 +17,13 @@
 #include <signal.h>
 
 #include "modulemd-subdocument-info.h"
-#include "modulemd-translation.h"
 #include "modulemd-translation-entry.h"
+#include "modulemd-translation.h"
 #include "private/glib-extensions.h"
+#include "private/modulemd-subdocument-info-private.h"
 #include "private/modulemd-translation-private.h"
 #include "private/modulemd-util.h"
 #include "private/modulemd-yaml.h"
-#include "private/modulemd-subdocument-info-private.h"
 #include "private/test-utils.h"
 
 typedef struct _TranslationFixture
@@ -271,7 +271,7 @@ translation_test_parse_yaml (TranslationFixture *fixture,
                                g_getenv ("MESON_SOURCE_ROOT"));
   g_assert_nonnull (yaml_path);
 
-  yaml_stream = g_fopen (yaml_path, "rb");
+  yaml_stream = g_fopen (yaml_path, "rbe");
   g_assert_nonnull (yaml_stream);
 
   yaml_parser_set_input_file (&parser, yaml_stream);


### PR DESCRIPTION
These patches switch our tests from running autopep8 to running black instead. This autoformatter includes some niceties as enforcing the same style of quotes everywhere and does a better job of aligning on the column boundaries.

They also add support for using `clang-tidy` instead of `clang-format` on systems with at least version 9.0.0 of `clang-tidy`.

I separated the patches that update all of the syntax from the patch that adds the auto-formatters to make review simpler.

I also noticed that .pyc and .pyo files weren't included in .gitignore while working on this, so there's a patch for that as well.

These patches are built atop #383 because that PR includes some fixes that clang-tidy revealed were needed.