### PR TITLE
CI: Update OpenMandriva Dockerfile.deps to use 'python3dist(autopep8)'

### DIFF
--- a/.travis/openmandriva/Dockerfile.deps.tmpl
+++ b/.travis/openmandriva/Dockerfile.deps.tmpl
@@ -15,7 +15,7 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	task-devel \
 	'pkgconfig(zlib)' \
 	'pkgconfig(gobject-introspection-1.0)' \
-	'python3egg(autopep8)' \
+	'python3dist(autopep8)' \
 	'python3dist(pygobject)' \
 	'pkgconfig(yaml-0.1)' \
 	'pkgconfig(rpm)' \


### PR DESCRIPTION
The transition has been completed to move from python3egg()
virtual package names to python3dist() as done by the upstream
RPM dependency generator. Now the old names are going away, so
this needs to be fixed to avoid breakage.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>