### PR TITLE
Make travis-common.inc more standalone

### DIFF
--- a/.travis/travis-archlinux.sh
+++ b/.travis/travis-archlinux.sh
@@ -17,3 +17,4 @@ mmd_run_docker_tests \
     repository=docker.io \
     image=archlinux/base
 
+popd # $SCRIPT_DIR

--- a/.travis/travis-centos.sh
+++ b/.travis/travis-centos.sh
@@ -17,3 +17,5 @@ mmd_run_docker_tests \
     os=centos \
     release=$release \
     repository=registry.centos.org
+
+popd # $SCRIPT_DIR

--- a/.travis/travis-common.inc
+++ b/.travis/travis-common.inc
@@ -91,9 +91,6 @@ function mmd_run_docker_tests {
         --build-arg TARBALL=${TARBALL} .
 
     $MMD_OCI run --rm fedora-modularity/libmodulemd-$MMD_OS:$MMD_RELEASE
-
-    popd
-
 }
 
 set +x

--- a/.travis/travis-fedora.sh
+++ b/.travis/travis-fedora.sh
@@ -18,3 +18,4 @@ mmd_run_docker_tests \
     release=$release \
     repository=registry.fedoraproject.org
 
+popd # $SCRIPT_DIR

--- a/.travis/travis-mageia.sh
+++ b/.travis/travis-mageia.sh
@@ -19,3 +19,4 @@ mmd_run_docker_tests \
     release=$release \
     repository=docker.io
 
+popd # $SCRIPT_DIR

--- a/.travis/travis-opensuse.sh
+++ b/.travis/travis-opensuse.sh
@@ -19,3 +19,4 @@ mmd_run_docker_tests \
     repository=registry.opensuse.org \
     image=opensuse/$release
 
+popd # $SCRIPT_DIR


### PR DESCRIPTION
Because of a bad copy-paste when it was refactored into common code,
the mmd_run_docker_tests() function was calling `popd` at the end of
its execution. Since it didn't call the `pushd` itself, it should
not be responsible for the accompanying `popd`.

This fixes an issue revealed by https://github.com/fedora-modularity/libmodulemd/pull/389 (which was using `cd` instead of `popd` in the `travis-openmandriva.sh`.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>