### PR TITLE
CI: add support to run tests for CentOS 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - bash
     - tar
     - bzip2
+    - m4
 
 env:
   global:
@@ -35,6 +36,10 @@ jobs:
 
     - stage: CentOS x86_64
       name: "CentOS 7 x86_64"
+      script: ./.travis/travis-centos.sh
+      arch: amd64
+
+    - name: "CentOS 8 x86_64"
       script: ./.travis/travis-centos.sh
       arch: amd64
 

--- a/.travis/centos/Dockerfile.deps.tmpl
+++ b/.travis/centos/Dockerfile.deps.tmpl
@@ -3,6 +3,10 @@ FROM @IMAGE@
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
 RUN yum -y install epel-release \
+ifelse(eval(_RELEASE_ >= 8), 1, `dnl
+    && yum -y install dnf-plugins-core \
+    && yum config-manager --enable PowerTools \
+')dnl
     && yum -y --setopt=tsflags='' install \
         clang \
 	createrepo_c \
@@ -21,9 +25,13 @@ RUN yum -y install epel-release \
 	pkgconfig \
 	python2-devel \
 	python2-six \
+ifelse(eval(_RELEASE_ < 8), 1, `dnl
 	python-gobject-base \
-	python36-devel \
 	python36-gobject-base \
+',`dnl
+	python3-gobject-base \
+')dnl
+	python36-devel \
 	python3-rpm-macros \
 	redhat-rpm-config \
 	rpm-build \

--- a/.travis/travis-centos.sh
+++ b/.travis/travis-centos.sh
@@ -12,10 +12,14 @@ JOB_NAME=${TRAVIS_JOB_NAME:-CentOS 7}
 
 arr=($JOB_NAME)
 release=${arr[1]:-7}
+case $release in
+8)	repository=docker.io ;;
+*)	repository=registry.centos.org ;;
+esac
 
 mmd_run_docker_tests \
     os=centos \
     release=$release \
-    repository=registry.centos.org
+    repository=$repository
 
 popd # $SCRIPT_DIR

--- a/.travis/travis-common.inc
+++ b/.travis/travis-common.inc
@@ -77,9 +77,12 @@ function mmd_run_docker_tests {
     git ls-files |xargs tar cfj $MMD_TARBALL_PATH .git
     popd
 
-    sed -e "s#@IMAGE@#$repository/$image#" \
-        $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.tmpl > $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE
-    sed -e "s/@RELEASE@/$MMD_OS:$MMD_RELEASE/" $SCRIPT_DIR/$MMD_OS/Dockerfile.tmpl > $SCRIPT_DIR/$MMD_OS/Dockerfile-$MMD_RELEASE
+    sed -e "s#@IMAGE@#$repository/$image#" $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.tmpl \
+        | m4 -D_RELEASE_=$release \
+        > $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE
+    sed -e "s/@RELEASE@/$MMD_OS:$MMD_RELEASE/" $SCRIPT_DIR/$MMD_OS/Dockerfile.tmpl \
+        | m4 -D_RELEASE_=$release \
+        > $SCRIPT_DIR/$MMD_OS/Dockerfile-$MMD_RELEASE
 
     $MMD_BUILDAH $MMD_LAYERS_TRUE \
         -f $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE \


### PR DESCRIPTION
Accounting for the fact that registry.centos.org doesn't yet have a centos:8 image, and dependencies have moved to repositories that aren't enabled by default, and a couple dependencies have been renamed or dropped...