### PR TITLE
Travis: Use default Ubuntu test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: c
 compiler: gcc
 sudo: required
-dist: trusty
 
 services:
   - docker


### PR DESCRIPTION
The kernel on "Trusty" (14.04) is too old to support some
distributions like OpenMandriva in Docker. Track the default
version of Ubuntu in Travis (16.04 at the time of this patch).

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>