### PR TITLE
Copy Python tests for Modulemd.ModuleStream.documentation into C

### DIFF
--- a/modulemd/tests/ModulemdTests/modulestream.py
+++ b/modulemd/tests/ModulemdTests/modulestream.py
@@ -350,6 +350,15 @@ class TestModuleStream(TestBase):
             assert stream.props.documentation is None
             assert stream.get_documentation() is None
 
+            # Test unicode characters
+            unicode_test_str = (
+                "À϶￥🌭∮⇒⇔¬β∀₂⌀ıəˈ⍳⍴V)═€ίζησθლბშიнстемองจึองታሽ።ደለᚢᛞᚦᚹ⠳⠞⠊⠎▉▒▒▓😃"
+            )
+
+            stream.props.documentation = unicode_test_str
+            assert stream.props.documentation == unicode_test_str
+            assert stream.get_documentation() == unicode_test_str
+
     def test_summary(self):
         for version in modulestream_versions:
             stream = Modulemd.ModuleStream.new(version)

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -17,6 +17,10 @@
 #define MMD_TEST_DOC_TEXT "http://example.com"
 #define MMD_TEST_DOC_TEXT2 "http://redhat.com"
 #define MMD_TEST_DOC_PROP "documentation"
+#define MMD_TEST_DOC_UNICODE_TEXT                                             \
+  "À϶￥🌭∮⇒⇔¬β∀₂⌀ıəˈ⍳⍴V)"                           \
+  "═€ίζησθლბშიнстемองจึองታሽ።ደለᚢᛞᚦᚹ⠳⠞⠊⠎▉▒▒▓😃"
+
 typedef struct _ModuleStreamFixture
 {
 } ModuleStreamFixture;
@@ -249,6 +253,18 @@ module_stream_v1_test_documentation (ModuleStreamFixture *fixture,
   g_assert_null (documentation_prop);
 
   g_clear_pointer (&documentation_prop, g_free);
+
+  // Test unicode characters
+  modulemd_module_stream_v1_set_documentation (stream,
+                                               MMD_TEST_DOC_UNICODE_TEXT);
+
+  documentation = modulemd_module_stream_v1_get_documentation (stream);
+  g_object_get (stream, MMD_TEST_DOC_PROP, &documentation_prop, NULL);
+  g_assert_cmpstr (documentation_prop, ==, MMD_TEST_DOC_UNICODE_TEXT);
+  g_assert_cmpstr (documentation, ==, MMD_TEST_DOC_UNICODE_TEXT);
+
+  g_clear_pointer (&documentation_prop, g_free);
+
   g_clear_object (&stream);
 }
 
