### PR TITLE
converted from g_test_add() to g_test_add_func()

### DIFF
--- a/modulemd/tests/test-modulemd-buildopts.c
+++ b/modulemd/tests/test-modulemd-buildopts.c
@@ -27,7 +27,7 @@ typedef struct _BuildoptsFixture
 } BuildoptsFixture;
 
 static void
-buildopts_test_construct (BuildoptsFixture *fixture, gconstpointer user_data)
+buildopts_test_construct (void)
 {
   g_autoptr (ModulemdBuildopts) b = NULL;
   g_auto (GStrv) whitelist = NULL;
@@ -60,7 +60,7 @@ buildopts_test_construct (BuildoptsFixture *fixture, gconstpointer user_data)
 
 
 static void
-buildopts_test_equals (BuildoptsFixture *fixture, gconstpointer user_data)
+buildopts_test_equals (void)
 {
   g_autoptr (ModulemdBuildopts) b_1 = NULL;
   g_autoptr (ModulemdBuildopts) b_2 = NULL;
@@ -210,7 +210,7 @@ buildopts_test_equals (BuildoptsFixture *fixture, gconstpointer user_data)
 
 
 static void
-buildopts_test_copy (BuildoptsFixture *fixture, gconstpointer user_data)
+buildopts_test_copy (void)
 {
   g_autoptr (ModulemdBuildopts) b = NULL;
   g_autoptr (ModulemdBuildopts) b_copy = NULL;
@@ -342,8 +342,7 @@ buildopts_test_copy (BuildoptsFixture *fixture, gconstpointer user_data)
 
 
 static void
-buildopts_test_get_set_rpm_macros (BuildoptsFixture *fixture,
-                                   gconstpointer user_data)
+buildopts_test_get_set_rpm_macros (void)
 {
   g_autoptr (ModulemdBuildopts) b = NULL;
   g_autofree gchar *rpm_macros;
@@ -372,7 +371,7 @@ buildopts_test_get_set_rpm_macros (BuildoptsFixture *fixture,
 }
 
 static void
-buildopts_test_whitelist (BuildoptsFixture *fixture, gconstpointer user_data)
+buildopts_test_whitelist (void)
 {
   g_autoptr (ModulemdBuildopts) b = NULL;
   g_auto (GStrv) whitelist = NULL;
@@ -409,7 +408,7 @@ buildopts_test_whitelist (BuildoptsFixture *fixture, gconstpointer user_data)
 }
 
 static void
-buildopts_test_arches (BuildoptsFixture *fixture, gconstpointer user_data)
+buildopts_test_arches (void)
 {
   g_autoptr (ModulemdBuildopts) b = NULL;
   g_auto (GStrv) arches = NULL;
@@ -447,7 +446,7 @@ buildopts_test_arches (BuildoptsFixture *fixture, gconstpointer user_data)
 
 
 static void
-buildopts_test_parse_yaml (BuildoptsFixture *fixture, gconstpointer user_data)
+buildopts_test_parse_yaml (void)
 {
   g_autoptr (ModulemdBuildopts) b = NULL;
   g_autoptr (GError) error = NULL;
@@ -487,7 +486,7 @@ buildopts_test_parse_yaml (BuildoptsFixture *fixture, gconstpointer user_data)
 
 
 static void
-buildopts_test_emit_yaml (BuildoptsFixture *fixture, gconstpointer user_data)
+buildopts_test_emit_yaml (void)
 {
   g_autoptr (ModulemdBuildopts) b = NULL;
   g_autoptr (GError) error = NULL;
@@ -557,61 +556,21 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/buildopts/construct",
-              BuildoptsFixture,
-              NULL,
-              NULL,
-              buildopts_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/buildopts/construct",buildopts_test_construct);
 
-  g_test_add ("/modulemd/v2/buildopts/equals",
-              BuildoptsFixture,
-              NULL,
-              NULL,
-              buildopts_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/buildopts/equals",buildopts_test_equals);
 
-  g_test_add ("/modulemd/v2/buildopts/copy",
-              BuildoptsFixture,
-              NULL,
-              NULL,
-              buildopts_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/buildopts/copy",buildopts_test_copy);
 
-  g_test_add ("/modulemd/v2/buildopts/get_set_rpm_macros",
-              BuildoptsFixture,
-              NULL,
-              NULL,
-              buildopts_test_get_set_rpm_macros,
-              NULL);
+  g_test_add_func ("/modulemd/v2/buildopts/get_set_rpm_macros",buildopts_test_get_set_rpm_macros);
 
-  g_test_add ("/modulemd/v2/buildopts/whitelist",
-              BuildoptsFixture,
-              NULL,
-              NULL,
-              buildopts_test_whitelist,
-              NULL);
+  g_test_add_func ("/modulemd/v2/buildopts/whitelist",buildopts_test_whitelist);
 
-  g_test_add ("/modulemd/v2/buildopts/arches",
-              BuildoptsFixture,
-              NULL,
-              NULL,
-              buildopts_test_arches,
-              NULL);
+  g_test_add_func ("/modulemd/v2/buildopts/arches",buildopts_test_arches);
 
-  g_test_add ("/modulemd/v2/buildopts/yaml/parse",
-              BuildoptsFixture,
-              NULL,
-              NULL,
-              buildopts_test_parse_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/buildopts/yaml/parse",buildopts_test_parse_yaml);
 
-  g_test_add ("/modulemd/v2/buildopts/yaml/emit",
-              BuildoptsFixture,
-              NULL,
-              NULL,
-              buildopts_test_emit_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/buildopts/yaml/emit",buildopts_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-buildopts.c
+++ b/modulemd/tests/test-modulemd-buildopts.c
@@ -556,21 +556,26 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add_func ("/modulemd/v2/buildopts/construct",buildopts_test_construct);
+  g_test_add_func ("/modulemd/v2/buildopts/construct",
+                   buildopts_test_construct);
 
-  g_test_add_func ("/modulemd/v2/buildopts/equals",buildopts_test_equals);
+  g_test_add_func ("/modulemd/v2/buildopts/equals", buildopts_test_equals);
 
-  g_test_add_func ("/modulemd/v2/buildopts/copy",buildopts_test_copy);
+  g_test_add_func ("/modulemd/v2/buildopts/copy", buildopts_test_copy);
 
-  g_test_add_func ("/modulemd/v2/buildopts/get_set_rpm_macros",buildopts_test_get_set_rpm_macros);
+  g_test_add_func ("/modulemd/v2/buildopts/get_set_rpm_macros",
+                   buildopts_test_get_set_rpm_macros);
 
-  g_test_add_func ("/modulemd/v2/buildopts/whitelist",buildopts_test_whitelist);
+  g_test_add_func ("/modulemd/v2/buildopts/whitelist",
+                   buildopts_test_whitelist);
 
-  g_test_add_func ("/modulemd/v2/buildopts/arches",buildopts_test_arches);
+  g_test_add_func ("/modulemd/v2/buildopts/arches", buildopts_test_arches);
 
-  g_test_add_func ("/modulemd/v2/buildopts/yaml/parse",buildopts_test_parse_yaml);
+  g_test_add_func ("/modulemd/v2/buildopts/yaml/parse",
+                   buildopts_test_parse_yaml);
 
-  g_test_add_func ("/modulemd/v2/buildopts/yaml/emit",buildopts_test_emit_yaml);
+  g_test_add_func ("/modulemd/v2/buildopts/yaml/emit",
+                   buildopts_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-component-module.c
+++ b/modulemd/tests/test-modulemd-component-module.c
@@ -37,8 +37,7 @@ sigtrap_handler (int sig_num)
 }
 
 static void
-component_module_test_construct (ComponentModuleFixture *fixture,
-                                 gconstpointer user_data)
+component_module_test_construct (void)
 {
   g_autoptr (ModulemdComponentModule) m = NULL;
   ModulemdComponent *mc = NULL;
@@ -110,8 +109,7 @@ component_module_test_construct (ComponentModuleFixture *fixture,
 
 
 static void
-component_module_test_equals (ComponentModuleFixture *fixture,
-                              gconstpointer user_data)
+component_module_test_equals (void)
 {
   g_autoptr (ModulemdComponentModule) m_1 = NULL;
   g_autoptr (ModulemdComponentModule) m_2 = NULL;
@@ -233,8 +231,7 @@ component_module_test_equals (ComponentModuleFixture *fixture,
 
 
 static void
-component_module_test_copy (ComponentModuleFixture *fixture,
-                            gconstpointer user_data)
+component_module_test_copy (void)
 {
   g_autoptr (ModulemdComponentModule) m_orig = NULL;
   g_autoptr (ModulemdComponentModule) m = NULL;
@@ -283,8 +280,7 @@ component_module_test_copy (ComponentModuleFixture *fixture,
 
 
 static void
-component_module_test_emit_yaml (ComponentModuleFixture *fixture,
-                                 gconstpointer user_data)
+component_module_test_emit_yaml (void)
 {
   g_autoptr (ModulemdComponentModule) m = NULL;
   g_autoptr (GError) error = NULL;
@@ -339,8 +335,7 @@ component_module_test_emit_yaml (ComponentModuleFixture *fixture,
 
 
 static void
-component_module_test_parse_yaml (ComponentModuleFixture *fixture,
-                                  gconstpointer user_data)
+component_module_test_parse_yaml (void)
 {
   g_autoptr (ModulemdComponentModule) m = NULL;
   g_autoptr (GError) error = NULL;
@@ -393,40 +388,15 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add ("/modulemd/v2/component/module/construct",
-              ComponentModuleFixture,
-              NULL,
-              NULL,
-              component_module_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/module/construct",component_module_test_construct);
 
-  g_test_add ("/modulemd/v2/component/module/equals",
-              ComponentModuleFixture,
-              NULL,
-              NULL,
-              component_module_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/module/equals",component_module_test_equals);
 
-  g_test_add ("/modulemd/v2/component/module/copy",
-              ComponentModuleFixture,
-              NULL,
-              NULL,
-              component_module_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/module/copy",component_module_test_copy);
 
-  g_test_add ("/modulemd/v2/component/module/yaml/emit",
-              ComponentModuleFixture,
-              NULL,
-              NULL,
-              component_module_test_emit_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/module/yaml/emit",component_module_test_emit_yaml);
 
-  g_test_add ("/modulemd/v2/component/module/yaml/parse",
-              ComponentModuleFixture,
-              NULL,
-              NULL,
-              component_module_test_parse_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/module/yaml/parse",component_module_test_parse_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-component-module.c
+++ b/modulemd/tests/test-modulemd-component-module.c
@@ -388,15 +388,20 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add_func ("/modulemd/v2/component/module/construct",component_module_test_construct);
+  g_test_add_func ("/modulemd/v2/component/module/construct",
+                   component_module_test_construct);
 
-  g_test_add_func ("/modulemd/v2/component/module/equals",component_module_test_equals);
+  g_test_add_func ("/modulemd/v2/component/module/equals",
+                   component_module_test_equals);
 
-  g_test_add_func ("/modulemd/v2/component/module/copy",component_module_test_copy);
+  g_test_add_func ("/modulemd/v2/component/module/copy",
+                   component_module_test_copy);
 
-  g_test_add_func ("/modulemd/v2/component/module/yaml/emit",component_module_test_emit_yaml);
+  g_test_add_func ("/modulemd/v2/component/module/yaml/emit",
+                   component_module_test_emit_yaml);
 
-  g_test_add_func ("/modulemd/v2/component/module/yaml/parse",component_module_test_parse_yaml);
+  g_test_add_func ("/modulemd/v2/component/module/yaml/parse",
+                   component_module_test_parse_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-component-rpm.c
+++ b/modulemd/tests/test-modulemd-component-rpm.c
@@ -448,17 +448,22 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add_func ("/modulemd/v2/component/rpm/construct",component_rpm_test_construct);
+  g_test_add_func ("/modulemd/v2/component/rpm/construct",
+                   component_rpm_test_construct);
 
-  g_test_add_func ("/modulemd/v2/component/rpm/equals",component_rpm_test_equals);
+  g_test_add_func ("/modulemd/v2/component/rpm/equals",
+                   component_rpm_test_equals);
 
-  g_test_add_func ("/modulemd/v2/component/rpm/copy",component_rpm_test_copy);
+  g_test_add_func ("/modulemd/v2/component/rpm/copy", component_rpm_test_copy);
 
-  g_test_add_func ("/modulemd/v2/component/rpm/yaml/emit",component_rpm_test_emit_yaml);
+  g_test_add_func ("/modulemd/v2/component/rpm/yaml/emit",
+                   component_rpm_test_emit_yaml);
 
-  g_test_add_func ("/modulemd/v2/component/rpm/yaml/parse",component_rpm_test_parse_yaml);
+  g_test_add_func ("/modulemd/v2/component/rpm/yaml/parse",
+                   component_rpm_test_parse_yaml);
 
-  g_test_add_func ("/modulemd/v2/component/rpm/override_name",component_rpm_test_override_name);
+  g_test_add_func ("/modulemd/v2/component/rpm/override_name",
+                   component_rpm_test_override_name);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-component-rpm.c
+++ b/modulemd/tests/test-modulemd-component-rpm.c
@@ -30,8 +30,7 @@ typedef struct _ComponentRpmFixture
 
 
 static void
-component_rpm_test_construct (ComponentRpmFixture *fixture,
-                              gconstpointer user_data)
+component_rpm_test_construct (void)
 {
   g_autoptr (ModulemdComponentRpm) r = NULL;
   ModulemdComponent *mc = NULL;
@@ -84,8 +83,7 @@ component_rpm_test_construct (ComponentRpmFixture *fixture,
 
 
 static void
-component_rpm_test_equals (ComponentRpmFixture *fixture,
-                           gconstpointer user_data)
+component_rpm_test_equals (void)
 {
   g_autoptr (ModulemdComponentRpm) r_1 = NULL;
   g_autoptr (ModulemdComponentRpm) r_2 = NULL;
@@ -195,7 +193,7 @@ component_rpm_test_equals (ComponentRpmFixture *fixture,
 
 
 static void
-component_rpm_test_copy (ComponentRpmFixture *fixture, gconstpointer user_data)
+component_rpm_test_copy (void)
 {
   g_autoptr (ModulemdComponentRpm) r_orig = NULL;
   g_autoptr (ModulemdComponentRpm) r = NULL;
@@ -281,8 +279,7 @@ component_rpm_test_copy (ComponentRpmFixture *fixture, gconstpointer user_data)
 
 
 static void
-component_rpm_test_emit_yaml (ComponentRpmFixture *fixture,
-                              gconstpointer user_data)
+component_rpm_test_emit_yaml (void)
 {
   g_autoptr (ModulemdComponentRpm) r = NULL;
   g_autoptr (GError) error = NULL;
@@ -349,8 +346,7 @@ component_rpm_test_emit_yaml (ComponentRpmFixture *fixture,
 
 
 static void
-component_rpm_test_parse_yaml (ComponentRpmFixture *fixture,
-                               gconstpointer user_data)
+component_rpm_test_parse_yaml (void)
 {
   g_autoptr (ModulemdComponentRpm) r = NULL;
   g_autoptr (GError) error = NULL;
@@ -406,8 +402,7 @@ component_rpm_test_parse_yaml (ComponentRpmFixture *fixture,
 }
 
 static void
-component_rpm_test_override_name (ComponentRpmFixture *fixture,
-                                  gconstpointer user_data)
+component_rpm_test_override_name (void)
 {
   g_autoptr (ModulemdComponentRpm) r = NULL;
 
@@ -453,47 +448,17 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add ("/modulemd/v2/component/rpm/construct",
-              ComponentRpmFixture,
-              NULL,
-              NULL,
-              component_rpm_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/rpm/construct",component_rpm_test_construct);
 
-  g_test_add ("/modulemd/v2/component/rpm/equals",
-              ComponentRpmFixture,
-              NULL,
-              NULL,
-              component_rpm_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/rpm/equals",component_rpm_test_equals);
 
-  g_test_add ("/modulemd/v2/component/rpm/copy",
-              ComponentRpmFixture,
-              NULL,
-              NULL,
-              component_rpm_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/rpm/copy",component_rpm_test_copy);
 
-  g_test_add ("/modulemd/v2/component/rpm/yaml/emit",
-              ComponentRpmFixture,
-              NULL,
-              NULL,
-              component_rpm_test_emit_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/rpm/yaml/emit",component_rpm_test_emit_yaml);
 
-  g_test_add ("/modulemd/v2/component/rpm/yaml/parse",
-              ComponentRpmFixture,
-              NULL,
-              NULL,
-              component_rpm_test_parse_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/rpm/yaml/parse",component_rpm_test_parse_yaml);
 
-  g_test_add ("/modulemd/v2/component/rpm/override_name",
-              ComponentRpmFixture,
-              NULL,
-              NULL,
-              component_rpm_test_override_name,
-              NULL);
+  g_test_add_func ("/modulemd/v2/component/rpm/override_name",component_rpm_test_override_name);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-defaults-v1.c
+++ b/modulemd/tests/test-modulemd-defaults-v1.c
@@ -26,8 +26,7 @@
 
 
 static void
-defaults_test_construct (CommonMmdTestFixture *fixture,
-                         gconstpointer user_data)
+defaults_test_construct (void)
 {
   g_autoptr (ModulemdDefaultsV1) defaults = NULL;
 
@@ -80,7 +79,7 @@ defaults_test_construct (CommonMmdTestFixture *fixture,
 
 
 static void
-defaults_test_copy (CommonMmdTestFixture *fixture, gconstpointer user_data)
+defaults_test_copy (void)
 {
   g_autoptr (ModulemdDefaultsV1) defaults = NULL;
   g_autoptr (ModulemdDefaultsV1) copied_defaults = NULL;
@@ -148,8 +147,7 @@ defaults_test_copy (CommonMmdTestFixture *fixture, gconstpointer user_data)
 
 
 static void
-defaults_test_get_set_default_stream (CommonMmdTestFixture *fixture,
-                                      gconstpointer user_data)
+defaults_test_get_set_default_stream (void)
 {
   g_autoptr (ModulemdDefaultsV1) defaults = NULL;
 
@@ -168,7 +166,7 @@ defaults_test_get_set_default_stream (CommonMmdTestFixture *fixture,
 
 
 static void
-defaults_test_equals (CommonMmdTestFixture *fixture, gconstpointer user_data)
+defaults_test_equals (void)
 {
   g_autoptr (ModulemdDefaultsV1) defaults_1 = NULL;
   g_autoptr (ModulemdDefaultsV1) defaults_2 = NULL;
@@ -352,7 +350,7 @@ defaults_test_equals (CommonMmdTestFixture *fixture, gconstpointer user_data)
 
 
 static void
-defaults_test_validate (CommonMmdTestFixture *fixture, gconstpointer user_data)
+defaults_test_validate (void)
 {
   g_autoptr (ModulemdDefaultsV1) defaults = NULL;
 
@@ -368,7 +366,7 @@ defaults_test_validate (CommonMmdTestFixture *fixture, gconstpointer user_data)
 
 
 static void
-defaults_test_profiles (CommonMmdTestFixture *fixture, gconstpointer user_data)
+defaults_test_profiles (void)
 {
   g_autoptr (ModulemdDefaultsV1) defaults = NULL;
   g_auto (GStrv) streams = NULL;
@@ -457,8 +455,7 @@ defaults_test_profiles (CommonMmdTestFixture *fixture, gconstpointer user_data)
 
 
 static void
-defaults_test_parse_yaml (CommonMmdTestFixture *fixture,
-                          gconstpointer user_data)
+defaults_test_parse_yaml (void)
 {
   MMD_INIT_YAML_PARSER (parser);
   MMD_INIT_YAML_EVENT (event);
@@ -577,8 +574,7 @@ defaults_test_parse_yaml (CommonMmdTestFixture *fixture,
 
 
 static void
-defaults_test_emit_yaml (CommonMmdTestFixture *fixture,
-                         gconstpointer user_data)
+defaults_test_emit_yaml (void)
 {
   MMD_INIT_YAML_EMITTER (emitter);
   MMD_INIT_YAML_EVENT (event);
@@ -746,61 +742,21 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add ("/modulemd/v2/defaults/v1/equals",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/v1/equals",defaults_test_equals);
 
-  g_test_add ("/modulemd/v2/defaults/v1/construct",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/v1/construct",defaults_test_construct);
 
-  g_test_add ("/modulemd/v2/defaults/v1/copy",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/v1/copy",defaults_test_copy);
 
-  g_test_add ("/modulemd/v2/defaults/v1/default_stream",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_get_set_default_stream,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/v1/default_stream",defaults_test_get_set_default_stream);
 
-  g_test_add ("/modulemd/v2/defaults/v1/validate",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_validate,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/v1/validate",defaults_test_validate);
 
-  g_test_add ("/modulemd/v2/defaults/v1/profile_defaults",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_profiles,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/v1/profile_defaults",defaults_test_profiles);
 
-  g_test_add ("/modulemd/v2/defaults/v1/yaml/parse",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_parse_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/v1/yaml/parse",defaults_test_parse_yaml);
 
-  g_test_add ("/modulemd/v2/defaults/v1/yaml/emit",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_emit_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/v1/yaml/emit",defaults_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-defaults-v1.c
+++ b/modulemd/tests/test-modulemd-defaults-v1.c
@@ -742,21 +742,27 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add_func ("/modulemd/v2/defaults/v1/equals",defaults_test_equals);
+  g_test_add_func ("/modulemd/v2/defaults/v1/equals", defaults_test_equals);
 
-  g_test_add_func ("/modulemd/v2/defaults/v1/construct",defaults_test_construct);
+  g_test_add_func ("/modulemd/v2/defaults/v1/construct",
+                   defaults_test_construct);
 
-  g_test_add_func ("/modulemd/v2/defaults/v1/copy",defaults_test_copy);
+  g_test_add_func ("/modulemd/v2/defaults/v1/copy", defaults_test_copy);
 
-  g_test_add_func ("/modulemd/v2/defaults/v1/default_stream",defaults_test_get_set_default_stream);
+  g_test_add_func ("/modulemd/v2/defaults/v1/default_stream",
+                   defaults_test_get_set_default_stream);
 
-  g_test_add_func ("/modulemd/v2/defaults/v1/validate",defaults_test_validate);
+  g_test_add_func ("/modulemd/v2/defaults/v1/validate",
+                   defaults_test_validate);
 
-  g_test_add_func ("/modulemd/v2/defaults/v1/profile_defaults",defaults_test_profiles);
+  g_test_add_func ("/modulemd/v2/defaults/v1/profile_defaults",
+                   defaults_test_profiles);
 
-  g_test_add_func ("/modulemd/v2/defaults/v1/yaml/parse",defaults_test_parse_yaml);
+  g_test_add_func ("/modulemd/v2/defaults/v1/yaml/parse",
+                   defaults_test_parse_yaml);
 
-  g_test_add_func ("/modulemd/v2/defaults/v1/yaml/emit",defaults_test_emit_yaml);
+  g_test_add_func ("/modulemd/v2/defaults/v1/yaml/emit",
+                   defaults_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-defaults.c
+++ b/modulemd/tests/test-modulemd-defaults.c
@@ -24,8 +24,7 @@
 #include "private/test-utils.h"
 
 static void
-defaults_test_construct (CommonMmdTestFixture *fixture,
-                         gconstpointer user_data)
+defaults_test_construct (void)
 {
   g_autoptr (ModulemdDefaults) defaults = NULL;
 
@@ -63,7 +62,7 @@ defaults_test_construct (CommonMmdTestFixture *fixture,
 
 
 static void
-defaults_test_copy (CommonMmdTestFixture *fixture, gconstpointer user_data)
+defaults_test_copy (void)
 {
   g_autoptr (ModulemdDefaults) defaults = NULL;
   g_autoptr (ModulemdDefaults) copied_defaults = NULL;
@@ -88,8 +87,7 @@ defaults_test_copy (CommonMmdTestFixture *fixture, gconstpointer user_data)
 
 
 static void
-defaults_test_get_mdversion (CommonMmdTestFixture *fixture,
-                             gconstpointer user_data)
+defaults_test_get_mdversion (void)
 {
   g_autoptr (ModulemdDefaults) defaults = NULL;
   guint64 mdversion;
@@ -103,8 +101,7 @@ defaults_test_get_mdversion (CommonMmdTestFixture *fixture,
 
 
 static void
-defaults_test_get_module_name (CommonMmdTestFixture *fixture,
-                               gconstpointer user_data)
+defaults_test_get_module_name (void)
 {
   g_autoptr (ModulemdDefaults) defaults = NULL;
   const gchar *module_name;
@@ -118,7 +115,7 @@ defaults_test_get_module_name (CommonMmdTestFixture *fixture,
 
 
 static void
-defaults_test_validate (CommonMmdTestFixture *fixture, gconstpointer user_data)
+defaults_test_validate (void)
 {
   g_autoptr (ModulemdDefaults) defaults = NULL;
 
@@ -134,7 +131,7 @@ defaults_test_validate (CommonMmdTestFixture *fixture, gconstpointer user_data)
 
 
 static void
-defaults_test_equals (CommonMmdTestFixture *fixture, gconstpointer user_data)
+defaults_test_equals (void)
 {
   g_autoptr (ModulemdDefaults) defaults_1 = NULL;
   g_autoptr (ModulemdDefaults) defaults_2 = NULL;
@@ -164,7 +161,7 @@ defaults_test_equals (CommonMmdTestFixture *fixture, gconstpointer user_data)
 
 
 static void
-defaults_test_upgrade (CommonMmdTestFixture *fixture, gconstpointer user_data)
+defaults_test_upgrade (void)
 {
   g_autoptr (ModulemdDefaults) defaults = NULL;
   g_autoptr (ModulemdDefaults) upgraded_defaults = NULL;
@@ -206,54 +203,19 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add ("/modulemd/v2/defaults/construct",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/construct",defaults_test_construct);
 
-  g_test_add ("/modulemd/v2/defaults/copy",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/copy",defaults_test_copy);
 
-  g_test_add ("/modulemd/v2/defaults/mdversion",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_get_mdversion,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/mdversion",defaults_test_get_mdversion);
 
-  g_test_add ("/modulemd/v2/defaults/module_name",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_get_module_name,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/module_name",defaults_test_get_module_name);
 
-  g_test_add ("/modulemd/v2/defaults/validate",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_validate,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/validate",defaults_test_validate);
 
-  g_test_add ("/modulemd/v2/defaults/equals",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/equals",defaults_test_equals);
 
-  g_test_add ("/modulemd/v2/defaults/upgrade",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              defaults_test_upgrade,
-              NULL);
+  g_test_add_func ("/modulemd/v2/defaults/upgrade",defaults_test_upgrade);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-defaults.c
+++ b/modulemd/tests/test-modulemd-defaults.c
@@ -203,19 +203,21 @@ main (int argc, char *argv[])
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
   // Define the tests.
-  g_test_add_func ("/modulemd/v2/defaults/construct",defaults_test_construct);
+  g_test_add_func ("/modulemd/v2/defaults/construct", defaults_test_construct);
 
-  g_test_add_func ("/modulemd/v2/defaults/copy",defaults_test_copy);
+  g_test_add_func ("/modulemd/v2/defaults/copy", defaults_test_copy);
 
-  g_test_add_func ("/modulemd/v2/defaults/mdversion",defaults_test_get_mdversion);
+  g_test_add_func ("/modulemd/v2/defaults/mdversion",
+                   defaults_test_get_mdversion);
 
-  g_test_add_func ("/modulemd/v2/defaults/module_name",defaults_test_get_module_name);
+  g_test_add_func ("/modulemd/v2/defaults/module_name",
+                   defaults_test_get_module_name);
 
-  g_test_add_func ("/modulemd/v2/defaults/validate",defaults_test_validate);
+  g_test_add_func ("/modulemd/v2/defaults/validate", defaults_test_validate);
 
-  g_test_add_func ("/modulemd/v2/defaults/equals",defaults_test_equals);
+  g_test_add_func ("/modulemd/v2/defaults/equals", defaults_test_equals);
 
-  g_test_add_func ("/modulemd/v2/defaults/upgrade",defaults_test_upgrade);
+  g_test_add_func ("/modulemd/v2/defaults/upgrade", defaults_test_upgrade);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-dependencies.c
+++ b/modulemd/tests/test-modulemd-dependencies.c
@@ -592,19 +592,25 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add_func ("/modulemd/v2/dependencies/construct",dependencies_test_construct);
+  g_test_add_func ("/modulemd/v2/dependencies/construct",
+                   dependencies_test_construct);
 
-  g_test_add_func ("/modulemd/v2/dependencies/dependencies",dependencies_test_dependencies);
+  g_test_add_func ("/modulemd/v2/dependencies/dependencies",
+                   dependencies_test_dependencies);
 
-  g_test_add_func ("/modulemd/v2/dependencies/equals",dependencies_test_equals);
+  g_test_add_func ("/modulemd/v2/dependencies/equals",
+                   dependencies_test_equals);
 
-  g_test_add_func ("/modulemd/v2/dependencies/copy",dependencies_test_copy);
+  g_test_add_func ("/modulemd/v2/dependencies/copy", dependencies_test_copy);
 
-  g_test_add_func ("/modulemd/v2/dependencies/yaml/parse",dependencies_test_parse_yaml);
+  g_test_add_func ("/modulemd/v2/dependencies/yaml/parse",
+                   dependencies_test_parse_yaml);
 
-  g_test_add_func ("/modulemd/v2/dependencies/yaml/parse/bad",dependencies_test_parse_bad_yaml);
+  g_test_add_func ("/modulemd/v2/dependencies/yaml/parse/bad",
+                   dependencies_test_parse_bad_yaml);
 
-  g_test_add_func ("/modulemd/v2/dependencies/yaml/emit",dependencies_test_emit_yaml);
+  g_test_add_func ("/modulemd/v2/dependencies/yaml/emit",
+                   dependencies_test_emit_yaml);
 
   /*
   g_test_add_func ("/modulemd/v2/profile/copy",profile_test_copy);

--- a/modulemd/tests/test-modulemd-dependencies.c
+++ b/modulemd/tests/test-modulemd-dependencies.c
@@ -36,8 +36,7 @@ sigtrap_handler (int sig_num)
 }
 
 static void
-dependencies_test_construct (DependenciesFixture *fixture,
-                             gconstpointer user_data)
+dependencies_test_construct (void)
 {
   g_autoptr (ModulemdDependencies) d = NULL;
   g_auto (GStrv) list = NULL;
@@ -61,8 +60,7 @@ dependencies_test_construct (DependenciesFixture *fixture,
 
 
 static void
-dependencies_test_dependencies (DependenciesFixture *fixture,
-                                gconstpointer user_data)
+dependencies_test_dependencies (void)
 {
   g_autoptr (ModulemdDependencies) d = NULL;
   g_auto (GStrv) list = NULL;
@@ -133,8 +131,7 @@ dependencies_test_dependencies (DependenciesFixture *fixture,
 
 
 static void
-dependencies_test_equals (DependenciesFixture *fixture,
-                          gconstpointer user_data)
+dependencies_test_equals (void)
 {
   g_autoptr (ModulemdDependencies) d_1 = NULL;
   g_autoptr (ModulemdDependencies) d_2 = NULL;
@@ -301,7 +298,7 @@ dependencies_test_equals (DependenciesFixture *fixture,
 
 
 static void
-dependencies_test_copy (DependenciesFixture *fixture, gconstpointer user_data)
+dependencies_test_copy (void)
 {
   g_autoptr (ModulemdDependencies) d = NULL;
   g_autoptr (ModulemdDependencies) d_copy = NULL;
@@ -392,8 +389,7 @@ dependencies_test_copy (DependenciesFixture *fixture, gconstpointer user_data)
 }
 
 static void
-dependencies_test_parse_yaml (DependenciesFixture *fixture,
-                              gconstpointer user_data)
+dependencies_test_parse_yaml (void)
 {
   g_autoptr (ModulemdDependencies) d = NULL;
   g_autoptr (GError) error = NULL;
@@ -442,8 +438,7 @@ dependencies_test_parse_yaml (DependenciesFixture *fixture,
 
 
 static void
-dependencies_test_parse_bad_yaml (DependenciesFixture *fixture,
-                                  gconstpointer user_data)
+dependencies_test_parse_bad_yaml (void)
 {
   g_autoptr (ModulemdDependencies) d = NULL;
   g_autoptr (GError) error = NULL;
@@ -471,8 +466,7 @@ dependencies_test_parse_bad_yaml (DependenciesFixture *fixture,
 
 
 static void
-dependencies_test_emit_yaml (DependenciesFixture *fixture,
-                             gconstpointer user_data)
+dependencies_test_emit_yaml (void)
 {
   g_autoptr (ModulemdDependencies) d = NULL;
   g_autoptr (GError) error = NULL;
@@ -598,97 +592,32 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/dependencies/construct",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              dependencies_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/dependencies/construct",dependencies_test_construct);
 
-  g_test_add ("/modulemd/v2/dependencies/dependencies",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              dependencies_test_dependencies,
-              NULL);
+  g_test_add_func ("/modulemd/v2/dependencies/dependencies",dependencies_test_dependencies);
 
-  g_test_add ("/modulemd/v2/dependencies/equals",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              dependencies_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/dependencies/equals",dependencies_test_equals);
 
-  g_test_add ("/modulemd/v2/dependencies/copy",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              dependencies_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/dependencies/copy",dependencies_test_copy);
 
-  g_test_add ("/modulemd/v2/dependencies/yaml/parse",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              dependencies_test_parse_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/dependencies/yaml/parse",dependencies_test_parse_yaml);
 
-  g_test_add ("/modulemd/v2/dependencies/yaml/parse/bad",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              dependencies_test_parse_bad_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/dependencies/yaml/parse/bad",dependencies_test_parse_bad_yaml);
 
-  g_test_add ("/modulemd/v2/dependencies/yaml/emit",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              dependencies_test_emit_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/dependencies/yaml/emit",dependencies_test_emit_yaml);
 
   /*
-  g_test_add ("/modulemd/v2/profile/copy",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              profile_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/copy",profile_test_copy);
 
-  g_test_add ("/modulemd/v2/profile/get_name",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              profile_test_get_name,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/get_name",profile_test_get_name);
 
-  g_test_add ("/modulemd/v2/profile/get_set_description",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              profile_test_get_set_description,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/get_set_description",profile_test_get_set_description);
 
-  g_test_add ("/modulemd/v2/profile/rpms",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              profile_test_rpms,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/rpms",profile_test_rpms);
 
-  g_test_add ("/modulemd/v2/profile/yaml/parse",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              profile_test_parse_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/yaml/parse",profile_test_parse_yaml);
 
-  g_test_add ("/modulemd/v2/profile/yaml/emit",
-              DependenciesFixture,
-              NULL,
-              NULL,
-              profile_test_emit_yaml,
-              NULL);
+  g_test_add _func("/modulemd/v2/profile/yaml/emit",profile_test_emit_yaml);
               */
 
   return g_test_run ();

--- a/modulemd/tests/test-modulemd-merger.c
+++ b/modulemd/tests/test-modulemd-merger.c
@@ -246,9 +246,11 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add_func ("/modulemd/v2/module/index/merger/constructors",merger_test_constructors);
+  g_test_add_func ("/modulemd/v2/module/index/merger/constructors",
+                   merger_test_constructors);
 
-  g_test_add_func ("/modulemd/v2/module/index/merger/deduplicate",merger_test_deduplicate);
+  g_test_add_func ("/modulemd/v2/module/index/merger/deduplicate",
+                   merger_test_deduplicate);
 
   g_test_add_func ("/modulemd/module/index/merger/add_only",
                    merger_test_add_only);

--- a/modulemd/tests/test-modulemd-merger.c
+++ b/modulemd/tests/test-modulemd-merger.c
@@ -22,8 +22,7 @@
 
 
 static void
-merger_test_constructors (CommonMmdTestFixture *fixture,
-                          gconstpointer user_data)
+merger_test_constructors (void)
 {
   g_autoptr (ModulemdModuleIndexMerger) merger = NULL;
 
@@ -40,8 +39,7 @@ merger_test_constructors (CommonMmdTestFixture *fixture,
 
 
 static void
-merger_test_deduplicate (CommonMmdTestFixture *fixture,
-                         gconstpointer user_data)
+merger_test_deduplicate (void)
 {
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (ModulemdModuleIndex) index2 = NULL;
@@ -248,19 +246,9 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/module/index/merger/constructors",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              merger_test_constructors,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/merger/constructors",merger_test_constructors);
 
-  g_test_add ("/modulemd/v2/module/index/merger/deduplicate",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              merger_test_deduplicate,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/merger/deduplicate",merger_test_deduplicate);
 
   g_test_add_func ("/modulemd/module/index/merger/add_only",
                    merger_test_add_only);

--- a/modulemd/tests/test-modulemd-module.c
+++ b/modulemd/tests/test-modulemd-module.c
@@ -35,7 +35,7 @@ typedef struct _ModuleFixture
 
 
 static void
-module_test_construct (ModuleFixture *fixture, gconstpointer user_data)
+module_test_construct (void)
 {
   g_autoptr (ModulemdModule) m = NULL;
   g_autoptr (GPtrArray) list = NULL;
@@ -88,7 +88,7 @@ module_test_construct (ModuleFixture *fixture, gconstpointer user_data)
 
 
 static void
-module_test_defaults (ModuleFixture *fixture, gconstpointer user_data)
+module_test_defaults (void)
 {
   g_autoptr (ModulemdModule) m = NULL;
   g_autoptr (ModulemdDefaultsV1) d = NULL;
@@ -134,7 +134,7 @@ module_test_defaults (ModuleFixture *fixture, gconstpointer user_data)
 
 
 static void
-module_test_streams (ModuleFixture *fixture, gconstpointer user_data)
+module_test_streams (void)
 {
   g_autoptr (ModulemdModule) m = modulemd_module_new ("testmodule");
   g_autoptr (ModulemdTranslation) t = NULL;
@@ -330,7 +330,7 @@ module_test_streams (ModuleFixture *fixture, gconstpointer user_data)
 
 
 static void
-module_test_get_stream_names (ModuleFixture *fixture, gconstpointer user_data)
+module_test_get_stream_names (void)
 {
   g_autoptr (ModulemdModule) m = NULL;
   g_autoptr (ModulemdModuleStream) stream = NULL;
@@ -500,33 +500,13 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/module/construct",
-              ModuleFixture,
-              NULL,
-              NULL,
-              module_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/construct",module_test_construct);
 
-  g_test_add ("/modulemd/v2/module/defaults",
-              ModuleFixture,
-              NULL,
-              NULL,
-              module_test_defaults,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/defaults",module_test_defaults);
 
-  g_test_add ("/modulemd/v2/module/stream_names",
-              ModuleFixture,
-              NULL,
-              NULL,
-              module_test_get_stream_names,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/stream_names",module_test_get_stream_names);
 
-  g_test_add ("/modulemd/v2/module/streams",
-              ModuleFixture,
-              NULL,
-              NULL,
-              module_test_streams,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/streams",module_test_streams);
 
   g_test_add_func ("/modulemd/v2/module/streams/remove",
                    modulemd_test_remove_streams);

--- a/modulemd/tests/test-modulemd-module.c
+++ b/modulemd/tests/test-modulemd-module.c
@@ -500,13 +500,14 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add_func ("/modulemd/v2/module/construct",module_test_construct);
+  g_test_add_func ("/modulemd/v2/module/construct", module_test_construct);
 
-  g_test_add_func ("/modulemd/v2/module/defaults",module_test_defaults);
+  g_test_add_func ("/modulemd/v2/module/defaults", module_test_defaults);
 
-  g_test_add_func ("/modulemd/v2/module/stream_names",module_test_get_stream_names);
+  g_test_add_func ("/modulemd/v2/module/stream_names",
+                   module_test_get_stream_names);
 
-  g_test_add_func ("/modulemd/v2/module/streams",module_test_streams);
+  g_test_add_func ("/modulemd/v2/module/streams", module_test_streams);
 
   g_test_add_func ("/modulemd/v2/module/streams/remove",
                    modulemd_test_remove_streams);

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -1351,32 +1351,30 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add_func ("/modulemd/v2/module/index/dump",
-              module_index_test_dump);
+  g_test_add_func ("/modulemd/v2/module/index/dump", module_index_test_dump);
 
-  g_test_add_func ("/modulemd/v2/module/index/read",
-              module_index_test_read);
+  g_test_add_func ("/modulemd/v2/module/index/read", module_index_test_read);
 
   g_test_add_func ("/modulemd/v2/module/index/read/mixed",
-	      module_index_test_read_mixed);
+                   module_index_test_read_mixed);
 
   g_test_add_func ("/modulemd/v2/module/index/read/unknown",
-              module_index_test_read_unknown);
+                   module_index_test_read_unknown);
 
   g_test_add_func ("/modulemd/v2/module/index/upgrade/stream",
-              module_index_test_stream_upgrade);
+                   module_index_test_stream_upgrade);
 
   g_test_add_func ("/modulemd/v2/module/index/upgrade/index",
-              module_index_test_index_upgrade);
+                   module_index_test_index_upgrade);
 
   g_test_add_func ("/modulemd/v2/module/index/remove_module",
-              module_index_test_remove_module);
+                   module_index_test_remove_module);
 
   g_test_add_func ("/modulemd/v2/module/index/custom_read",
-              module_index_test_custom_read);
+                   module_index_test_custom_read);
 
   g_test_add_func ("/modulemd/v2/module/index/custom_write",
-              module_index_test_custom_write);
+                   module_index_test_custom_write);
 
   g_test_add_func ("/modulemd/v2/module/index/get_default_streams",
                    module_index_test_get_default_streams);

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -35,7 +35,7 @@ typedef struct _ModuleIndexFixture
 
 
 static void
-module_index_test_dump (ModuleIndexFixture *fixture, gconstpointer user_data)
+module_index_test_dump (void)
 {
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (ModulemdTranslation) translation = NULL;
@@ -164,7 +164,7 @@ module_index_test_dump (ModuleIndexFixture *fixture, gconstpointer user_data)
 
 
 static void
-module_index_test_read (ModuleIndexFixture *fixture, gconstpointer user_data)
+module_index_test_read (void)
 {
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (GError) error = NULL;
@@ -278,8 +278,7 @@ module_index_test_read (ModuleIndexFixture *fixture, gconstpointer user_data)
 
 
 static void
-module_index_test_read_mixed (ModuleIndexFixture *fixture,
-                              gconstpointer user_data)
+module_index_test_read_mixed (void)
 {
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autofree gchar *yaml_path = NULL;
@@ -306,8 +305,7 @@ module_index_test_read_mixed (ModuleIndexFixture *fixture,
 
 
 static void
-module_index_test_read_unknown (ModuleIndexFixture *fixture,
-                                gconstpointer user_data)
+module_index_test_read_unknown (void)
 {
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autofree gchar *yaml_path = NULL;
@@ -333,8 +331,7 @@ module_index_test_read_unknown (ModuleIndexFixture *fixture,
 
 
 static void
-module_index_test_stream_upgrade (ModuleIndexFixture *fixture,
-                                  gconstpointer user_data)
+module_index_test_stream_upgrade (void)
 {
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (ModulemdModuleStream) stream = NULL;
@@ -457,8 +454,7 @@ module_index_test_stream_upgrade (ModuleIndexFixture *fixture,
 
 
 static void
-module_index_test_index_upgrade (ModuleIndexFixture *fixture,
-                                 gconstpointer user_data)
+module_index_test_index_upgrade (void)
 {
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (ModulemdModuleStream) stream = NULL;
@@ -655,8 +651,7 @@ module_index_test_index_upgrade (ModuleIndexFixture *fixture,
 
 
 static void
-module_index_test_remove_module (ModuleIndexFixture *fixture,
-                                 gconstpointer user_data)
+module_index_test_remove_module (void)
 {
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autofree gchar *yaml_path = NULL;
@@ -725,8 +720,7 @@ custom_string_read_handler (void *data,
 
 
 static void
-module_index_test_custom_read (ModuleIndexFixture *fixture,
-                               gconstpointer user_data)
+module_index_test_custom_read (void)
 {
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -837,8 +831,7 @@ module_index_test_custom_read (ModuleIndexFixture *fixture,
 
 
 static void
-module_index_test_custom_write (ModuleIndexFixture *fixture,
-                                gconstpointer user_data)
+module_index_test_custom_write (void)
 {
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -1358,68 +1351,32 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/module/index/dump",
-              ModuleIndexFixture,
-              NULL,
-              NULL,
-              module_index_test_dump,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/dump",
+              module_index_test_dump);
 
-  g_test_add ("/modulemd/v2/module/index/read",
-              ModuleIndexFixture,
-              NULL,
-              NULL,
-              module_index_test_read,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/read",
+              module_index_test_read);
 
-  g_test_add ("/modulemd/v2/module/index/read/mixed",
-              ModuleIndexFixture,
-              NULL,
-              NULL,
-              module_index_test_read_mixed,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/read/mixed",
+	      module_index_test_read_mixed);
 
-  g_test_add ("/modulemd/v2/module/index/read/unknown",
-              ModuleIndexFixture,
-              NULL,
-              NULL,
-              module_index_test_read_unknown,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/read/unknown",
+              module_index_test_read_unknown);
 
-  g_test_add ("/modulemd/v2/module/index/upgrade/stream",
-              ModuleIndexFixture,
-              NULL,
-              NULL,
-              module_index_test_stream_upgrade,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/upgrade/stream",
+              module_index_test_stream_upgrade);
 
-  g_test_add ("/modulemd/v2/module/index/upgrade/index",
-              ModuleIndexFixture,
-              NULL,
-              NULL,
-              module_index_test_index_upgrade,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/upgrade/index",
+              module_index_test_index_upgrade);
 
-  g_test_add ("/modulemd/v2/module/index/remove_module",
-              ModuleIndexFixture,
-              NULL,
-              NULL,
-              module_index_test_remove_module,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/remove_module",
+              module_index_test_remove_module);
 
-  g_test_add ("/modulemd/v2/module/index/custom_read",
-              ModuleIndexFixture,
-              NULL,
-              NULL,
-              module_index_test_custom_read,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/custom_read",
+              module_index_test_custom_read);
 
-  g_test_add ("/modulemd/v2/module/index/custom_write",
-              ModuleIndexFixture,
-              NULL,
-              NULL,
-              module_index_test_custom_write,
-              NULL);
+  g_test_add_func ("/modulemd/v2/module/index/custom_write",
+              module_index_test_custom_write);
 
   g_test_add_func ("/modulemd/v2/module/index/get_default_streams",
                    module_index_test_get_default_streams);

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -29,8 +29,7 @@ typedef struct _ModuleStreamFixture
 
 
 static void
-module_stream_test_construct (ModuleStreamFixture *fixture,
-                              gconstpointer user_data)
+module_stream_test_construct (void)
 {
   g_autoptr (ModulemdModuleStream) stream = NULL;
   guint64 version;
@@ -94,7 +93,7 @@ module_stream_test_construct (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_test_arch (ModuleStreamFixture *fixture, gconstpointer user_data)
+module_stream_test_arch (void)
 {
   g_autoptr (ModulemdModuleStream) stream = NULL;
   guint64 version;
@@ -137,8 +136,7 @@ module_stream_test_arch (ModuleStreamFixture *fixture, gconstpointer user_data)
 
 
 static void
-module_stream_v1_test_licenses (ModuleStreamFixture *fixture,
-                                gconstpointer user_data)
+module_stream_v1_test_licenses (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
   g_auto (GStrv) licenses = NULL;
@@ -174,8 +172,7 @@ module_stream_v1_test_licenses (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v2_test_licenses (ModuleStreamFixture *fixture,
-                                gconstpointer user_data)
+module_stream_v2_test_licenses (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   g_auto (GStrv) licenses = NULL;
@@ -212,8 +209,7 @@ module_stream_v2_test_licenses (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v1_test_profiles (ModuleStreamFixture *fixture,
-                                gconstpointer user_data)
+module_stream_v1_test_profiles (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
   g_autoptr (ModulemdProfile) profile = NULL;
@@ -248,8 +244,7 @@ module_stream_v1_test_profiles (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v2_test_profiles (ModuleStreamFixture *fixture,
-                                gconstpointer user_data)
+module_stream_v2_test_profiles (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   g_autoptr (ModulemdProfile) profile = NULL;
@@ -284,8 +279,7 @@ module_stream_v2_test_profiles (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v1_test_rpm_api (ModuleStreamFixture *fixture,
-                               gconstpointer user_data)
+module_stream_v1_test_rpm_api (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
   g_auto (GStrv) rpm_apis = NULL;
@@ -312,8 +306,7 @@ module_stream_v1_test_rpm_api (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v2_test_rpm_api (ModuleStreamFixture *fixture,
-                               gconstpointer user_data)
+module_stream_v2_test_rpm_api (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   g_auto (GStrv) rpm_apis = NULL;
@@ -340,8 +333,7 @@ module_stream_v2_test_rpm_api (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v1_test_rpm_filters (ModuleStreamFixture *fixture,
-                                   gconstpointer user_data)
+module_stream_v1_test_rpm_filters (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
   g_auto (GStrv) filters = NULL;
@@ -376,8 +368,7 @@ module_stream_v1_test_rpm_filters (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v2_test_rpm_filters (ModuleStreamFixture *fixture,
-                                   gconstpointer user_data)
+module_stream_v2_test_rpm_filters (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   g_auto (GStrv) filters = NULL;
@@ -412,8 +403,7 @@ module_stream_v2_test_rpm_filters (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v1_test_rpm_artifacts (ModuleStreamFixture *fixture,
-                                     gconstpointer user_data)
+module_stream_v1_test_rpm_artifacts (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
   g_auto (GStrv) artifacts = NULL;
@@ -440,8 +430,7 @@ module_stream_v1_test_rpm_artifacts (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v2_test_rpm_artifacts (ModuleStreamFixture *fixture,
-                                     gconstpointer user_data)
+module_stream_v2_test_rpm_artifacts (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   g_auto (GStrv) artifacts = NULL;
@@ -467,8 +456,7 @@ module_stream_v2_test_rpm_artifacts (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v1_test_documentation (ModuleStreamFixture *fixture,
-                                     gconstpointer user_data)
+module_stream_v1_test_documentation (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
   const gchar *documentation = NULL;
@@ -530,8 +518,7 @@ module_stream_v1_test_documentation (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v2_test_documentation (ModuleStreamFixture *fixture,
-                                     gconstpointer user_data)
+module_stream_v2_test_documentation (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   const gchar *documentation = NULL;
@@ -592,8 +579,7 @@ module_stream_v2_test_documentation (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v1_test_tracker (ModuleStreamFixture *fixture,
-                               gconstpointer user_data)
+module_stream_v1_test_tracker (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
   g_autofree gchar *tracker_prop = NULL;
@@ -657,8 +643,7 @@ module_stream_v1_test_tracker (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v2_test_tracker (ModuleStreamFixture *fixture,
-                               gconstpointer user_data)
+module_stream_v2_test_tracker (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   g_autofree gchar *tracker_prop = NULL;
@@ -722,8 +707,7 @@ module_stream_v2_test_tracker (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v1_test_components (ModuleStreamFixture *fixture,
-                                  gconstpointer user_data)
+module_stream_v1_test_components (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
   g_autoptr (ModulemdComponentRpm) rpm_component = NULL;
@@ -795,8 +779,7 @@ module_stream_v1_test_components (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v2_test_components (ModuleStreamFixture *fixture,
-                                  gconstpointer user_data)
+module_stream_v2_test_components (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   g_autoptr (ModulemdComponentRpm) rpm_component = NULL;
@@ -867,7 +850,7 @@ module_stream_v2_test_components (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_test_copy (ModuleStreamFixture *fixture, gconstpointer user_data)
+module_stream_test_copy (void)
 {
   g_autoptr (ModulemdModuleStream) stream = NULL;
   g_autoptr (ModulemdModuleStream) copied_stream = NULL;
@@ -926,8 +909,7 @@ module_stream_test_copy (ModuleStreamFixture *fixture, gconstpointer user_data)
 
 
 static void
-module_stream_test_equals (ModuleStreamFixture *fixture,
-                           gconstpointer user_data)
+module_stream_test_equals (void)
 {
   g_autoptr (ModulemdModuleStream) stream_1 = NULL;
   g_autoptr (ModulemdModuleStream) stream_2 = NULL;
@@ -987,7 +969,7 @@ module_stream_test_equals (ModuleStreamFixture *fixture,
 
 G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 static void
-module_stream_test_nsvc (ModuleStreamFixture *fixture, gconstpointer user_data)
+module_stream_test_nsvc (void)
 {
   g_autoptr (ModulemdModuleStream) stream = NULL;
   g_autofree gchar *s_nsvc = NULL;
@@ -1036,8 +1018,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
 
 static void
-module_stream_test_nsvca (ModuleStreamFixture *fixture,
-                          gconstpointer user_data)
+module_stream_test_nsvca (void)
 {
   g_autoptr (ModulemdModuleStream) stream = NULL;
   g_autofree gchar *s_nsvca = NULL;
@@ -1116,8 +1097,7 @@ module_stream_test_nsvca (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v1_test_equals (ModuleStreamFixture *fixture,
-                              gconstpointer user_data)
+module_stream_v1_test_equals (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream_1 = NULL;
   g_autoptr (ModulemdModuleStreamV1) stream_2 = NULL;
@@ -1316,8 +1296,7 @@ module_stream_v1_test_equals (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v2_test_equals (ModuleStreamFixture *fixture,
-                              gconstpointer user_data)
+module_stream_v2_test_equals (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream_1 = NULL;
   g_autoptr (ModulemdModuleStreamV2) stream_2 = NULL;
@@ -1552,8 +1531,7 @@ module_stream_v2_test_equals (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v1_test_dependencies (ModuleStreamFixture *fixture,
-                                    gconstpointer user_data)
+module_stream_v1_test_dependencies (void)
 {
   g_auto (GStrv) list = NULL;
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
@@ -1584,8 +1562,7 @@ module_stream_v1_test_dependencies (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v2_test_dependencies (ModuleStreamFixture *fixture,
-                                    gconstpointer user_data)
+module_stream_v2_test_dependencies (void)
 {
   g_auto (GStrv) list = NULL;
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
@@ -1623,8 +1600,7 @@ module_stream_v2_test_dependencies (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v1_test_parse_dump (ModuleStreamFixture *fixture,
-                                  gconstpointer user_data)
+module_stream_v1_test_parse_dump (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
   g_autoptr (GError) error = NULL;
@@ -1793,8 +1769,7 @@ module_stream_v1_test_parse_dump (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v2_test_parse_dump (ModuleStreamFixture *fixture,
-                                  gconstpointer user_data)
+module_stream_v2_test_parse_dump (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   g_autoptr (GError) error = NULL;
@@ -1999,8 +1974,7 @@ module_stream_v2_test_parse_dump (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v1_test_depends_on_stream (ModuleStreamFixture *fixture,
-                                         gconstpointer user_data)
+module_stream_v1_test_depends_on_stream (void)
 {
   g_autoptr (ModulemdModuleStream) stream = NULL;
   g_autofree gchar *path = NULL;
@@ -2032,8 +2006,7 @@ module_stream_v1_test_depends_on_stream (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v2_test_depends_on_stream (ModuleStreamFixture *fixture,
-                                         gconstpointer user_data)
+module_stream_v2_test_depends_on_stream (void)
 {
   g_autoptr (ModulemdModuleStream) stream = NULL;
   g_autofree gchar *path = NULL;
@@ -2065,8 +2038,7 @@ module_stream_v2_test_depends_on_stream (ModuleStreamFixture *fixture,
 }
 
 static void
-module_stream_v2_test_validate_buildafter (ModuleStreamFixture *fixture,
-                                           gconstpointer user_data)
+module_stream_v2_test_validate_buildafter (void)
 {
   g_autoptr (ModulemdModuleStream) stream = NULL;
   g_autofree gchar *path = NULL;
@@ -2121,8 +2093,7 @@ module_stream_v2_test_validate_buildafter (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v2_test_validate_buildarches (ModuleStreamFixture *fixture,
-                                            gconstpointer user_data)
+module_stream_v2_test_validate_buildarches (void)
 {
   g_autoptr (ModulemdModuleStream) stream = NULL;
   g_autofree gchar *path = NULL;
@@ -2191,8 +2162,7 @@ module_stream_v2_test_validate_buildarches (ModuleStreamFixture *fixture,
 
 
 static void
-module_stream_v2_test_rpm_map (ModuleStreamFixture *fixture,
-                               gconstpointer user_data)
+module_stream_v2_test_rpm_map (void)
 {
   g_autoptr (ModulemdModuleStreamV2) stream = NULL;
   g_autoptr (ModulemdRpmMapEntry) entry = NULL;
@@ -2463,236 +2433,105 @@ main (int argc, char *argv[])
 
   // Define the tests.o
 
-  g_test_add ("/modulemd/v2/modulestream/construct",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/construct",
+              module_stream_test_construct);
 
-  g_test_add ("/modulemd/v2/modulestream/arch",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_test_arch,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/arch",
+              module_stream_test_arch);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/documentation",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_documentation,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/documentation",
+              module_stream_v1_test_documentation);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/documentation",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_documentation,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/documentation",
+              module_stream_v2_test_documentation);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/licenses",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_licenses,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/licenses",
+              module_stream_v1_test_licenses);
 
 
-  g_test_add ("/modulemd/v2/modulestream/v2/licenses",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_licenses,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/licenses",
+              module_stream_v2_test_licenses);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/tracker",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_tracker,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/tracker",
+              module_stream_v1_test_tracker);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/tracker",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_tracker,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/tracker",
+              module_stream_v2_test_tracker);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/profiles",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_profiles,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/profiles",
+              module_stream_v1_test_profiles);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/profiles",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_profiles,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/profiles",
+              module_stream_v2_test_profiles);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/rpm_api",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_rpm_api,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/rpm_api",
+              module_stream_v1_test_rpm_api);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/rpm_api",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_rpm_api,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/rpm_api",
+              module_stream_v2_test_rpm_api);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/rpm_filters",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_rpm_filters,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/rpm_filters",
+              module_stream_v1_test_rpm_filters);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/rpm_filters",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_rpm_filters,
-              NULL);
-  g_test_add ("/modulemd/v2/modulestream/v1/rpm_artifacts",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_rpm_artifacts,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/rpm_filters",
+              module_stream_v2_test_rpm_filters);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/rpm_artifacts",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_rpm_artifacts,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/rpm_artifacts",
+              module_stream_v1_test_rpm_artifacts);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/components",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_components,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/rpm_artifacts",
+              module_stream_v2_test_rpm_artifacts);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/components",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_components,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/components",
+              module_stream_v1_test_components);
 
-  g_test_add ("/modulemd/v2/modulestream/copy",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/components",
+              module_stream_v2_test_components);
 
-  g_test_add ("/modulemd/v2/modulestream/equals",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/copy",
+              module_stream_test_copy);
 
-  g_test_add ("/modulemd/v2/modulestream/nsvc",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_test_nsvc,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/equals",
+              module_stream_test_equals);
+
+  g_test_add_func ("/modulemd/v2/modulestream/nsvc",
+              module_stream_test_nsvc);
 
 
-  g_test_add ("/modulemd/v2/modulestream/nsvca",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_test_nsvca,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/nsvca",
+              module_stream_test_nsvca);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/equals",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/equals",
+              module_stream_v1_test_equals);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/equals",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/equals",
+		module_stream_v2_test_equals);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/dependencies",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_dependencies,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/dependencies",
+              module_stream_v1_test_dependencies);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/dependencies",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_dependencies,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/dependencies",
+              module_stream_v2_test_dependencies);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/parse_dump",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_parse_dump,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/parse_dump",
+              module_stream_v1_test_parse_dump);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/parse_dump",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_parse_dump,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/parse_dump",
+              module_stream_v2_test_parse_dump);
 
-  g_test_add ("/modulemd/v2/modulestream/v1/depends_on_stream",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v1_test_depends_on_stream,
-              NULL);
-  g_test_add ("/modulemd/v2/modulestream/v2/depends_on_stream",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_depends_on_stream,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v1/depends_on_stream",
+              module_stream_v1_test_depends_on_stream);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/depends_on_stream",
+              module_stream_v2_test_depends_on_stream);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/validate/buildafter",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_validate_buildafter,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/validate/buildafter",
+              module_stream_v2_test_validate_buildafter);
 
-  g_test_add ("/modulemd/v2/modulestream/v2/validate/buildarches",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_validate_buildarches,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/validate/buildarches",
+              module_stream_v2_test_validate_buildarches) ;
 
-  g_test_add ("/modulemd/v2/modulestream/v2/rpm_map",
-              ModuleStreamFixture,
-              NULL,
-              NULL,
-              module_stream_v2_test_rpm_map,
-              NULL);
+  g_test_add_func ("/modulemd/v2/modulestream/v2/rpm_map",
+              module_stream_v2_test_rpm_map);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/community",
                    module_stream_v1_test_community);

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -2434,104 +2434,101 @@ main (int argc, char *argv[])
   // Define the tests.o
 
   g_test_add_func ("/modulemd/v2/modulestream/construct",
-              module_stream_test_construct);
+                   module_stream_test_construct);
 
-  g_test_add_func ("/modulemd/v2/modulestream/arch",
-              module_stream_test_arch);
+  g_test_add_func ("/modulemd/v2/modulestream/arch", module_stream_test_arch);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/documentation",
-              module_stream_v1_test_documentation);
+                   module_stream_v1_test_documentation);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/documentation",
-              module_stream_v2_test_documentation);
+                   module_stream_v2_test_documentation);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/licenses",
-              module_stream_v1_test_licenses);
+                   module_stream_v1_test_licenses);
 
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/licenses",
-              module_stream_v2_test_licenses);
+                   module_stream_v2_test_licenses);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/tracker",
-              module_stream_v1_test_tracker);
+                   module_stream_v1_test_tracker);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/tracker",
-              module_stream_v2_test_tracker);
+                   module_stream_v2_test_tracker);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/profiles",
-              module_stream_v1_test_profiles);
+                   module_stream_v1_test_profiles);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/profiles",
-              module_stream_v2_test_profiles);
+                   module_stream_v2_test_profiles);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/rpm_api",
-              module_stream_v1_test_rpm_api);
+                   module_stream_v1_test_rpm_api);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/rpm_api",
-              module_stream_v2_test_rpm_api);
+                   module_stream_v2_test_rpm_api);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/rpm_filters",
-              module_stream_v1_test_rpm_filters);
+                   module_stream_v1_test_rpm_filters);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/rpm_filters",
-              module_stream_v2_test_rpm_filters);
+                   module_stream_v2_test_rpm_filters);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/rpm_artifacts",
-              module_stream_v1_test_rpm_artifacts);
+                   module_stream_v1_test_rpm_artifacts);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/rpm_artifacts",
-              module_stream_v2_test_rpm_artifacts);
+                   module_stream_v2_test_rpm_artifacts);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/components",
-              module_stream_v1_test_components);
+                   module_stream_v1_test_components);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/components",
-              module_stream_v2_test_components);
+                   module_stream_v2_test_components);
 
-  g_test_add_func ("/modulemd/v2/modulestream/copy",
-              module_stream_test_copy);
+  g_test_add_func ("/modulemd/v2/modulestream/copy", module_stream_test_copy);
 
   g_test_add_func ("/modulemd/v2/modulestream/equals",
-              module_stream_test_equals);
+                   module_stream_test_equals);
 
-  g_test_add_func ("/modulemd/v2/modulestream/nsvc",
-              module_stream_test_nsvc);
+  g_test_add_func ("/modulemd/v2/modulestream/nsvc", module_stream_test_nsvc);
 
 
   g_test_add_func ("/modulemd/v2/modulestream/nsvca",
-              module_stream_test_nsvca);
+                   module_stream_test_nsvca);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/equals",
-              module_stream_v1_test_equals);
+                   module_stream_v1_test_equals);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/equals",
-		module_stream_v2_test_equals);
+                   module_stream_v2_test_equals);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/dependencies",
-              module_stream_v1_test_dependencies);
+                   module_stream_v1_test_dependencies);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/dependencies",
-              module_stream_v2_test_dependencies);
+                   module_stream_v2_test_dependencies);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/parse_dump",
-              module_stream_v1_test_parse_dump);
+                   module_stream_v1_test_parse_dump);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/parse_dump",
-              module_stream_v2_test_parse_dump);
+                   module_stream_v2_test_parse_dump);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/depends_on_stream",
-              module_stream_v1_test_depends_on_stream);
+                   module_stream_v1_test_depends_on_stream);
   g_test_add_func ("/modulemd/v2/modulestream/v2/depends_on_stream",
-              module_stream_v2_test_depends_on_stream);
+                   module_stream_v2_test_depends_on_stream);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/validate/buildafter",
-              module_stream_v2_test_validate_buildafter);
+                   module_stream_v2_test_validate_buildafter);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/validate/buildarches",
-              module_stream_v2_test_validate_buildarches) ;
+                   module_stream_v2_test_validate_buildarches);
 
   g_test_add_func ("/modulemd/v2/modulestream/v2/rpm_map",
-              module_stream_v2_test_rpm_map);
+                   module_stream_v2_test_rpm_map);
 
   g_test_add_func ("/modulemd/v2/modulestream/v1/community",
                    module_stream_v1_test_community);

--- a/modulemd/tests/test-modulemd-profile.c
+++ b/modulemd/tests/test-modulemd-profile.c
@@ -489,29 +489,22 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add_func ("/modulemd/v2/profile/construct",
-              profile_test_construct);
+  g_test_add_func ("/modulemd/v2/profile/construct", profile_test_construct);
 
-  g_test_add_func ("/modulemd/v2/profile/equals",
-              profile_test_equals);
+  g_test_add_func ("/modulemd/v2/profile/equals", profile_test_equals);
 
-  g_test_add_func ("/modulemd/v2/profile/copy",
-              profile_test_copy);
+  g_test_add_func ("/modulemd/v2/profile/copy", profile_test_copy);
 
-  g_test_add_func ("/modulemd/v2/profile/get_name",
-              profile_test_get_name);
+  g_test_add_func ("/modulemd/v2/profile/get_name", profile_test_get_name);
 
   g_test_add_func ("/modulemd/v2/profile/get_set_description",
-              profile_test_get_set_description);
+                   profile_test_get_set_description);
 
-  g_test_add_func ("/modulemd/v2/profile/rpms",
-              profile_test_rpms);
+  g_test_add_func ("/modulemd/v2/profile/rpms", profile_test_rpms);
 
-  g_test_add_func ("/modulemd/v2/profile/yaml/parse",
-              profile_test_parse_yaml);
+  g_test_add_func ("/modulemd/v2/profile/yaml/parse", profile_test_parse_yaml);
 
-  g_test_add_func ("/modulemd/v2/profile/yaml/emit",
-              profile_test_emit_yaml);
+  g_test_add_func ("/modulemd/v2/profile/yaml/emit", profile_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-profile.c
+++ b/modulemd/tests/test-modulemd-profile.c
@@ -35,7 +35,7 @@ sigtrap_handler (int sig_num)
 }
 
 static void
-profile_test_construct (ProfileFixture *fixture, gconstpointer user_data)
+profile_test_construct (void)
 {
   g_autoptr (ModulemdProfile) p = NULL;
   g_auto (GStrv) rpms;
@@ -81,7 +81,7 @@ profile_test_construct (ProfileFixture *fixture, gconstpointer user_data)
 
 
 static void
-profile_test_equals (ProfileFixture *fixture, gconstpointer user_data)
+profile_test_equals (void)
 {
   g_autoptr (ModulemdProfile) p_1 = NULL;
   g_autoptr (ModulemdProfile) p_2 = NULL;
@@ -226,7 +226,7 @@ profile_test_equals (ProfileFixture *fixture, gconstpointer user_data)
 
 
 static void
-profile_test_copy (ProfileFixture *fixture, gconstpointer user_data)
+profile_test_copy (void)
 {
   g_autoptr (ModulemdProfile) p = NULL;
   g_autoptr (ModulemdProfile) p_copy = NULL;
@@ -308,7 +308,7 @@ profile_test_copy (ProfileFixture *fixture, gconstpointer user_data)
 
 
 static void
-profile_test_get_name (ProfileFixture *fixture, gconstpointer user_data)
+profile_test_get_name (void)
 {
   g_autoptr (ModulemdProfile) p = NULL;
   g_autofree gchar *name;
@@ -331,8 +331,7 @@ profile_test_get_name (ProfileFixture *fixture, gconstpointer user_data)
 
 
 static void
-profile_test_get_set_description (ProfileFixture *fixture,
-                                  gconstpointer user_data)
+profile_test_get_set_description (void)
 {
   g_autoptr (ModulemdProfile) p = NULL;
 
@@ -353,7 +352,7 @@ profile_test_get_set_description (ProfileFixture *fixture,
 }
 
 static void
-profile_test_rpms (ProfileFixture *fixture, gconstpointer user_data)
+profile_test_rpms (void)
 {
   g_autoptr (ModulemdProfile) p = NULL;
   g_auto (GStrv) rpms = NULL;
@@ -391,7 +390,7 @@ profile_test_rpms (ProfileFixture *fixture, gconstpointer user_data)
 
 
 static void
-profile_test_parse_yaml (ProfileFixture *fixture, gconstpointer user_data)
+profile_test_parse_yaml (void)
 {
   g_autoptr (ModulemdProfile) p = NULL;
   g_autoptr (GError) error = NULL;
@@ -431,7 +430,7 @@ profile_test_parse_yaml (ProfileFixture *fixture, gconstpointer user_data)
 
 
 static void
-profile_test_emit_yaml (ProfileFixture *fixture, gconstpointer user_data)
+profile_test_emit_yaml (void)
 {
   g_autoptr (ModulemdProfile) p = NULL;
   g_autoptr (GError) error = NULL;
@@ -490,61 +489,29 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/profile/construct",
-              ProfileFixture,
-              NULL,
-              NULL,
-              profile_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/construct",
+              profile_test_construct);
 
-  g_test_add ("/modulemd/v2/profile/equals",
-              ProfileFixture,
-              NULL,
-              NULL,
-              profile_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/equals",
+              profile_test_equals);
 
-  g_test_add ("/modulemd/v2/profile/copy",
-              ProfileFixture,
-              NULL,
-              NULL,
-              profile_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/copy",
+              profile_test_copy);
 
-  g_test_add ("/modulemd/v2/profile/get_name",
-              ProfileFixture,
-              NULL,
-              NULL,
-              profile_test_get_name,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/get_name",
+              profile_test_get_name);
 
-  g_test_add ("/modulemd/v2/profile/get_set_description",
-              ProfileFixture,
-              NULL,
-              NULL,
-              profile_test_get_set_description,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/get_set_description",
+              profile_test_get_set_description);
 
-  g_test_add ("/modulemd/v2/profile/rpms",
-              ProfileFixture,
-              NULL,
-              NULL,
-              profile_test_rpms,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/rpms",
+              profile_test_rpms);
 
-  g_test_add ("/modulemd/v2/profile/yaml/parse",
-              ProfileFixture,
-              NULL,
-              NULL,
-              profile_test_parse_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/yaml/parse",
+              profile_test_parse_yaml);
 
-  g_test_add ("/modulemd/v2/profile/yaml/emit",
-              ProfileFixture,
-              NULL,
-              NULL,
-              profile_test_emit_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/profile/yaml/emit",
+              profile_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-rpmmap.c
+++ b/modulemd/tests/test-modulemd-rpmmap.c
@@ -271,26 +271,24 @@ main (int argc, char *argv[])
   g_test_init (&argc, &argv, NULL);
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
-  g_test_add_func ("/modulemd/v2/rpm_map/basic",
-              test_basic);
+  g_test_add_func ("/modulemd/v2/rpm_map/basic", test_basic);
 
-  g_test_add_func ("/modulemd/v2/rpm_map/compare",
-              test_compare);
+  g_test_add_func ("/modulemd/v2/rpm_map/compare", test_compare);
 
   g_test_add_func ("/modulemd/v2/rpm_map/yaml/parse/valid",
-              test_parse_yaml_valid);
+                   test_parse_yaml_valid);
 
   g_test_add_func ("/modulemd/v2/rpm_map/yaml/parse/missing",
-              test_parse_yaml_missing);
+                   test_parse_yaml_missing);
 
   g_test_add_func ("/modulemd/v2/rpm_map/yaml/parse/mismatch",
-              test_parse_yaml_mismatch);
+                   test_parse_yaml_mismatch);
 
   g_test_add_func ("/modulemd/v2/rpm_map/yaml/emit/valid",
-              test_emit_yaml_valid);
+                   test_emit_yaml_valid);
 
   g_test_add_func ("/modulemd/v2/rpm_map/yaml/emit/invalid",
-              test_emit_yaml_invalid);
+                   test_emit_yaml_invalid);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-rpmmap.c
+++ b/modulemd/tests/test-modulemd-rpmmap.c
@@ -23,7 +23,7 @@
 #include "private/test-utils.h"
 
 static void
-test_basic (CommonMmdTestFixture *fixture, gconstpointer user_data)
+test_basic (void)
 {
   g_autoptr (ModulemdRpmMapEntry) entry = NULL;
   g_autoptr (GError) error = NULL;
@@ -93,7 +93,7 @@ test_basic (CommonMmdTestFixture *fixture, gconstpointer user_data)
 
 
 static void
-test_compare (CommonMmdTestFixture *fixture, gconstpointer user_data)
+test_compare (void)
 {
   g_autoptr (ModulemdRpmMapEntry) entry = NULL;
   ModulemdRpmMapEntry *entry_pointer;
@@ -125,7 +125,7 @@ test_compare (CommonMmdTestFixture *fixture, gconstpointer user_data)
 
 
 static void
-test_parse_yaml_valid (CommonMmdTestFixture *fixture, gconstpointer user_data)
+test_parse_yaml_valid (void)
 {
   g_autoptr (ModulemdRpmMapEntry) entry = NULL;
   g_autoptr (GError) error = NULL;
@@ -155,8 +155,7 @@ test_parse_yaml_valid (CommonMmdTestFixture *fixture, gconstpointer user_data)
 }
 
 static void
-test_parse_yaml_missing (CommonMmdTestFixture *fixture,
-                         gconstpointer user_data)
+test_parse_yaml_missing (void)
 {
   g_autoptr (ModulemdRpmMapEntry) entry = NULL;
   g_autoptr (GError) error = NULL;
@@ -182,8 +181,7 @@ test_parse_yaml_missing (CommonMmdTestFixture *fixture,
 }
 
 static void
-test_parse_yaml_mismatch (CommonMmdTestFixture *fixture,
-                          gconstpointer user_data)
+test_parse_yaml_mismatch (void)
 {
   g_autoptr (ModulemdRpmMapEntry) entry = NULL;
   g_autoptr (GError) error = NULL;
@@ -210,7 +208,7 @@ test_parse_yaml_mismatch (CommonMmdTestFixture *fixture,
 }
 
 static void
-test_emit_yaml_valid (CommonMmdTestFixture *fixture, gconstpointer user_data)
+test_emit_yaml_valid (void)
 {
   g_autoptr (ModulemdRpmMapEntry) entry = NULL;
   g_autoptr (GError) error = NULL;
@@ -248,7 +246,7 @@ test_emit_yaml_valid (CommonMmdTestFixture *fixture, gconstpointer user_data)
 
 
 static void
-test_emit_yaml_invalid (CommonMmdTestFixture *fixture, gconstpointer user_data)
+test_emit_yaml_invalid (void)
 {
   g_autoptr (ModulemdRpmMapEntry) entry = NULL;
   g_autoptr (GError) error = NULL;
@@ -265,7 +263,6 @@ test_emit_yaml_invalid (CommonMmdTestFixture *fixture, gconstpointer user_data)
   g_assert_error (error, MODULEMD_ERROR, MODULEMD_ERROR_VALIDATE);
 }
 
-
 int
 main (int argc, char *argv[])
 {
@@ -274,54 +271,26 @@ main (int argc, char *argv[])
   g_test_init (&argc, &argv, NULL);
   g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
 
-  g_test_add ("/modulemd/v2/rpm_map/basic",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              test_basic,
-              NULL);
+  g_test_add_func ("/modulemd/v2/rpm_map/basic",
+              test_basic);
 
-  g_test_add ("/modulemd/v2/rpm_map/compare",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              test_compare,
-              NULL);
+  g_test_add_func ("/modulemd/v2/rpm_map/compare",
+              test_compare);
 
-  g_test_add ("/modulemd/v2/rpm_map/yaml/parse/valid",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              test_parse_yaml_valid,
-              NULL);
+  g_test_add_func ("/modulemd/v2/rpm_map/yaml/parse/valid",
+              test_parse_yaml_valid);
 
-  g_test_add ("/modulemd/v2/rpm_map/yaml/parse/missing",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              test_parse_yaml_missing,
-              NULL);
+  g_test_add_func ("/modulemd/v2/rpm_map/yaml/parse/missing",
+              test_parse_yaml_missing);
 
-  g_test_add ("/modulemd/v2/rpm_map/yaml/parse/mismatch",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              test_parse_yaml_mismatch,
-              NULL);
+  g_test_add_func ("/modulemd/v2/rpm_map/yaml/parse/mismatch",
+              test_parse_yaml_mismatch);
 
-  g_test_add ("/modulemd/v2/rpm_map/yaml/emit/valid",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              test_emit_yaml_valid,
-              NULL);
+  g_test_add_func ("/modulemd/v2/rpm_map/yaml/emit/valid",
+              test_emit_yaml_valid);
 
-  g_test_add ("/modulemd/v2/rpm_map/yaml/emit/invalid",
-              CommonMmdTestFixture,
-              NULL,
-              NULL,
-              test_emit_yaml_invalid,
-              NULL);
+  g_test_add_func ("/modulemd/v2/rpm_map/yaml/emit/invalid",
+              test_emit_yaml_invalid);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-service-level.c
+++ b/modulemd/tests/test-modulemd-service-level.c
@@ -35,8 +35,7 @@ sigtrap_handler (int sig_num)
 }
 
 static void
-service_level_test_construct (ServiceLevelFixture *fixture,
-                              gconstpointer user_data)
+service_level_test_construct (void)
 {
   g_autoptr (ModulemdServiceLevel) sl = NULL;
 
@@ -92,8 +91,7 @@ service_level_test_construct (ServiceLevelFixture *fixture,
 
 
 static void
-service_level_test_equals (ServiceLevelFixture *fixture,
-                           gconstpointer user_data)
+service_level_test_equals (void)
 {
   g_autoptr (ModulemdServiceLevel) sl_1 = NULL;
   g_autoptr (ModulemdServiceLevel) sl_2 = NULL;
@@ -196,7 +194,7 @@ service_level_test_equals (ServiceLevelFixture *fixture,
 
 
 static void
-service_level_test_copy (ServiceLevelFixture *fixture, gconstpointer user_data)
+service_level_test_copy (void)
 {
   g_autoptr (ModulemdServiceLevel) sl = NULL;
   g_autoptr (ModulemdServiceLevel) sl_copy = NULL;
@@ -230,8 +228,7 @@ service_level_test_copy (ServiceLevelFixture *fixture, gconstpointer user_data)
 
 
 static void
-service_level_test_get_name (ServiceLevelFixture *fixture,
-                             gconstpointer user_data)
+service_level_test_get_name (void)
 {
   g_autoptr (ModulemdServiceLevel) sl = NULL;
   g_autofree gchar *name = NULL;
@@ -270,8 +267,7 @@ service_level_test_get_name (ServiceLevelFixture *fixture,
 
 
 static void
-service_level_test_get_set_eol (ServiceLevelFixture *fixture,
-                                gconstpointer user_data)
+service_level_test_get_set_eol (void)
 {
   g_autoptr (ModulemdServiceLevel) sl = NULL;
   g_autoptr (GDate) eol = NULL;
@@ -345,8 +341,7 @@ service_level_test_get_set_eol (ServiceLevelFixture *fixture,
 }
 
 static void
-service_level_test_parse_yaml (ServiceLevelFixture *fixture,
-                               gconstpointer user_data)
+service_level_test_parse_yaml (void)
 {
   g_autoptr (ModulemdServiceLevel) sl = NULL;
   g_autoptr (GError) error = NULL;
@@ -386,8 +381,7 @@ service_level_test_parse_yaml (ServiceLevelFixture *fixture,
 
 
 static void
-service_level_test_emit_yaml (ServiceLevelFixture *fixture,
-                              gconstpointer user_data)
+service_level_test_emit_yaml (void)
 {
   g_autoptr (ModulemdServiceLevel) sl = NULL;
   g_autoptr (GError) error = NULL;
@@ -453,54 +447,26 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/servicelevel/construct",
-              ServiceLevelFixture,
-              NULL,
-              NULL,
-              service_level_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/servicelevel/construct",
+              service_level_test_construct);
 
-  g_test_add ("/modulemd/v2/servicelevel/get_set_name",
-              ServiceLevelFixture,
-              NULL,
-              NULL,
-              service_level_test_get_name,
-              NULL);
+  g_test_add_func ("/modulemd/v2/servicelevel/get_set_name",
+              service_level_test_get_name);
 
-  g_test_add ("/modulemd/v2/servicelevel/equals",
-              ServiceLevelFixture,
-              NULL,
-              NULL,
-              service_level_test_equals,
-              NULL);
+  g_test_add_func ("/modulemd/v2/servicelevel/equals",
+              service_level_test_equals);
 
-  g_test_add ("/modulemd/v2/servicelevel/copy",
-              ServiceLevelFixture,
-              NULL,
-              NULL,
-              service_level_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/servicelevel/copy",
+              service_level_test_copy);
 
-  g_test_add ("/modulemd/v2/servicelevel/get_set_eol",
-              ServiceLevelFixture,
-              NULL,
-              NULL,
-              service_level_test_get_set_eol,
-              NULL);
+  g_test_add_func ("/modulemd/v2/servicelevel/get_set_eol",
+              service_level_test_get_set_eol);
 
-  g_test_add ("/modulemd/v2/servicelevel/yaml/parse",
-              ServiceLevelFixture,
-              NULL,
-              NULL,
-              service_level_test_parse_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/servicelevel/yaml/parse",
+              service_level_test_parse_yaml);
 
-  g_test_add ("/modulemd/v2/servicelevel/yaml/emit",
-              ServiceLevelFixture,
-              NULL,
-              NULL,
-              service_level_test_emit_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/servicelevel/yaml/emit",
+              service_level_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-service-level.c
+++ b/modulemd/tests/test-modulemd-service-level.c
@@ -448,25 +448,24 @@ main (int argc, char *argv[])
   // Define the tests.
 
   g_test_add_func ("/modulemd/v2/servicelevel/construct",
-              service_level_test_construct);
+                   service_level_test_construct);
 
   g_test_add_func ("/modulemd/v2/servicelevel/get_set_name",
-              service_level_test_get_name);
+                   service_level_test_get_name);
 
   g_test_add_func ("/modulemd/v2/servicelevel/equals",
-              service_level_test_equals);
+                   service_level_test_equals);
 
-  g_test_add_func ("/modulemd/v2/servicelevel/copy",
-              service_level_test_copy);
+  g_test_add_func ("/modulemd/v2/servicelevel/copy", service_level_test_copy);
 
   g_test_add_func ("/modulemd/v2/servicelevel/get_set_eol",
-              service_level_test_get_set_eol);
+                   service_level_test_get_set_eol);
 
   g_test_add_func ("/modulemd/v2/servicelevel/yaml/parse",
-              service_level_test_parse_yaml);
+                   service_level_test_parse_yaml);
 
   g_test_add_func ("/modulemd/v2/servicelevel/yaml/emit",
-              service_level_test_emit_yaml);
+                   service_level_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-translation-entry.c
+++ b/modulemd/tests/test-modulemd-translation-entry.c
@@ -577,28 +577,28 @@ main (int argc, char *argv[])
   // Define the tests.
 
   g_test_add_func ("/modulemd/v2/translationentry/construct",
-              translation_entry_test_construct);
+                   translation_entry_test_construct);
 
   g_test_add_func ("/modulemd/v2/translationentry/copy",
-              translation_entry_test_copy);
+                   translation_entry_test_copy);
 
   g_test_add_func ("/modulemd/v2/translationentry/get_locale",
-              translation_entry_test_get_locale);
+                   translation_entry_test_get_locale);
 
   g_test_add_func ("/modulemd/v2/translationentry/get_set_summary",
-              translation_entry_test_get_set_summary);
+                   translation_entry_test_get_set_summary);
 
   g_test_add_func ("/modulemd/v2/translationentry/get_set_description",
-              translation_entry_test_get_set_description);
+                   translation_entry_test_get_set_description);
 
   g_test_add_func ("/modulemd/v2/translationentry/profile_descriptions",
-              translation_entry_test_profile_descriptions);
+                   translation_entry_test_profile_descriptions);
 
   g_test_add_func ("/modulemd/v2/translationentry/yaml/parse",
-              translation_entry_test_parse_yaml);
+                   translation_entry_test_parse_yaml);
 
   g_test_add_func ("/modulemd/v2/translationentry/yaml/emit",
-              translation_entry_test_emit_yaml);
+                   translation_entry_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-translation-entry.c
+++ b/modulemd/tests/test-modulemd-translation-entry.c
@@ -35,8 +35,7 @@ sigtrap_handler (int sig_num)
 }
 
 static void
-translation_entry_test_construct (TranslationEntryFixture *fixture,
-                                  gconstpointer user_data)
+translation_entry_test_construct (void)
 {
   g_autoptr (ModulemdTranslationEntry) te = NULL;
   g_auto (GStrv) profile_names;
@@ -143,8 +142,7 @@ translation_entry_test_construct (TranslationEntryFixture *fixture,
 
 
 static void
-translation_entry_test_copy (TranslationEntryFixture *fixture,
-                             gconstpointer user_data)
+translation_entry_test_copy (void)
 {
   g_autoptr (ModulemdTranslationEntry) te = NULL;
   g_autoptr (ModulemdTranslationEntry) te_copy = NULL;
@@ -323,8 +321,7 @@ translation_entry_test_copy (TranslationEntryFixture *fixture,
 
 
 static void
-translation_entry_test_get_locale (TranslationEntryFixture *fixture,
-                                   gconstpointer user_data)
+translation_entry_test_get_locale (void)
 {
   g_autoptr (ModulemdTranslationEntry) te = NULL;
   g_autofree gchar *locale;
@@ -347,8 +344,7 @@ translation_entry_test_get_locale (TranslationEntryFixture *fixture,
 
 
 static void
-translation_entry_test_get_set_summary (TranslationEntryFixture *fixture,
-                                        gconstpointer user_data)
+translation_entry_test_get_set_summary (void)
 {
   g_autoptr (ModulemdTranslationEntry) te = NULL;
   g_autofree gchar *summary;
@@ -387,8 +383,7 @@ translation_entry_test_get_set_summary (TranslationEntryFixture *fixture,
 
 
 static void
-translation_entry_test_get_set_description (TranslationEntryFixture *fixture,
-                                            gconstpointer user_data)
+translation_entry_test_get_set_description (void)
 {
   g_autoptr (ModulemdTranslationEntry) te = NULL;
   g_autofree gchar *description;
@@ -428,8 +423,7 @@ translation_entry_test_get_set_description (TranslationEntryFixture *fixture,
 
 
 static void
-translation_entry_test_profile_descriptions (TranslationEntryFixture *fixture,
-                                             gconstpointer user_data)
+translation_entry_test_profile_descriptions (void)
 {
   g_autoptr (ModulemdTranslationEntry) te = NULL;
   g_auto (GStrv) profile_names;
@@ -482,8 +476,7 @@ translation_entry_test_profile_descriptions (TranslationEntryFixture *fixture,
 
 
 static void
-translation_entry_test_parse_yaml (TranslationEntryFixture *fixture,
-                                   gconstpointer user_data)
+translation_entry_test_parse_yaml (void)
 {
   g_autoptr (ModulemdTranslationEntry) te = NULL;
   g_autoptr (GError) error = NULL;
@@ -520,8 +513,7 @@ translation_entry_test_parse_yaml (TranslationEntryFixture *fixture,
 
 
 static void
-translation_entry_test_emit_yaml (TranslationEntryFixture *fixture,
-                                  gconstpointer user_data)
+translation_entry_test_emit_yaml (void)
 {
   g_autoptr (ModulemdTranslationEntry) te = NULL;
   g_autoptr (GError) error = NULL;
@@ -584,61 +576,29 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/translationentry/construct",
-              TranslationEntryFixture,
-              NULL,
-              NULL,
-              translation_entry_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translationentry/construct",
+              translation_entry_test_construct);
 
-  g_test_add ("/modulemd/v2/translationentry/copy",
-              TranslationEntryFixture,
-              NULL,
-              NULL,
-              translation_entry_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translationentry/copy",
+              translation_entry_test_copy);
 
-  g_test_add ("/modulemd/v2/translationentry/get_locale",
-              TranslationEntryFixture,
-              NULL,
-              NULL,
-              translation_entry_test_get_locale,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translationentry/get_locale",
+              translation_entry_test_get_locale);
 
-  g_test_add ("/modulemd/v2/translationentry/get_set_summary",
-              TranslationEntryFixture,
-              NULL,
-              NULL,
-              translation_entry_test_get_set_summary,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translationentry/get_set_summary",
+              translation_entry_test_get_set_summary);
 
-  g_test_add ("/modulemd/v2/translationentry/get_set_description",
-              TranslationEntryFixture,
-              NULL,
-              NULL,
-              translation_entry_test_get_set_description,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translationentry/get_set_description",
+              translation_entry_test_get_set_description);
 
-  g_test_add ("/modulemd/v2/translationentry/profile_descriptions",
-              TranslationEntryFixture,
-              NULL,
-              NULL,
-              translation_entry_test_profile_descriptions,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translationentry/profile_descriptions",
+              translation_entry_test_profile_descriptions);
 
-  g_test_add ("/modulemd/v2/translationentry/yaml/parse",
-              TranslationEntryFixture,
-              NULL,
-              NULL,
-              translation_entry_test_parse_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translationentry/yaml/parse",
+              translation_entry_test_parse_yaml);
 
-  g_test_add ("/modulemd/v2/translationentry/yaml/emit",
-              TranslationEntryFixture,
-              NULL,
-              NULL,
-              translation_entry_test_emit_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translationentry/yaml/emit",
+              translation_entry_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-translation.c
+++ b/modulemd/tests/test-modulemd-translation.c
@@ -40,8 +40,7 @@ sigtrap_handler (int sig_num)
 
 
 static void
-translation_test_construct (TranslationFixture *fixture,
-                            gconstpointer user_data)
+translation_test_construct (void)
 {
   g_autoptr (ModulemdTranslation) t = NULL;
   g_auto (GStrv) locales;
@@ -133,7 +132,7 @@ translation_test_construct (TranslationFixture *fixture,
 }
 
 static void
-translation_test_copy (TranslationFixture *fixture, gconstpointer user_data)
+translation_test_copy (void)
 {
   g_autoptr (ModulemdTranslation) t = NULL;
   g_autoptr (ModulemdTranslation) t_copy = NULL;
@@ -186,8 +185,7 @@ translation_test_copy (TranslationFixture *fixture, gconstpointer user_data)
 }
 
 static void
-translation_test_validate (TranslationFixture *fixture,
-                           gconstpointer user_data)
+translation_test_validate (void)
 {
   g_autoptr (ModulemdTranslation) t = NULL;
   g_autoptr (GError) error = NULL;
@@ -211,8 +209,7 @@ translation_test_validate (TranslationFixture *fixture,
 }
 
 static void
-translation_test_set_modified (TranslationFixture *fixture,
-                               gconstpointer user_data)
+translation_test_set_modified (void)
 {
   g_autoptr (ModulemdTranslation) t = NULL;
 
@@ -227,8 +224,7 @@ translation_test_set_modified (TranslationFixture *fixture,
 }
 
 static void
-translation_test_translations (TranslationFixture *fixture,
-                               gconstpointer user_data)
+translation_test_translations (void)
 {
   g_autoptr (ModulemdTranslation) t = NULL;
   ModulemdTranslationEntry *te = NULL;
@@ -253,8 +249,7 @@ translation_test_translations (TranslationFixture *fixture,
 
 
 static void
-translation_test_parse_yaml (TranslationFixture *fixture,
-                             gconstpointer user_data)
+translation_test_parse_yaml (void)
 {
   MMD_INIT_YAML_PARSER (parser);
   MMD_INIT_YAML_EVENT (event);
@@ -313,8 +308,7 @@ translation_test_parse_yaml (TranslationFixture *fixture,
 
 
 static void
-translation_test_emit_yaml (TranslationFixture *fixture,
-                            gconstpointer user_data)
+translation_test_emit_yaml (void)
 {
   MMD_INIT_YAML_EMITTER (emitter);
   MMD_INIT_YAML_EVENT (event);
@@ -381,54 +375,26 @@ main (int argc, char *argv[])
 
   // Define the tests.
 
-  g_test_add ("/modulemd/v2/translation/construct",
-              TranslationFixture,
-              NULL,
-              NULL,
-              translation_test_construct,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translation/construct",
+              translation_test_construct);
 
-  g_test_add ("/modulemd/v2/translation/copy",
-              TranslationFixture,
-              NULL,
-              NULL,
-              translation_test_copy,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translation/copy",
+              translation_test_copy);
 
-  g_test_add ("/modulemd/v2/translation/validate",
-              TranslationFixture,
-              NULL,
-              NULL,
-              translation_test_validate,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translation/validate",
+              translation_test_validate);
 
-  g_test_add ("/modulemd/v2/translation/set_modified",
-              TranslationFixture,
-              NULL,
-              NULL,
-              translation_test_set_modified,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translation/set_modified",
+              translation_test_set_modified);
 
-  g_test_add ("/modulemd/v2/translation/translations",
-              TranslationFixture,
-              NULL,
-              NULL,
-              translation_test_translations,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translation/translations",
+              translation_test_translations);
 
-  g_test_add ("/modulemd/v2/translation/yaml/parse",
-              TranslationFixture,
-              NULL,
-              NULL,
-              translation_test_parse_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translation/yaml/parse",
+              translation_test_parse_yaml);
 
-  g_test_add ("/modulemd/v2/translation/yaml/emit",
-              TranslationFixture,
-              NULL,
-              NULL,
-              translation_test_emit_yaml,
-              NULL);
+  g_test_add_func ("/modulemd/v2/translation/yaml/emit",
+              translation_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-translation.c
+++ b/modulemd/tests/test-modulemd-translation.c
@@ -376,25 +376,24 @@ main (int argc, char *argv[])
   // Define the tests.
 
   g_test_add_func ("/modulemd/v2/translation/construct",
-              translation_test_construct);
+                   translation_test_construct);
 
-  g_test_add_func ("/modulemd/v2/translation/copy",
-              translation_test_copy);
+  g_test_add_func ("/modulemd/v2/translation/copy", translation_test_copy);
 
   g_test_add_func ("/modulemd/v2/translation/validate",
-              translation_test_validate);
+                   translation_test_validate);
 
   g_test_add_func ("/modulemd/v2/translation/set_modified",
-              translation_test_set_modified);
+                   translation_test_set_modified);
 
   g_test_add_func ("/modulemd/v2/translation/translations",
-              translation_test_translations);
+                   translation_test_translations);
 
   g_test_add_func ("/modulemd/v2/translation/yaml/parse",
-              translation_test_parse_yaml);
+                   translation_test_parse_yaml);
 
   g_test_add_func ("/modulemd/v2/translation/yaml/emit",
-              translation_test_emit_yaml);
+                   translation_test_emit_yaml);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-valgrind.py
+++ b/modulemd/tests/test-valgrind.py
@@ -1,115 +1,52 @@
-#!/usr/bin/python3
+#!/ usr / bin / python3
 
-# This file is part of libmodulemd
-# Copyright (C) 2017-2018 Stephen Gallagher
+#This file is part of libmodulemd
+#Copyright(C) 2017 - 2018 Stephen Gallagher
 #
-# Fedora-License-Identifier: MIT
-# SPDX-2.0-License-Identifier: MIT
-# SPDX-3.0-License-Identifier: MIT
+#Fedora - License - Identifier : MIT
+#SPDX - 2.0 - License - Identifier : MIT
+#SPDX - 3.0 - License - Identifier : MIT
 #
-# This program is free software.
-# For more information on the license, see COPYING.
-# For more information on free software, see
-# <https://www.gnu.org/philosophy/free-sw.en.html>.
+#This program is free software.
+#For more information on the license, see COPYING.
+#For more information on free software, see
+# <https: //www.gnu.org/philosophy/free-sw.en.html>.
 
-import os
-import sys
-import subprocess
-import tempfile
-import xml.etree.ElementTree as ET
+import os import sys import subprocess import tempfile import xml.etree.ElementTree as ET
 
-from multiprocessing import Pool, TimeoutError
+  from multiprocessing import Pool, TimeoutError
 
-if os.getenv("MMD_SKIP_VALGRIND"):
-    sys.exit(77)
+                                    if os.getenv ("MMD_SKIP_VALGRIND") : sys.exit (77)
 
 
-failed = False
+                                                    failed = False
 
-# Get the list of tests to run
-tests = []
-if len(sys.argv) > 1:
-    tests = sys.argv[1:]
-else:
-    sys.exit(77)
+#Get the list of tests to run
+                                                  tests =[] if len (sys.argv)> 1 : tests = sys.argv[1 : ] else : sys.exit (77)
 
 
-with tempfile.TemporaryDirectory(prefix="libmodulemd_valgrind_") as tmpdirname:
+                                                                                                                             with tempfile.TemporaryDirectory (prefix = "libmodulemd_valgrind_") as tmpdirname :
 
-    def exec_valgrind(test):
-        valgrind_command = (
-            "/usr/bin/valgrind "
-            "--leak-check=full "
-            "--suppressions=/usr/share/glib-2.0/valgrind/glib.supp "
-            "--xml=yes "
-            "--xml-file=%s/%s.xml " % (tmpdirname, test)
-        )
-        proc_result = subprocess.run(
-            [
-                "meson",
-                "test",
-                "--no-rebuild",
-                "-t",
-                "10",
-                "--logbase=%s" % test,
-                "--wrap=%s" % valgrind_command,
-                test,
-            ]
-        )
+                                                                                                                           def exec_valgrind (test) : valgrind_command =("/usr/bin/valgrind "
+                                                                                                                                                                         "--leak-check=full "
+                                                                                                                                                                         "--suppressions=/usr/share/glib-2.0/valgrind/glib.supp "
+                                                                                                                                                                         "--xml=yes "
+                                                                                                                                                                         "--xml-file=%s/%s.xml " %(tmpdirname, test)) proc_result = subprocess.run (["meson", "test", "--no-rebuild", "-t", "10", "--logbase=%s" % test, "--wrap=%s" % valgrind_command, test, ])
 
-        return proc_result.returncode, test
+                                                                                                                                                                                                                                                       return proc_result.returncode, test
 
-    with Pool() as pool:
-        for returncode, test in pool.map(exec_valgrind, tests):
-            if returncode != 0:
-                print(
-                    "Valgrind exited with error [%d] on %s"
-                    % (returncode, test),
-                    file=sys.stderr,
-                )
-                failed = True
-                continue
+                                                                                                                                                                                                                                                    with Pool () as pool : for returncode, test in pool.map (exec_valgrind, tests) : if returncode != 0 : print ("Valgrind exited with error [%d] on %s" %(returncode, test), file = sys.stderr, ) failed = True continue
 
-            # Process the XML for leaks
-            tree = ET.parse("%s/%s.xml" % (tmpdirname, test))
-            root = tree.getroot()
+#Process the XML for leaks
+                                                                                                                                                                                                                                                                                                                                                                                                           tree = ET.parse ("%s/%s.xml" %(tmpdirname, test)) root = tree.getroot ()
 
-            for root_child in root:
-                if root_child.tag == "error":
-                    for error_child in root_child:
-                        if error_child.tag == "kind":
-                            if error_child.text == "Leak_DefinitelyLost":
-                                print(
-                                    "Memory leak detected in %s" % test,
-                                    file=sys.stderr,
-                                )
-                                failed = True
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    for root_child in root : if root_child.tag == "error" : for error_child in root_child : if error_child.tag == "kind" : if error_child.text == "Leak_DefinitelyLost" : print ("Memory leak detected in %s" % test, file = sys.stderr, ) failed = True
 
-                            elif error_child.text == "InvalidFree":
-                                print(
-                                    "Invalid free() detected in %s" % test,
-                                    file=sys.stderr,
-                                )
-                                failed = True
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 elif error_child.text == "InvalidFree" : print ("Invalid free() detected in %s" % test, file = sys.stderr, ) failed = True
 
-                            elif error_child.text == "InvalidRead":
-                                print(
-                                    "Invalid read detected in %s" % test,
-                                    file=sys.stderr,
-                                )
-                                failed = True
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 elif error_child.text == "InvalidRead" : print ("Invalid read detected in %s" % test, file = sys.stderr, ) failed = True
 
-                            elif error_child.text == "UninitCondition":
-                                print(
-                                    "Uninitialized usage detected in %s"
-                                    % test,
-                                    file=sys.stderr,
-                                )
-                                failed = True
-            if failed:
-                with open("%s/%s.xml" % (tmpdirname, test), "r") as xml:
-                    print(xml.read())
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 elif error_child.text == "UninitCondition" : print ("Uninitialized usage detected in %s" % test, file = sys.stderr, ) failed = True if failed : with open ("%s/%s.xml" %(tmpdirname, test), "r") as xml : print (xml.read ())
 
 
-if failed:
-    sys.exit(1)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    if failed : sys.exit (1)


### PR DESCRIPTION
corrected the previous syntax and also modified the required functions to enable compatibility with g_test_add_func()