### PR TITLE
Fix GDate autoptr cleanup build errors that started appearing with GLib 2.63.3

### DIFF
--- a/modulemd/include/private/glib-extensions.h
+++ b/modulemd/include/private/glib-extensions.h
@@ -13,4 +13,7 @@
 
 #include <glib.h>
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (GDate, g_date_free);
+/* GDate autoptr cleanup was finally added in GLib 2.63.3. */
+#if !GLIB_CHECK_VERSION(2, 63, 3)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (GDate, g_date_free)
+#endif


### PR DESCRIPTION
The GDate autoptr cleanup was finally officially added in GLib 2.63.3--which is now available in Fedora Rawhide--so stop defining it ourselves.

https://gitlab.gnome.org/GNOME/glib/merge_requests/1256