### PR TITLE
Clarify the meaning of the components arches field

### DIFF
--- a/spec.v1.yaml
+++ b/spec.v1.yaml
@@ -225,6 +225,8 @@ data:
                 # xxx is only available on the listed architectures.
                 # Includes specific hardware architectures, not families.
                 # See the data.arch field for details.
+                # Instructs the build system to only build the
+                # component on this specific set of architectures.
                 # Optional, defaults to all available arches.
                 arches: [ i686, x86_64 ]
                 # A list of architectures with multilib

--- a/spec.v2.yaml
+++ b/spec.v2.yaml
@@ -306,6 +306,8 @@ data:
                 # xxx is only available on the listed architectures.
                 # Includes specific hardware architectures, not families.
                 # See the data.arch field for details.
+                # Instructs the build system to only build the
+                # component on this specific set of architectures.
                 # Optional, defaults to all available arches.
                 arches: [i686, x86_64]
                 # A list of architectures with multilib


### PR DESCRIPTION
Only used at build time; instructs the build system (such as MBS or
Koji) to only build the component on the listed architectures.

Signed-off-by: Petr Šabata <contyk@redhat.com>