### PR TITLE
The GDate autoptr cleanup was finally officially added in GLib 2.63.3…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,7 @@ jobs:
 
 
     - stage: Fedora x86_64
-      name: "Fedora 29 x86_64"
-      script: ./.travis/travis-fedora.sh
-      arch: amd64
-
-    - name: "Fedora 30 x86_64"
+      name: "Fedora 30 x86_64"
       script: ./.travis/travis-fedora.sh
       arch: amd64
 
@@ -75,10 +71,7 @@ jobs:
       arch: amd64
 
     - stage: Fedora aarch64
-      name: "Fedora 29 aarch64"
-      script: ./.travis/travis-fedora.sh
-      arch: arm64
-    - name: "Fedora 30 aarch64"
+      name: "Fedora 30 aarch64"
       script: ./.travis/travis-fedora.sh
       arch: arm64
     - name: "Fedora 31 aarch64"

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,8 @@ with_libmagic = get_option('libmagic')
 rpm = dependency('rpm', required : with_rpmio)
 magic = cc.find_library('magic', required : with_libmagic)
 
-glib_prefix = dependency('glib-2.0').get_pkgconfig_variable('prefix')
+glib = dependency('glib-2.0')
+glib_prefix = glib.get_pkgconfig_variable('prefix')
 
 sh = find_program('sh')
 sed = find_program('sed')
@@ -80,6 +81,20 @@ if with_docs
     error('Missing documentation for GObject.')
   endif
 endif
+
+
+# Check whether this version of glib has the GDate autoptr defined
+gdate_check = '''#include <glib.h>
+int main (int argc, char **argv)
+{
+  g_autoptr(GDate) date = NULL;
+  return 0;
+}
+'''
+has_gdate_autoptr = cc.compiles(
+    gdate_check,
+    dependencies : [ glib ],
+    name : 'g_autoptr(GDate)')
 
 python_name = get_option('python_name')
 

--- a/modulemd/include/private/glib-extensions.h
+++ b/modulemd/include/private/glib-extensions.h
@@ -11,6 +11,13 @@
  * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
  */
 
+#pragma once
+
 #include <glib.h>
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (GDate, g_date_free);
+#include "config.h"
+
+/* GDate autoptr cleanup was finally added in GLib 2.63.3. */
+#ifndef HAVE_GDATE_AUTOPTR
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (GDate, g_date_free)
+#endif

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -229,6 +229,7 @@ cdata = configuration_data()
 cdata.set_quoted('LIBMODULEMD_VERSION', libmodulemd_version)
 cdata.set('HAVE_RPMIO', rpm.found())
 cdata.set('HAVE_LIBMAGIC', magic.found())
+cdata.set('HAVE_GDATE_AUTOPTR', has_gdate_autoptr)
 configure_file(
   output : 'config.h',
   configuration : cdata

--- a/modulemd/modulemd-util.c
+++ b/modulemd/modulemd-util.c
@@ -360,7 +360,7 @@ modulemd_validate_nevra (const gchar *nevra)
         {
           break;
         }
-      else if (*i == '-')
+      if (*i == '-')
         {
           /* '-' between version and epoch is not allowed */
           return FALSE;


### PR DESCRIPTION
…--which is now available in Fedora Rawhide--so stop defining it ourselves.

https://gitlab.gnome.org/GNOME/glib/merge_requests/1256

Fixes: https://github.com/fedora-modularity/libmodulemd/pull/414

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>