@@ -300,6 +316,18 @@ module_stream_v2_test_documentation (ModuleStreamFixture *fixture,
   g_assert_null (documentation_prop);
 
   g_clear_pointer (&documentation_prop, g_free);
+
+  // Test unicode characters
+  modulemd_module_stream_v2_set_documentation (stream,
+                                               MMD_TEST_DOC_UNICODE_TEXT);
+
+  documentation = modulemd_module_stream_v2_get_documentation (stream);
+  g_object_get (stream, MMD_TEST_DOC_PROP, &documentation_prop, NULL);
+  g_assert_cmpstr (documentation_prop, ==, MMD_TEST_DOC_UNICODE_TEXT);
+  g_assert_cmpstr (documentation, ==, MMD_TEST_DOC_UNICODE_TEXT);
+
+  g_clear_pointer (&documentation_prop, g_free);
+
   g_clear_object (&stream);
 }
 

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -200,6 +200,107 @@ module_stream_v2_test_profiles (ModuleStreamFixture *fixture,
 
 
 static void
+module_stream_v1_test_documentation (ModuleStreamFixture *fixture,
+                                     gconstpointer user_data)
+{
+  g_autoptr (ModulemdModuleStreamV1) stream = NULL;
+  g_autofree const gchar *documentation = NULL;
+  g_autofree gchar *documentation_prop = NULL;
+
+  stream = modulemd_module_stream_v1_new (NULL, NULL);
+
+  // Check the defaults
+  documentation = modulemd_module_stream_v1_get_documentation (stream);
+  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_assert_null (documentation);
+  g_assert_null (documentation_prop);
+
+  g_clear_pointer (&documentation_prop, g_free);
+
+  // Test property setting
+  g_object_set (stream, "documentation", "http://example.com", NULL);
+
+  documentation = modulemd_module_stream_v1_get_documentation (stream);
+  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_assert_cmpstr (documentation_prop, ==, "http://example.com");
+  g_assert_cmpstr (documentation, ==, "http://example.com");
+
+  g_clear_pointer (&documentation_prop, g_free);
+
+  // Test set_documentation()
+  modulemd_module_stream_v1_set_documentation (stream, "http://redhat.com");
+
+  documentation = modulemd_module_stream_v1_get_documentation (stream);
+  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_assert_cmpstr (documentation_prop, ==, "http://redhat.com");
+  g_assert_cmpstr (documentation, ==, "http://redhat.com");
+
+  g_clear_pointer (&documentation_prop, g_free);
+
+  // Test setting to NULL
+  g_object_set (stream, "documentation", NULL, NULL);
+
+  documentation = modulemd_module_stream_v1_get_documentation (stream);
+  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_assert_null (documentation);
+  g_assert_null (documentation_prop);
+
+  g_clear_pointer (&documentation_prop, g_free);
+  g_clear_object (&stream);
+}
+
+
+static void
+module_stream_v2_test_documentation (ModuleStreamFixture *fixture,
+                                     gconstpointer user_data)
+{
+  g_autoptr (ModulemdModuleStreamV2) stream = NULL;
+  g_autofree const gchar *documentation = NULL;
+  g_autofree gchar *documentation_prop = NULL;
+
+  stream = modulemd_module_stream_v2_new (NULL, NULL);
+
+  // Check the defaults
+  documentation = modulemd_module_stream_v2_get_documentation (stream);
+  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_assert_null (documentation);
+  g_assert_null (documentation_prop);
+
+  g_clear_pointer (&documentation_prop, g_free);
+
+  // Test property setting
+  g_object_set (stream, "documentation", "http://example.com", NULL);
+
+  documentation = modulemd_module_stream_v2_get_documentation (stream);
+  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_assert_cmpstr (documentation_prop, ==, "http://example.com");
+  g_assert_cmpstr (documentation, ==, "http://example.com");
+
+  g_clear_pointer (&documentation_prop, g_free);
+
+  // Test set_documentation()
+  modulemd_module_stream_v2_set_documentation (stream, "http://redhat.com");
+
+  documentation = modulemd_module_stream_v2_get_documentation (stream);
+  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_assert_cmpstr (documentation_prop, ==, "http://redhat.com");
+  g_assert_cmpstr (documentation, ==, "http://redhat.com");
+
+  g_clear_pointer (&documentation_prop, g_free);
+
+  // Test setting to NULL
+  g_object_set (stream, "documentation", NULL, NULL);
+
+  documentation = modulemd_module_stream_v2_get_documentation (stream);
+  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_assert_null (documentation);
+  g_assert_null (documentation_prop);
+
+  g_clear_pointer (&documentation_prop, g_free);
+  g_clear_object (&stream);
+}
+
+static void
 module_stream_test_copy (ModuleStreamFixture *fixture, gconstpointer user_data)
 {
   g_autoptr (ModulemdModuleStream) stream = NULL;
@@ -1640,6 +1741,20 @@ main (int argc, char *argv[])
               NULL,
               NULL,
               module_stream_test_arch,
+              NULL);
+
+  g_test_add ("/modulemd/v2/modulestream/v1/documentation",
+              ModuleStreamFixture,
+              NULL,
+              NULL,
+              module_stream_v1_test_documentation,
+              NULL);
+
+  g_test_add ("/modulemd/v2/modulestream/v2/documentation",
+              ModuleStreamFixture,
+              NULL,
+              NULL,
+              module_stream_v2_test_documentation,
               NULL);
 
   g_test_add ("/modulemd/v2/modulestream/v1/profiles",

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -14,6 +14,9 @@
 #include "private/modulemd-yaml.h"
 #include "private/test-utils.h"
 
+#define MMD_TEST_DOC_TEXT "http://example.com"
+#define MMD_TEST_DOC_TEXT2 "http://redhat.com"
+#define MMD_TEST_DOC_PROP "documentation"
 typedef struct _ModuleStreamFixture
 {
 } ModuleStreamFixture;
@@ -211,37 +214,37 @@ module_stream_v1_test_documentation (ModuleStreamFixture *fixture,
 
   // Check the defaults
   documentation = modulemd_module_stream_v1_get_documentation (stream);
-  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_object_get (stream, MMD_TEST_DOC_PROP, &documentation_prop, NULL);
   g_assert_null (documentation);
   g_assert_null (documentation_prop);
 
   g_clear_pointer (&documentation_prop, g_free);
 
   // Test property setting
-  g_object_set (stream, "documentation", "http://example.com", NULL);
+  g_object_set (stream, MMD_TEST_DOC_PROP, MMD_TEST_DOC_TEXT, NULL);
 
   documentation = modulemd_module_stream_v1_get_documentation (stream);
-  g_object_get (stream, "documentation", &documentation_prop, NULL);
-  g_assert_cmpstr (documentation_prop, ==, "http://example.com");
-  g_assert_cmpstr (documentation, ==, "http://example.com");
+  g_object_get (stream, MMD_TEST_DOC_PROP, &documentation_prop, NULL);
+  g_assert_cmpstr (documentation_prop, ==, MMD_TEST_DOC_TEXT);
+  g_assert_cmpstr (documentation, ==, MMD_TEST_DOC_TEXT);
 
   g_clear_pointer (&documentation_prop, g_free);
 
   // Test set_documentation()
-  modulemd_module_stream_v1_set_documentation (stream, "http://redhat.com");
+  modulemd_module_stream_v1_set_documentation (stream, MMD_TEST_DOC_TEXT2);
 
   documentation = modulemd_module_stream_v1_get_documentation (stream);
-  g_object_get (stream, "documentation", &documentation_prop, NULL);
-  g_assert_cmpstr (documentation_prop, ==, "http://redhat.com");
-  g_assert_cmpstr (documentation, ==, "http://redhat.com");
+  g_object_get (stream, MMD_TEST_DOC_PROP, &documentation_prop, NULL);
+  g_assert_cmpstr (documentation_prop, ==, MMD_TEST_DOC_TEXT2);
+  g_assert_cmpstr (documentation, ==, MMD_TEST_DOC_TEXT2);
 
   g_clear_pointer (&documentation_prop, g_free);
 
   // Test setting to NULL
-  g_object_set (stream, "documentation", NULL, NULL);
+  g_object_set (stream, MMD_TEST_DOC_PROP, NULL, NULL);
 
   documentation = modulemd_module_stream_v1_get_documentation (stream);
-  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_object_get (stream, MMD_TEST_DOC_PROP, &documentation_prop, NULL);
   g_assert_null (documentation);
   g_assert_null (documentation_prop);
 
@@ -262,37 +265,37 @@ module_stream_v2_test_documentation (ModuleStreamFixture *fixture,
 
   // Check the defaults
   documentation = modulemd_module_stream_v2_get_documentation (stream);
-  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_object_get (stream, MMD_TEST_DOC_PROP, &documentation_prop, NULL);
   g_assert_null (documentation);
   g_assert_null (documentation_prop);
 
   g_clear_pointer (&documentation_prop, g_free);
 
   // Test property setting
-  g_object_set (stream, "documentation", "http://example.com", NULL);
+  g_object_set (stream, MMD_TEST_DOC_PROP, MMD_TEST_DOC_TEXT, NULL);
 
   documentation = modulemd_module_stream_v2_get_documentation (stream);
-  g_object_get (stream, "documentation", &documentation_prop, NULL);
-  g_assert_cmpstr (documentation_prop, ==, "http://example.com");
-  g_assert_cmpstr (documentation, ==, "http://example.com");
+  g_object_get (stream, MMD_TEST_DOC_PROP, &documentation_prop, NULL);
+  g_assert_cmpstr (documentation_prop, ==, MMD_TEST_DOC_TEXT);
+  g_assert_cmpstr (documentation, ==, MMD_TEST_DOC_TEXT);
 
   g_clear_pointer (&documentation_prop, g_free);
 
   // Test set_documentation()
-  modulemd_module_stream_v2_set_documentation (stream, "http://redhat.com");
+  modulemd_module_stream_v2_set_documentation (stream, MMD_TEST_DOC_TEXT2);
 
   documentation = modulemd_module_stream_v2_get_documentation (stream);
-  g_object_get (stream, "documentation", &documentation_prop, NULL);
-  g_assert_cmpstr (documentation_prop, ==, "http://redhat.com");
-  g_assert_cmpstr (documentation, ==, "http://redhat.com");
+  g_object_get (stream, MMD_TEST_DOC_PROP, &documentation_prop, NULL);
+  g_assert_cmpstr (documentation_prop, ==, MMD_TEST_DOC_TEXT2);
+  g_assert_cmpstr (documentation, ==, MMD_TEST_DOC_TEXT2);
 
   g_clear_pointer (&documentation_prop, g_free);
 
   // Test setting to NULL
-  g_object_set (stream, "documentation", NULL, NULL);
+  g_object_set (stream, MMD_TEST_DOC_PROP, NULL, NULL);
 
   documentation = modulemd_module_stream_v2_get_documentation (stream);
-  g_object_get (stream, "documentation", &documentation_prop, NULL);
+  g_object_get (stream, MMD_TEST_DOC_PROP, &documentation_prop, NULL);
   g_assert_null (documentation);
   g_assert_null (documentation_prop);
 

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -204,7 +204,7 @@ module_stream_v1_test_documentation (ModuleStreamFixture *fixture,
                                      gconstpointer user_data)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
-  g_autofree const gchar *documentation = NULL;
+  const gchar *documentation = NULL;
   g_autofree gchar *documentation_prop = NULL;
 
   stream = modulemd_module_stream_v1_new (NULL, NULL);
@@ -255,7 +255,7 @@ module_stream_v2_test_documentation (ModuleStreamFixture *fixture,
                                      gconstpointer user_data)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
-  g_autofree const gchar *documentation = NULL;
+  const gchar *documentation = NULL;
   g_autofree gchar *documentation_prop = NULL;
 
   stream = modulemd_module_stream_v2_new (NULL, NULL);


### PR DESCRIPTION
This copies the Python test [`test_documentation`](https://github.com/fedora-modularity/libmodulemd/blob/f10d1aac981faa2ec1f0fe4f014e4ad5851bb943/modulemd/tests/ModulemdTests/modulestream.py#L330) into C. This is related to #199.