### PR TITLE
bindings/python: Remove duplicate license header

### DIFF
--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -11,18 +11,6 @@
 # This program is free software.
 # For more information on the license, see COPYING.
 # For more information on free software, see
-# <https://www.gnu.org/philosophy/free-sw.en.html>.#!/usr/bin/python3
-
-# This file is part of libmodulemd
-# Copyright (C) 2017-2018 Stephen Gallagher
-#
-# Fedora-License-Identifier: MIT
-# SPDX-2.0-License-Identifier: MIT
-# SPDX-3.0-License-Identifier: MIT
-#
-# This program is free software.
-# For more information on the license, see COPYING.
-# For more information on free software, see
 # <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 from ..module import get_introspection_module


### PR DESCRIPTION
It seems that the license header was duplicated
and inserted incorrectly.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>