### PR TITLE
converted all g_test_add() to g_test_add_func()

### DIFF
--- a/modulemd/tests/test-modulemd-buildopts.c
+++ b/modulemd/tests/test-modulemd-buildopts.c
@@ -557,56 +557,56 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/buildopts/construct",
+  g_test_add_func ("/modulemd/v2/buildopts/construct",
               BuildoptsFixture,
               NULL,
               NULL,
               buildopts_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/buildopts/equals",
+  g_test_add_func ("/modulemd/v2/buildopts/equals",
               BuildoptsFixture,
               NULL,
               NULL,
               buildopts_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/buildopts/copy",
+  g_test_add_func ("/modulemd/v2/buildopts/copy",
               BuildoptsFixture,
               NULL,
               NULL,
               buildopts_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/buildopts/get_set_rpm_macros",
+  g_test_add_func ("/modulemd/v2/buildopts/get_set_rpm_macros",
               BuildoptsFixture,
               NULL,
               NULL,
               buildopts_test_get_set_rpm_macros,
               NULL);
 
-  g_test_add ("/modulemd/v2/buildopts/whitelist",
+  g_test_add_func ("/modulemd/v2/buildopts/whitelist",
               BuildoptsFixture,
               NULL,
               NULL,
               buildopts_test_whitelist,
               NULL);
 
-  g_test_add ("/modulemd/v2/buildopts/arches",
+  g_test_add_func ("/modulemd/v2/buildopts/arches",
               BuildoptsFixture,
               NULL,
               NULL,
               buildopts_test_arches,
               NULL);
 
-  g_test_add ("/modulemd/v2/buildopts/yaml/parse",
+  g_test_add_func ("/modulemd/v2/buildopts/yaml/parse",
               BuildoptsFixture,
               NULL,
               NULL,
               buildopts_test_parse_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/buildopts/yaml/emit",
+  g_test_add_func ("/modulemd/v2/buildopts/yaml/emit",
               BuildoptsFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-component-module.c
+++ b/modulemd/tests/test-modulemd-component-module.c
@@ -393,35 +393,35 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add ("/modulemd/v2/component/module/construct",
+  g_test_add_func ("/modulemd/v2/component/module/construct",
               ComponentModuleFixture,
               NULL,
               NULL,
               component_module_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/component/module/equals",
+  g_test_add_func ("/modulemd/v2/component/module/equals",
               ComponentModuleFixture,
               NULL,
               NULL,
               component_module_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/component/module/copy",
+  g_test_add_func ("/modulemd/v2/component/module/copy",
               ComponentModuleFixture,
               NULL,
               NULL,
               component_module_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/component/module/yaml/emit",
+  g_test_add_func ("/modulemd/v2/component/module/yaml/emit",
               ComponentModuleFixture,
               NULL,
               NULL,
               component_module_test_emit_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/component/module/yaml/parse",
+  g_test_add_func ("/modulemd/v2/component/module/yaml/parse",
               ComponentModuleFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-component-rpm.c
+++ b/modulemd/tests/test-modulemd-component-rpm.c
@@ -453,42 +453,42 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add ("/modulemd/v2/component/rpm/construct",
+  g_test_add_func ("/modulemd/v2/component/rpm/construct",
               ComponentRpmFixture,
               NULL,
               NULL,
               component_rpm_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/component/rpm/equals",
+  g_test_add_func ("/modulemd/v2/component/rpm/equals",
               ComponentRpmFixture,
               NULL,
               NULL,
               component_rpm_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/component/rpm/copy",
+  g_test_add_func ("/modulemd/v2/component/rpm/copy",
               ComponentRpmFixture,
               NULL,
               NULL,
               component_rpm_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/component/rpm/yaml/emit",
+  g_test_add_func ("/modulemd/v2/component/rpm/yaml/emit",
               ComponentRpmFixture,
               NULL,
               NULL,
               component_rpm_test_emit_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/component/rpm/yaml/parse",
+  g_test_add_func ("/modulemd/v2/component/rpm/yaml/parse",
               ComponentRpmFixture,
               NULL,
               NULL,
               component_rpm_test_parse_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/component/rpm/override_name",
+  g_test_add_func ("/modulemd/v2/component/rpm/override_name",
               ComponentRpmFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-defaults-v1.c
+++ b/modulemd/tests/test-modulemd-defaults-v1.c
@@ -746,56 +746,56 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add ("/modulemd/v2/defaults/v1/equals",
+  g_test_add_func ("/modulemd/v2/defaults/v1/equals",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/v1/construct",
+  g_test_add_func ("/modulemd/v2/defaults/v1/construct",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/v1/copy",
+  g_test_add_func ("/modulemd/v2/defaults/v1/copy",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/v1/default_stream",
+  g_test_add_func ("/modulemd/v2/defaults/v1/default_stream",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_get_set_default_stream,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/v1/validate",
+  g_test_add_func ("/modulemd/v2/defaults/v1/validate",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_validate,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/v1/profile_defaults",
+  g_test_add_func ("/modulemd/v2/defaults/v1/profile_defaults",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_profiles,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/v1/yaml/parse",
+  g_test_add_func ("/modulemd/v2/defaults/v1/yaml/parse",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_parse_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/v1/yaml/emit",
+  g_test_add_func ("/modulemd/v2/defaults/v1/yaml/emit",
               CommonMmdTestFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-defaults.c
+++ b/modulemd/tests/test-modulemd-defaults.c
@@ -206,49 +206,49 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add ("/modulemd/v2/defaults/construct",
+  g_test_add_func ("/modulemd/v2/defaults/construct",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/copy",
+  g_test_add_func ("/modulemd/v2/defaults/copy",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/mdversion",
+  g_test_add_func ("/modulemd/v2/defaults/mdversion",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_get_mdversion,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/module_name",
+  g_test_add_func ("/modulemd/v2/defaults/module_name",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_get_module_name,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/validate",
+  g_test_add_func ("/modulemd/v2/defaults/validate",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_validate,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/equals",
+  g_test_add_func ("/modulemd/v2/defaults/equals",
               CommonMmdTestFixture,
               NULL,
               NULL,
               defaults_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/defaults/upgrade",
+  g_test_add_func ("/modulemd/v2/defaults/upgrade",
               CommonMmdTestFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-dependencies.c
+++ b/modulemd/tests/test-modulemd-dependencies.c
@@ -598,49 +598,49 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/dependencies/construct",
+  g_test_add_func ("/modulemd/v2/dependencies/construct",
               DependenciesFixture,
               NULL,
               NULL,
               dependencies_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/dependencies/dependencies",
+  g_test_add_func ("/modulemd/v2/dependencies/dependencies",
               DependenciesFixture,
               NULL,
               NULL,
               dependencies_test_dependencies,
               NULL);
 
-  g_test_add ("/modulemd/v2/dependencies/equals",
+  g_test_add_func ("/modulemd/v2/dependencies/equals",
               DependenciesFixture,
               NULL,
               NULL,
               dependencies_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/dependencies/copy",
+  g_test_add_func ("/modulemd/v2/dependencies/copy",
               DependenciesFixture,
               NULL,
               NULL,
               dependencies_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/dependencies/yaml/parse",
+  g_test_add_func ("/modulemd/v2/dependencies/yaml/parse",
               DependenciesFixture,
               NULL,
               NULL,
               dependencies_test_parse_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/dependencies/yaml/parse/bad",
+  g_test_add_func ("/modulemd/v2/dependencies/yaml/parse/bad",
               DependenciesFixture,
               NULL,
               NULL,
               dependencies_test_parse_bad_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/dependencies/yaml/emit",
+  g_test_add_func ("/modulemd/v2/dependencies/yaml/emit",
               DependenciesFixture,
               NULL,
               NULL,
@@ -648,42 +648,42 @@ main (int argc, char *argv[])
               NULL);
 
   /*
-  g_test_add ("/modulemd/v2/profile/copy",
+  g_test_add_func ("/modulemd/v2/profile/copy",
               DependenciesFixture,
               NULL,
               NULL,
               profile_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/get_name",
+  g_test_add_func ("/modulemd/v2/profile/get_name",
               DependenciesFixture,
               NULL,
               NULL,
               profile_test_get_name,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/get_set_description",
+  g_test_add_func ("/modulemd/v2/profile/get_set_description",
               DependenciesFixture,
               NULL,
               NULL,
               profile_test_get_set_description,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/rpms",
+  g_test_add_func ("/modulemd/v2/profile/rpms",
               DependenciesFixture,
               NULL,
               NULL,
               profile_test_rpms,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/yaml/parse",
+  g_test_add_func ("/modulemd/v2/profile/yaml/parse",
               DependenciesFixture,
               NULL,
               NULL,
               profile_test_parse_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/yaml/emit",
+  g_test_add_func ("/modulemd/v2/profile/yaml/emit",
               DependenciesFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-merger.c
+++ b/modulemd/tests/test-modulemd-merger.c
@@ -248,14 +248,14 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/module/index/merger/constructors",
+  g_test_add_func ("/modulemd/v2/module/index/merger/constructors",
               CommonMmdTestFixture,
               NULL,
               NULL,
               merger_test_constructors,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/index/merger/deduplicate",
+  g_test_add_func ("/modulemd/v2/module/index/merger/deduplicate",
               CommonMmdTestFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-module.c
+++ b/modulemd/tests/test-modulemd-module.c
@@ -500,28 +500,28 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/module/construct",
+  g_test_add_func ("/modulemd/v2/module/construct",
               ModuleFixture,
               NULL,
               NULL,
               module_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/defaults",
+  g_test_add_func ("/modulemd/v2/module/defaults",
               ModuleFixture,
               NULL,
               NULL,
               module_test_defaults,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/stream_names",
+  g_test_add_func ("/modulemd/v2/module/stream_names",
               ModuleFixture,
               NULL,
               NULL,
               module_test_get_stream_names,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/streams",
+  g_test_add_func ("/modulemd/v2/module/streams",
               ModuleFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -1358,63 +1358,63 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/module/index/dump",
+  g_test_add_func ("/modulemd/v2/module/index/dump",
               ModuleIndexFixture,
               NULL,
               NULL,
               module_index_test_dump,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/index/read",
+  g_test_add_func ("/modulemd/v2/module/index/read",
               ModuleIndexFixture,
               NULL,
               NULL,
               module_index_test_read,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/index/read/mixed",
+  g_test_add_func ("/modulemd/v2/module/index/read/mixed",
               ModuleIndexFixture,
               NULL,
               NULL,
               module_index_test_read_mixed,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/index/read/unknown",
+  g_test_add_func ("/modulemd/v2/module/index/read/unknown",
               ModuleIndexFixture,
               NULL,
               NULL,
               module_index_test_read_unknown,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/index/upgrade/stream",
+  g_test_add_func ("/modulemd/v2/module/index/upgrade/stream",
               ModuleIndexFixture,
               NULL,
               NULL,
               module_index_test_stream_upgrade,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/index/upgrade/index",
+  g_test_add_func ("/modulemd/v2/module/index/upgrade/index",
               ModuleIndexFixture,
               NULL,
               NULL,
               module_index_test_index_upgrade,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/index/remove_module",
+  g_test_add_func ("/modulemd/v2/module/index/remove_module",
               ModuleIndexFixture,
               NULL,
               NULL,
               module_index_test_remove_module,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/index/custom_read",
+  g_test_add_func ("/modulemd/v2/module/index/custom_read",
               ModuleIndexFixture,
               NULL,
               NULL,
               module_index_test_custom_read,
               NULL);
 
-  g_test_add ("/modulemd/v2/module/index/custom_write",
+  g_test_add_func ("/modulemd/v2/module/index/custom_write",
               ModuleIndexFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -1976,77 +1976,77 @@ main (int argc, char *argv[])
 
   // Define the tests.o
 
-  g_test_add ("/modulemd/v2/modulestream/construct",
+  g_test_add_func ("/modulemd/v2/modulestream/construct",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/arch",
+  g_test_add_func ("/modulemd/v2/modulestream/arch",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_test_arch,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/documentation",
+  g_test_add_func ("/modulemd/v2/modulestream/v1/documentation",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v1_test_documentation,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/documentation",
+  g_test_add_func ("/modulemd/v2/modulestream/v2/documentation",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v2_test_documentation,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/profiles",
+  g_test_add_func ("/modulemd/v2/modulestream/v1/profiles",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v1_test_profiles,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/profiles",
+  g_test_add_func ("/modulemd/v2/modulestream/v2/profiles",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v2_test_profiles,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/components",
+  g_test_add_func ("/modulemd/v2/modulestream/v1/components",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v1_test_components,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/components",
+  g_test_add_func ("/modulemd/v2/modulestream/v2/components",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v2_test_components,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/copy",
+  g_test_add_func ("/modulemd/v2/modulestream/copy",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/equals",
+  g_test_add_func ("/modulemd/v2/modulestream/equals",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/nsvc",
+  g_test_add_func ("/modulemd/v2/modulestream/nsvc",
               ModuleStreamFixture,
               NULL,
               NULL,
@@ -2054,83 +2054,83 @@ main (int argc, char *argv[])
               NULL);
 
 
-  g_test_add ("/modulemd/v2/modulestream/nsvca",
+  g_test_add_func ("/modulemd/v2/modulestream/nsvca",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_test_nsvca,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/equals",
+  g_test_add_func ("/modulemd/v2/modulestream/v1/equals",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v1_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/equals",
+  g_test_add_func ("/modulemd/v2/modulestream/v2/equals",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v2_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/dependencies",
+  g_test_add_func ("/modulemd/v2/modulestream/v1/dependencies",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v1_test_dependencies,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/dependencies",
+  g_test_add_func ("/modulemd/v2/modulestream/v2/dependencies",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v2_test_dependencies,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/parse_dump",
+  g_test_add_func ("/modulemd/v2/modulestream/v1/parse_dump",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v1_test_parse_dump,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/parse_dump",
+  g_test_add_func ("/modulemd/v2/modulestream/v2/parse_dump",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v2_test_parse_dump,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/depends_on_stream",
+  g_test_add_func ("/modulemd/v2/modulestream/v1/depends_on_stream",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v1_test_depends_on_stream,
               NULL);
-  g_test_add ("/modulemd/v2/modulestream/v2/depends_on_stream",
+  g_test_add_func ("/modulemd/v2/modulestream/v2/depends_on_stream",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v2_test_depends_on_stream,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/validate/buildafter",
+  g_test_add_func ("/modulemd/v2/modulestream/v2/validate/buildafter",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v2_test_validate_buildafter,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/validate/buildarches",
+  g_test_add_func ("/modulemd/v2/modulestream/v2/validate/buildarches",
               ModuleStreamFixture,
               NULL,
               NULL,
               module_stream_v2_test_validate_buildarches,
               NULL);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/rpm_map",
+  g_test_add_func ("/modulemd/v2/modulestream/v2/rpm_map",
               ModuleStreamFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-profile.c
+++ b/modulemd/tests/test-modulemd-profile.c
@@ -490,56 +490,56 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/profile/construct",
+  g_test_add_func ("/modulemd/v2/profile/construct",
               ProfileFixture,
               NULL,
               NULL,
               profile_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/equals",
+  g_test_add_func ("/modulemd/v2/profile/equals",
               ProfileFixture,
               NULL,
               NULL,
               profile_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/copy",
+  g_test_add_func ("/modulemd/v2/profile/copy",
               ProfileFixture,
               NULL,
               NULL,
               profile_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/get_name",
+  g_test_add_func ("/modulemd/v2/profile/get_name",
               ProfileFixture,
               NULL,
               NULL,
               profile_test_get_name,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/get_set_description",
+  g_test_add_func ("/modulemd/v2/profile/get_set_description",
               ProfileFixture,
               NULL,
               NULL,
               profile_test_get_set_description,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/rpms",
+  g_test_add_func ("/modulemd/v2/profile/rpms",
               ProfileFixture,
               NULL,
               NULL,
               profile_test_rpms,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/yaml/parse",
+  g_test_add_func ("/modulemd/v2/profile/yaml/parse",
               ProfileFixture,
               NULL,
               NULL,
               profile_test_parse_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/profile/yaml/emit",
+  g_test_add_func ("/modulemd/v2/profile/yaml/emit",
               ProfileFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-rpmmap.c
+++ b/modulemd/tests/test-modulemd-rpmmap.c
@@ -274,49 +274,49 @@ main (int argc, char *argv[])
   g_test_init (&argc, &argv, NULL);
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
-  g_test_add ("/modulemd/v2/rpm_map/basic",
+  g_test_add_func ("/modulemd/v2/rpm_map/basic",
               CommonMmdTestFixture,
               NULL,
               NULL,
               test_basic,
               NULL);
 
-  g_test_add ("/modulemd/v2/rpm_map/compare",
+  g_test_add_func ("/modulemd/v2/rpm_map/compare",
               CommonMmdTestFixture,
               NULL,
               NULL,
               test_compare,
               NULL);
 
-  g_test_add ("/modulemd/v2/rpm_map/yaml/parse/valid",
+  g_test_add_func ("/modulemd/v2/rpm_map/yaml/parse/valid",
               CommonMmdTestFixture,
               NULL,
               NULL,
               test_parse_yaml_valid,
               NULL);
 
-  g_test_add ("/modulemd/v2/rpm_map/yaml/parse/missing",
+  g_test_add_func ("/modulemd/v2/rpm_map/yaml/parse/missing",
               CommonMmdTestFixture,
               NULL,
               NULL,
               test_parse_yaml_missing,
               NULL);
 
-  g_test_add ("/modulemd/v2/rpm_map/yaml/parse/mismatch",
+  g_test_add_func ("/modulemd/v2/rpm_map/yaml/parse/mismatch",
               CommonMmdTestFixture,
               NULL,
               NULL,
               test_parse_yaml_mismatch,
               NULL);
 
-  g_test_add ("/modulemd/v2/rpm_map/yaml/emit/valid",
+  g_test_add_func ("/modulemd/v2/rpm_map/yaml/emit/valid",
               CommonMmdTestFixture,
               NULL,
               NULL,
               test_emit_yaml_valid,
               NULL);
 
-  g_test_add ("/modulemd/v2/rpm_map/yaml/emit/invalid",
+  g_test_add_func ("/modulemd/v2/rpm_map/yaml/emit/invalid",
               CommonMmdTestFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-service-level.c
+++ b/modulemd/tests/test-modulemd-service-level.c
@@ -453,49 +453,49 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/servicelevel/construct",
+  g_test_add_func ("/modulemd/v2/servicelevel/construct",
               ServiceLevelFixture,
               NULL,
               NULL,
               service_level_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/servicelevel/get_set_name",
+  g_test_add_func ("/modulemd/v2/servicelevel/get_set_name",
               ServiceLevelFixture,
               NULL,
               NULL,
               service_level_test_get_name,
               NULL);
 
-  g_test_add ("/modulemd/v2/servicelevel/equals",
+  g_test_add_func ("/modulemd/v2/servicelevel/equals",
               ServiceLevelFixture,
               NULL,
               NULL,
               service_level_test_equals,
               NULL);
 
-  g_test_add ("/modulemd/v2/servicelevel/copy",
+  g_test_add_func ("/modulemd/v2/servicelevel/copy",
               ServiceLevelFixture,
               NULL,
               NULL,
               service_level_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/servicelevel/get_set_eol",
+  g_test_add_func ("/modulemd/v2/servicelevel/get_set_eol",
               ServiceLevelFixture,
               NULL,
               NULL,
               service_level_test_get_set_eol,
               NULL);
 
-  g_test_add ("/modulemd/v2/servicelevel/yaml/parse",
+  g_test_add_func ("/modulemd/v2/servicelevel/yaml/parse",
               ServiceLevelFixture,
               NULL,
               NULL,
               service_level_test_parse_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/servicelevel/yaml/emit",
+  g_test_add_func ("/modulemd/v2/servicelevel/yaml/emit",
               ServiceLevelFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-translation-entry.c
+++ b/modulemd/tests/test-modulemd-translation-entry.c
@@ -584,56 +584,56 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/translationentry/construct",
+  g_test_add_func ("/modulemd/v2/translationentry/construct",
               TranslationEntryFixture,
               NULL,
               NULL,
               translation_entry_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/translationentry/copy",
+  g_test_add_func ("/modulemd/v2/translationentry/copy",
               TranslationEntryFixture,
               NULL,
               NULL,
               translation_entry_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/translationentry/get_locale",
+  g_test_add_func ("/modulemd/v2/translationentry/get_locale",
               TranslationEntryFixture,
               NULL,
               NULL,
               translation_entry_test_get_locale,
               NULL);
 
-  g_test_add ("/modulemd/v2/translationentry/get_set_summary",
+  g_test_add_func ("/modulemd/v2/translationentry/get_set_summary",
               TranslationEntryFixture,
               NULL,
               NULL,
               translation_entry_test_get_set_summary,
               NULL);
 
-  g_test_add ("/modulemd/v2/translationentry/get_set_description",
+  g_test_add_func ("/modulemd/v2/translationentry/get_set_description",
               TranslationEntryFixture,
               NULL,
               NULL,
               translation_entry_test_get_set_description,
               NULL);
 
-  g_test_add ("/modulemd/v2/translationentry/profile_descriptions",
+  g_test_add_func ("/modulemd/v2/translationentry/profile_descriptions",
               TranslationEntryFixture,
               NULL,
               NULL,
               translation_entry_test_profile_descriptions,
               NULL);
 
-  g_test_add ("/modulemd/v2/translationentry/yaml/parse",
+  g_test_add_func ("/modulemd/v2/translationentry/yaml/parse",
               TranslationEntryFixture,
               NULL,
               NULL,
               translation_entry_test_parse_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/translationentry/yaml/emit",
+  g_test_add_func ("/modulemd/v2/translationentry/yaml/emit",
               TranslationEntryFixture,
               NULL,
               NULL,

--- a/modulemd/tests/test-modulemd-translation.c
+++ b/modulemd/tests/test-modulemd-translation.c
@@ -381,49 +381,49 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/translation/construct",
+  g_test_add_func ("/modulemd/v2/translation/construct",
               TranslationFixture,
               NULL,
               NULL,
               translation_test_construct,
               NULL);
 
-  g_test_add ("/modulemd/v2/translation/copy",
+  g_test_add_func ("/modulemd/v2/translation/copy",
               TranslationFixture,
               NULL,
               NULL,
               translation_test_copy,
               NULL);
 
-  g_test_add ("/modulemd/v2/translation/validate",
+  g_test_add_func ("/modulemd/v2/translation/validate",
               TranslationFixture,
               NULL,
               NULL,
               translation_test_validate,
               NULL);
 
-  g_test_add ("/modulemd/v2/translation/set_modified",
+  g_test_add_func ("/modulemd/v2/translation/set_modified",
               TranslationFixture,
               NULL,
               NULL,
               translation_test_set_modified,
               NULL);
 
-  g_test_add ("/modulemd/v2/translation/translations",
+  g_test_add_func ("/modulemd/v2/translation/translations",
               TranslationFixture,
               NULL,
               NULL,
               translation_test_translations,
               NULL);
 
-  g_test_add ("/modulemd/v2/translation/yaml/parse",
+  g_test_add_func ("/modulemd/v2/translation/yaml/parse",
               TranslationFixture,
               NULL,
               NULL,
               translation_test_parse_yaml,
               NULL);
 
-  g_test_add ("/modulemd/v2/translation/yaml/emit",
+  g_test_add_func ("/modulemd/v2/translation/yaml/emit",
               TranslationFixture,
               NULL,
               NULL,


### PR DESCRIPTION
Converting all g_test_add() to g_test_add_func() to improve readability, simplicity and uniformity of the program