### PR TITLE
Add tests for ModulemdModuleStream description

### DIFF
--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -21,6 +21,8 @@
   "À϶￥🌭∮⇒⇔¬β∀₂⌀ıəˈ⍳⍴V)"                           \
   "═€ίζησθლბშიнстемองจึองታሽ።ደለᚢᛞᚦᚹ⠳⠞⠊⠎▉▒▒▓😃"
 
+#define MMD_TEST_DESC_TEXT "A different description"
+
 typedef struct _ModuleStreamFixture
 {
 } ModuleStreamFixture;
@@ -205,6 +207,69 @@ module_stream_v2_test_profiles (ModuleStreamFixture *fixture,
   g_clear_pointer (&rpms, g_strfreev);
 }
 
+static void
+module_stream_v1_test_description (ModuleStreamFixture *fixture,
+                                   gconstpointer user_date)
+{
+  g_autoptr (ModulemdModuleStreamV1) stream = NULL;
+  const gchar *description = NULL;
+
+  stream = modulemd_module_stream_v1_new (NULL, NULL);
+
+  // Check the defaults
+  description = modulemd_module_stream_v1_get_description (stream, "C");
+  g_assert_null (description);
+
+  // Test setting description
+  modulemd_module_stream_v1_set_description (stream, MMD_TEST_DESC_TEXT);
+  description = modulemd_module_stream_v1_get_description (stream, "C");
+  g_assert_cmpstr (description, ==, MMD_TEST_DESC_TEXT);
+
+  // Test setting it back to NULL
+  modulemd_module_stream_v1_set_description (stream, NULL);
+  description = modulemd_module_stream_v1_get_description (stream, "C");
+  g_assert_null (description);
+
+  // Test unicode characters
+  modulemd_module_stream_v1_set_description (stream,
+                                             MMD_TEST_DOC_UNICODE_TEXT);
+  description = modulemd_module_stream_v1_get_description (stream, "C");
+  g_assert_cmpstr (description, ==, MMD_TEST_DOC_UNICODE_TEXT);
+
+  g_clear_object (&stream);
+}
+
+static void
+module_stream_v2_test_description (ModuleStreamFixture *fixture,
+                                   gconstpointer user_date)
+{
+  g_autoptr (ModulemdModuleStreamV2) stream = NULL;
+  const gchar *description = NULL;
+
+  stream = modulemd_module_stream_v2_new (NULL, NULL);
+
+  // Check the defaults
+  description = modulemd_module_stream_v2_get_description (stream, "C");
+  g_assert_null (description);
+
+  // Test setting description
+  modulemd_module_stream_v2_set_description (stream, MMD_TEST_DESC_TEXT);
+  description = modulemd_module_stream_v2_get_description (stream, "C");
+  g_assert_cmpstr (description, ==, MMD_TEST_DESC_TEXT);
+
+  // Test setting it back to NULL
+  modulemd_module_stream_v2_set_description (stream, NULL);
+  description = modulemd_module_stream_v2_get_description (stream, "C");
+  g_assert_null (description);
+
+  // Test unicode characters
+  modulemd_module_stream_v2_set_description (stream,
+                                             MMD_TEST_DOC_UNICODE_TEXT);
+  description = modulemd_module_stream_v2_get_description (stream, "C");
+  g_assert_cmpstr (description, ==, MMD_TEST_DOC_UNICODE_TEXT);
+
+  g_clear_object (&stream);
+}
 
 static void
 module_stream_v1_test_documentation (ModuleStreamFixture *fixture,
@@ -2002,6 +2067,20 @@ main (int argc, char *argv[])
               NULL,
               NULL,
               module_stream_v2_test_documentation,
+              NULL);
+
+  g_test_add ("/modulemd/v2/modulestream/v1/description",
+              ModuleStreamFixture,
+              NULL,
+              NULL,
+              module_stream_v1_test_description,
+              NULL);
+
+  g_test_add ("/modulemd/v2/modulestream/v2/description",
+              ModuleStreamFixture,
+              NULL,
+              NULL,
+              module_stream_v2_test_description,
               NULL);
 
   g_test_add ("/modulemd/v2/modulestream/v1/profiles",


### PR DESCRIPTION
Copied python tests for Modulemd.ModuleStream.description into C as a Google Code-in 2019 Task.