### PR TITLE
Add ModuleIndex.search_rpms()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@
 # For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
 
 project('modulemd', 'c',
-        version : '2.8.3',
+        version : '2.9.0',
         default_options : [
           'buildtype=debugoptimized',
           'c_std=c11',

--- a/meson.build
+++ b/meson.build
@@ -96,6 +96,12 @@ has_gdate_autoptr = cc.compiles(
     dependencies : [ glib ],
     name : 'g_autoptr(GDate)')
 
+# Check whether glib2 has g_ptr_array_extend_and_steal or if we
+# need to bundle it.
+has_extend_and_steal = cc.has_function(
+    'g_ptr_array_extend_and_steal',
+    dependencies : [ glib ])
+
 python_name = get_option('python_name')
 
 if python_name != ''

--- a/modulemd/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-index.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "modulemd-module.h"
+#include "modulemd-module-stream.h"
 #include "modulemd-subdocument-info.h"
 #include "modulemd-translation.h"
 #include <glib-object.h>
@@ -362,6 +363,41 @@ modulemd_module_index_get_module_names_as_strv (ModulemdModuleIndex *self);
 ModulemdModule *
 modulemd_module_index_get_module (ModulemdModuleIndex *self,
                                   const gchar *module_name);
+
+
+/**
+ * modulemd_module_index_search_streams:
+ * @self: This #ModulemdModuleIndex object.
+ * @module_name: (nullable): The name of the module to retrieve. If NULL, will
+ * search all modules in the index.
+ * @stream_name: (nullable): The name of the stream to retrieve. If NULL, will
+ * search all streams in a module.
+ * @version: (nullable): The version of the stream to retrieve. If NULL, will
+ * search all versions.
+ * @context: (nullable): The context of the stream to retrieve. If NULL, will
+ * search all contexts.
+ * @arch: (nullable): The processor architecture of the stream to retrieve. If
+ * NULL, the architecture is not included in the search.
+ *
+ * All arguments to this method will be compared using
+ * [fnmatch(3)](https://www.mankier.com/3/fnmatch).
+ *
+ * Returns: (transfer container) (element-type ModulemdModuleStream): The list
+ * of stream objects matching all of the requested parameters. This function
+ * cannot fail, but it may return a zero-length list if no matches were found.
+ * The returned streams will be in a predictable order, sorted first by module
+ * name, then stream name, then by version (highest first), then by context
+ * and finally by architecture.
+ *
+ * Since: 2.9
+ */
+GPtrArray *
+modulemd_module_index_search_streams (ModulemdModuleIndex *self,
+                                      const gchar *module_name,
+                                      const gchar *stream_name,
+                                      const gchar *version,
+                                      const gchar *context,
+                                      const gchar *arch);
 
 
 /**

--- a/modulemd/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-index.h
@@ -422,6 +422,31 @@ modulemd_module_index_search_streams_by_nsvca_glob (
 
 
 /**
+ * modulemd_module_index_search_rpms:
+ * @self: This #ModulemdModuleIndex object.
+ * @nevra_pattern: (not nullable): A [glob](https://www.mankier.com/3/glob)
+ * pattern to match against the NEVRA strings of the rpm artifacts in the
+ * #ModulemdModuleStream objects in this module.
+ *
+ * All arguments to this method will be compared using
+ * [fnmatch(3)](https://www.mankier.com/3/fnmatch).
+ *
+ * Returns: (transfer container) (element-type ModulemdModuleStream): The list
+ * of stream objects containing an RPM that matches the @nevra_pattern.
+ * This function cannot fail, but it may return a zero-length list if no
+ * matches were found.
+ * The returned streams will be in a predictable order, sorted first by module
+ * name, then stream name, then by version (highest first), then by context
+ * and finally by architecture.
+ *
+ * Since: 2.9
+ */
+GPtrArray *
+modulemd_module_index_search_rpms (ModulemdModuleIndex *self,
+                                   const gchar *nevra_pattern);
+
+
+/**
  * modulemd_module_index_remove_module:
  * @self: This #ModulemdModuleIndex object.
  * @module_name: The name of the module to remove from the index.

--- a/modulemd/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-index.h
@@ -401,6 +401,27 @@ modulemd_module_index_search_streams (ModulemdModuleIndex *self,
 
 
 /**
+ * modulemd_module_index_search_streams_by_nsvca_glob:
+ * @self: This #ModulemdModuleIndex object.
+ * @nsvca_pattern: (not nullable): A [glob](https://www.mankier.com/3/glob)
+ * pattern to match against the NSVCA strings of the #ModulemdModuleStream
+ * objects in this module.
+ *
+ * Returns: (transfer container) (element-type ModulemdModuleStream): The list
+ * of stream objects matching all of the requested parameters. This function
+ * cannot fail, but it may return a zero-length list if no matches were found.
+ * The returned streams will be in a predictable order, sorted first by module
+ * name, then stream name, then by version (highest first), then by context
+ * and finally by architecture.
+ *
+ * Since: 2.9
+ */
+GPtrArray *
+modulemd_module_index_search_streams_by_nsvca_glob (
+  ModulemdModuleIndex *self, const gchar *nsvca_pattern);
+
+
+/**
  * modulemd_module_index_remove_module:
  * @self: This #ModulemdModuleIndex object.
  * @module_name: The name of the module to remove from the index.

--- a/modulemd/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module.h
@@ -193,6 +193,26 @@ modulemd_module_search_streams_by_glob (ModulemdModule *self,
                                         const gchar *context,
                                         const gchar *arch);
 
+/**
+ * modulemd_module_search_streams_by_nsvca_glob:
+ * @self: This #ModulemdModule object.
+ * @nsvca_pattern: (not nullable): A [glob](https://www.mankier.com/3/glob)
+ * pattern to match against the NSVCA strings of the #ModulemdModuleStream
+ * objects in this module.
+ *
+ * Returns: (transfer container) (element-type ModulemdModuleStream): An array
+ * of #ModulemdModuleStream objects whose NSVCA string matches the provided
+ * pattern. This function cannot fail, but may return an array of zero entries
+ * if the pattern did not match any streams. The returned streams will be in a
+ * predictable order, sorted first by module name, then stream name, then by
+ * version (highest first), then by context and finally by architecture.
+ *
+ * Since: 2.9
+ */
+GPtrArray *
+modulemd_module_search_streams_by_nsvca_glob (ModulemdModule *self,
+                                              const gchar *nsvca_pattern);
+
 
 /**
  * modulemd_module_get_stream_by_NSVCA:

--- a/modulemd/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module.h
@@ -162,6 +162,37 @@ modulemd_module_search_streams (ModulemdModule *self,
                                 const gchar *context,
                                 const gchar *arch);
 
+/**
+ * modulemd_module_search_streams_by_glob:
+ * @self: This #ModulemdModule object.
+ * @stream_name: (nullable): The name of the stream to retrieve. If NULL, will
+ * search all streams.
+ * @version: (nullable): The version of the stream to retrieve. If NULL, will
+ * search all versions.
+ * @context: (nullable): The context of the stream to retrieve. If NULL, will
+ * search all contexts.
+ * @arch: (nullable): The processor architecture of the stream to retrieve. If
+ * NULL, the architecture is not included in the search.
+ *
+ * All arguments to this method will be compared using
+ * [fnmatch(3)](https://www.mankier.com/3/fnmatch).
+ *
+ * Returns: (transfer container) (element-type ModulemdModuleStream): The list
+ * of stream objects matching all of the requested parameters. This function
+ * cannot fail, but it may return a zero-length list if no matches were found.
+ * The returned streams will be in a predictable order, sorted first by module
+ * name, then stream name, then by version (highest first), then by context
+ * and finally by architecture.
+ *
+ * Since: 2.9
+ */
+GPtrArray *
+modulemd_module_search_streams_by_glob (ModulemdModule *self,
+                                        const gchar *stream_name,
+                                        const gchar *version,
+                                        const gchar *context,
+                                        const gchar *arch);
+
 
 /**
  * modulemd_module_get_stream_by_NSVCA:

--- a/modulemd/include/private/glib-extensions.h
+++ b/modulemd/include/private/glib-extensions.h
@@ -14,10 +14,42 @@
 #pragma once
 
 #include <glib.h>
+#include <glib/gtypes.h>
 
 #include "config.h"
 
 /* GDate autoptr cleanup was finally added in GLib 2.63.3. */
 #ifndef HAVE_GDATE_AUTOPTR
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GDate, g_date_free)
+#endif
+
+
+#ifndef HAVE_EXTEND_AND_STEAL
+
+void
+g_ptr_array_extend (GPtrArray *array_to_extend,
+                    GPtrArray *array,
+                    GCopyFunc func,
+                    gpointer user_data);
+
+
+/*
+ * g_ptr_array_extend_and_steal:
+ * @array_to_extend: (transfer none): a #GPtrArray.
+ * @array: (transfer container): a #GPtrArray to add to the end of
+ *     @array_to_extend.
+ *
+ * Adds all the pointers in @array to the end of @array_to_extend, transferring
+ * ownership of each element from @array to @array_to_extend and modifying
+ * @array_to_extend in-place. @array is then freed.
+ *
+ * As with g_ptr_array_free(), @array will be destroyed if its reference count
+ * is 1. If its reference count is higher, it will be decremented and the
+ * length of @array set to zero.
+ *
+ * Since: glib 2.62
+ */
+
+void
+g_ptr_array_extend_and_steal (GPtrArray *array_to_extend, GPtrArray *array);
 #endif

--- a/modulemd/include/private/modulemd-module-stream-private.h
+++ b/modulemd/include/private/modulemd-module-stream-private.h
@@ -349,4 +349,20 @@ modulemd_module_stream_emit_yaml_base (ModulemdModuleStream *self,
                                        yaml_emitter_t *emitter,
                                        GError **error);
 
+
+/**
+ * modulemd_module_stream_includes_nevra:
+ * @self: This #ModulemdModuleStream object.
+ * @nevra_pattern: (not nullable): A [glob](https://www.mankier.com/3/glob)
+ * pattern to match against the NEVRA strings of the rpm artifacts in @self.
+ *
+ * Returns: TRUE if this stream includes at least one RPM artifact that
+ * matches @nevra_pattern. FALSE otherwise.
+ *
+ * Since: 2.9
+ */
+gboolean
+modulemd_module_stream_includes_nevra (ModulemdModuleStream *self,
+                                       const gchar *nevra_pattern);
+
 G_END_DECLS

--- a/modulemd/include/private/modulemd-module-stream-v1-private.h
+++ b/modulemd/include/private/modulemd-module-stream-v1-private.h
@@ -106,4 +106,20 @@ modulemd_module_stream_v1_emit_yaml (ModulemdModuleStreamV1 *self,
                                      GError **error);
 
 
+/**
+ * modulemd_module_stream_v1_includes_nevra:
+ * @self: This #ModulemdModuleStreamV1 object.
+ * @nevra_pattern: (not nullable): A [glob](https://www.mankier.com/3/glob)
+ * pattern to match against the NEVRA strings of the rpm artifacts in @self.
+ *
+ * Returns: TRUE if this stream includes at least one RPM artifact that
+ * matches @nevra_pattern. FALSE otherwise.
+ *
+ * Since: 2.9
+ */
+gboolean
+modulemd_module_stream_v1_includes_nevra (ModulemdModuleStreamV1 *self,
+                                          const gchar *nevra_pattern);
+
+
 G_END_DECLS

--- a/modulemd/include/private/modulemd-module-stream-v2-private.h
+++ b/modulemd/include/private/modulemd-module-stream-v2-private.h
@@ -198,4 +198,19 @@ modulemd_module_stream_v2_replace_dependencies (ModulemdModuleStreamV2 *self,
                                                 GPtrArray *array);
 
 
+/**
+ * modulemd_module_stream_v2_includes_nevra:
+ * @self: This #ModulemdModuleStreamV2 object.
+ * @nevra_pattern: (not nullable): A [glob](https://www.mankier.com/3/glob)
+ * pattern to match against the NEVRA strings of the rpm artifacts in @self.
+ *
+ * Returns: TRUE if this stream includes at least one RPM artifact that
+ * matches @nevra_pattern. FALSE otherwise.
+ *
+ * Since: 2.9
+ */
+gboolean
+modulemd_module_stream_v2_includes_nevra (ModulemdModuleStreamV2 *self,
+                                          const gchar *nevra_pattern);
+
 G_END_DECLS

--- a/modulemd/include/private/modulemd-util.h
+++ b/modulemd/include/private/modulemd-util.h
@@ -310,6 +310,48 @@ modulemd_validate_nevra (const gchar *nevra);
 gboolean
 modulemd_boolean_equals (gboolean a, gboolean b);
 
+
+/**
+ * modulemd_is_glob_pattern:
+ * @pattern: (nullable) A string to check for glob patterns as defined by
+ * [glob(7)[(https://www.mankier.com/7/glob)
+ *
+ * Returns: TRUE if @pattern contains any globbing characters. FALSE
+ * otherwise.
+ *
+ * Since: 2.9
+ */
+gboolean
+modulemd_is_glob_pattern (const char *pattern);
+
+
+/**
+ * compare_streams:
+ * @a: The first #ModulemdModuleStream to sort
+ * @b: The second #ModulemdModuleStream to sort
+ *
+ * Sorting function for GPtrArrays of #ModulemdModuleStream objects.
+ *
+ * Since: 2.9
+ */
+gint
+compare_streams (gconstpointer a, gconstpointer b);
+
+/**
+ * modulemd_fnmatch:
+ * @pattern: (nullable) A string to check for glob patterns as defined by
+ * [glob(7)[(https://www.mankier.com/7/glob)
+ * @string: (nullable) A string to check for matches.
+ *
+ * A wrapper around fnmatch() for use with modulemd.
+ *
+ * Returns: #TRUE if @pattern matched for this string or if @pattern is NULL.
+ * #FALSE if @pattern did not match or @string is NULL.
+ */
+gboolean
+modulemd_fnmatch (const gchar *pattern, const gchar *string);
+
+
 /**
  * MODULEMD_REPLACE_SET:
  * @_dest: A reference to a #GHashTable.

--- a/modulemd/include/private/modulemd-util.h
+++ b/modulemd/include/private/modulemd-util.h
@@ -359,6 +359,23 @@ modulemd_fnmatch (const gchar *pattern, const gchar *string);
 
 
 /**
+ * modulemd_rpm_match:
+ * @key: The key in the RPM artifacts hash table.
+ * @value: The value in the RPM artifacts hash table (should be the same
+ * as @key).
+ * @user_data: A [glob](https://www.mankier.com/3/glob)
+ * pattern to match against the NEVRA strings of the RPM artifacts in @self.
+ *
+ * This is a #GHRFunc for use with g_hash_table_find() to search for RPMs. It
+ * is a wrapper around modulemd_fnmatch().
+ *
+ * Returns: TRUE if @key is a match for the pattern in @user_data.
+ */
+gboolean
+modulemd_rpm_match (gpointer key, gpointer UNUSED (value), gpointer user_data);
+
+
+/**
  * MODULEMD_REPLACE_SET:
  * @_dest: A reference to a #GHashTable.
  * @_set: (nullable): A reference to a #GHashTable.

--- a/modulemd/include/private/modulemd-util.h
+++ b/modulemd/include/private/modulemd-util.h
@@ -25,6 +25,12 @@ G_BEGIN_DECLS
  * libmodulemd.
  */
 
+#ifdef __GNUC__
+#define UNUSED(x) UNUSED_##x __attribute__ ((__unused__))
+#else
+#define UNUSED(x) UNUSED_##x
+#endif
+
 
 /**
  * MODULEMD_ERROR:

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -230,6 +230,7 @@ cdata.set_quoted('LIBMODULEMD_VERSION', libmodulemd_version)
 cdata.set('HAVE_RPMIO', rpm.found())
 cdata.set('HAVE_LIBMAGIC', magic.found())
 cdata.set('HAVE_GDATE_AUTOPTR', has_gdate_autoptr)
+cdata.set('HAVE_EXTEND_AND_STEAL', has_extend_and_steal)
 configure_file(
   output : 'config.h',
   configuration : cdata

--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -977,6 +977,45 @@ modulemd_module_index_search_streams (ModulemdModuleIndex *self,
 }
 
 
+GPtrArray *
+modulemd_module_index_search_streams_by_nsvca_glob (ModulemdModuleIndex *self,
+                                                    const gchar *nsvca_pattern)
+{
+  g_autoptr (GPtrArray) module_names = NULL;
+  g_autoptr (GPtrArray) module_streams = NULL;
+  const gchar *mname = NULL;
+  ModulemdModule *module = NULL;
+
+  module_names =
+    modulemd_ordered_str_keys (self->modules, modulemd_strcmp_sort);
+
+  module_streams = g_ptr_array_new ();
+  for (guint i = 0; i < module_names->len; i++)
+    {
+      mname = g_ptr_array_index (module_names, i);
+      g_debug ("Searching through %s", mname);
+
+      module = modulemd_module_index_get_module (self, mname);
+      if (!module)
+        {
+          /* Since we're iterating through keys we just retrieved, this should
+           * be impossible. If we get here, it must be a bug.
+           */
+          g_assert_not_reached ();
+          continue;
+        }
+
+      g_ptr_array_extend_and_steal (
+        module_streams,
+        modulemd_module_search_streams_by_nsvca_glob (module, nsvca_pattern));
+    }
+
+  g_debug ("Module stream count: %d", module_streams->len);
+
+  return g_steal_pointer (&module_streams);
+}
+
+
 gboolean
 modulemd_module_index_remove_module (ModulemdModuleIndex *self,
                                      const gchar *module_name)

--- a/modulemd/modulemd-module-stream-v1.c
+++ b/modulemd/modulemd-module-stream-v1.c
@@ -1002,6 +1002,17 @@ modulemd_module_stream_v1_get_xmd (ModulemdModuleStreamV1 *self)
 }
 
 
+gboolean
+modulemd_module_stream_v1_includes_nevra (ModulemdModuleStreamV1 *self,
+                                          const gchar *nevra_pattern)
+{
+  /* If g_hash_table_find() returns non-NULL, the nevra was found in this
+   * module stream, so return TRUE
+   */
+  return !!g_hash_table_find (
+    self->rpm_artifacts, modulemd_rpm_match, (void *)nevra_pattern);
+}
+
 static gboolean
 modulemd_module_stream_v1_equals (ModulemdModuleStream *self_1,
                                   ModulemdModuleStream *self_2)

--- a/modulemd/modulemd-module-stream-v2.c
+++ b/modulemd/modulemd-module-stream-v2.c
@@ -1100,6 +1100,18 @@ modulemd_module_stream_v2_get_xmd (ModulemdModuleStreamV2 *self)
 }
 
 
+gboolean
+modulemd_module_stream_v2_includes_nevra (ModulemdModuleStreamV2 *self,
+                                          const gchar *nevra_pattern)
+{
+  /* If g_hash_table_find() returns non-NULL, the nevra was found in this
+   * module stream, so return TRUE
+   */
+  return !!g_hash_table_find (
+    self->rpm_artifacts, modulemd_rpm_match, (void *)nevra_pattern);
+}
+
+
 static gboolean
 modulemd_module_stream_v2_validate (ModulemdModuleStream *self, GError **error)
 {

--- a/modulemd/modulemd-module-stream.c
+++ b/modulemd/modulemd-module-stream.c
@@ -1356,3 +1356,33 @@ modulemd_module_stream_build_depends_on_stream (ModulemdModuleStream *self,
 
   return klass->build_depends_on_stream (self, module_name, stream_name);
 }
+
+
+gboolean
+modulemd_module_stream_includes_nevra (ModulemdModuleStream *self,
+                                       const gchar *nevra_pattern)
+{
+  ModulemdModuleStreamVersionEnum version;
+  g_return_val_if_fail (MODULEMD_IS_MODULE_STREAM (self), FALSE);
+
+  version = modulemd_module_stream_get_mdversion (self);
+  switch (version)
+    {
+    case MD_MODULESTREAM_VERSION_ONE:
+      return modulemd_module_stream_v1_includes_nevra (
+        MODULEMD_MODULE_STREAM_V1 (self), nevra_pattern);
+      break;
+
+    case MD_MODULESTREAM_VERSION_TWO:
+      return modulemd_module_stream_v2_includes_nevra (
+        MODULEMD_MODULE_STREAM_V2 (self), nevra_pattern);
+      break;
+
+    default:
+      /* We should never reach here */
+      g_return_val_if_reached (FALSE);
+      break;
+    }
+
+  return FALSE;
+}

--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -518,6 +518,40 @@ modulemd_module_search_streams_by_glob (ModulemdModule *self,
 
 
 GPtrArray *
+modulemd_module_search_streams_by_nsvca_glob (ModulemdModule *self,
+                                              const gchar *nsvca_pattern)
+{
+  gsize i = 0;
+  g_autoptr (GPtrArray) matching_streams = NULL;
+  ModulemdModuleStream *under_consideration = NULL;
+  g_autofree gchar *nsvca = NULL;
+
+  g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
+  g_return_val_if_fail (nsvca_pattern, NULL);
+
+  /* Assume the worst-case scenario that all streams match to spare us extra
+   * mallocs.
+   */
+  matching_streams = g_ptr_array_sized_new (self->streams->len);
+
+  for (i = 0; i < self->streams->len; i++)
+    {
+      under_consideration =
+        (ModulemdModuleStream *)g_ptr_array_index (self->streams, i);
+
+      nsvca = modulemd_module_stream_get_NSVCA_as_string (under_consideration);
+      if (modulemd_fnmatch (nsvca_pattern, nsvca))
+        {
+          g_ptr_array_add (matching_streams, under_consideration);
+        }
+      g_clear_pointer (&nsvca, g_free);
+    }
+
+  return g_steal_pointer (&matching_streams);
+}
+
+
+GPtrArray *
 modulemd_module_search_streams (ModulemdModule *self,
                                 const gchar *stream_name,
                                 const guint64 version,

--- a/modulemd/modulemd-util.c
+++ b/modulemd/modulemd-util.c
@@ -499,6 +499,12 @@ modulemd_fnmatch (const gchar *pattern, const gchar *string)
   return !fnmatch (pattern, string, 0);
 }
 
+gboolean
+modulemd_rpm_match (gpointer key, gpointer UNUSED (value), gpointer user_data)
+{
+  return modulemd_fnmatch (user_data, key);
+}
+
 
 #ifndef HAVE_EXTEND_AND_STEAL
 

--- a/modulemd/modulemd-util.c
+++ b/modulemd/modulemd-util.c
@@ -487,10 +487,14 @@ gboolean
 modulemd_fnmatch (const gchar *pattern, const gchar *string)
 {
   if (!pattern)
-    return TRUE;
+    {
+      return TRUE;
+    }
 
   if (!string)
-    return FALSE;
+    {
+      return FALSE;
+    }
 
   return !fnmatch (pattern, string, 0);
 }

--- a/modulemd/tests/test-modulemd-module.c
+++ b/modulemd/tests/test-modulemd-module.c
@@ -566,6 +566,48 @@ module_test_search_streams_by_glob (void)
 }
 
 
+static void
+module_test_search_streams_by_nsvca_glob (void)
+{
+  g_autoptr (ModulemdModuleIndex) index = modulemd_module_index_new ();
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GPtrArray) failures = NULL;
+  g_autoptr (GPtrArray) streams = NULL;
+  g_autofree gchar *yaml_path = NULL;
+  ModulemdModule *module = NULL;
+
+  yaml_path = g_strdup_printf ("%s/search_streams/search_streams.yaml",
+                               g_getenv ("TEST_DATA_PATH"));
+
+  modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  g_assert_no_error (error);
+
+  module = modulemd_module_index_get_module (index, "nodejs");
+  g_assert_nonnull (module);
+
+  streams = modulemd_module_search_streams_by_nsvca_glob (module, "*");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 3);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_search_streams_by_nsvca_glob (module, "nodejs*");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 3);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_search_streams_by_nsvca_glob (module, "nodejs:?*");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 3);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_search_streams_by_nsvca_glob (module, "*8*");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 2);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -590,6 +632,9 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/modulemd/v2/module/streams/glob",
                    module_test_search_streams_by_glob);
+
+  g_test_add_func ("/modulemd/v2/module/streams/glob_nsvca",
+                   module_test_search_streams_by_nsvca_glob);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -1461,6 +1461,52 @@ test_modulemd_index_search_streams (void)
 }
 
 
+static void
+test_module_index_search_streams_by_nsvca_glob (void)
+{
+  g_autoptr (ModulemdModuleIndex) index = modulemd_module_index_new ();
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GPtrArray) failures = NULL;
+  g_autoptr (GPtrArray) streams = NULL;
+  g_autofree gchar *yaml_path = NULL;
+
+  yaml_path = g_strdup_printf ("%s/search_streams/search_streams.yaml",
+                               g_getenv ("TEST_DATA_PATH"));
+
+  modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  g_assert_no_error (error);
+
+  streams = modulemd_module_index_search_streams_by_nsvca_glob (index, "*");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 5);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams =
+    modulemd_module_index_search_streams_by_nsvca_glob (index, "nodejs*");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 3);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams =
+    modulemd_module_index_search_streams_by_nsvca_glob (index, "nodejs:?*");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 3);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams_by_nsvca_glob (index, "*8*");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 4);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams =
+    modulemd_module_index_search_streams_by_nsvca_glob (index, "nodejs:[68]*");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 2);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -1510,6 +1556,9 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/modulemd/v2/module/index/search",
                    test_modulemd_index_search_streams);
+
+  g_test_add_func ("/modulemd/v2/module/index/search_nsvca",
+                   test_module_index_search_streams_by_nsvca_glob);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -1341,6 +1341,126 @@ test_module_index_read_def_dir (void)
 }
 
 
+static void
+test_modulemd_index_search_streams (void)
+{
+  g_autoptr (ModulemdModuleIndex) index = modulemd_module_index_new ();
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GPtrArray) failures = NULL;
+  g_autoptr (GPtrArray) streams = NULL;
+  g_autofree gchar *yaml_path = NULL;
+
+  yaml_path = g_strdup_printf ("%s/search_streams/search_streams.yaml",
+                               g_getenv ("TEST_DATA_PATH"));
+
+  modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  g_assert_no_error (error);
+
+  streams = modulemd_module_index_search_streams (
+    index, "nodejs", NULL, NULL, NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 3);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams (
+    index, "nonexistent", NULL, NULL, NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 0);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams =
+    modulemd_module_index_search_streams (index, NULL, NULL, NULL, NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 5);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams =
+    modulemd_module_index_search_streams (index, NULL, "8", NULL, NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 1);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams (
+    index, NULL, "nosuchstream", NULL, NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 0);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams =
+    modulemd_module_index_search_streams (index, NULL, NULL, "1", NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 3);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams =
+    modulemd_module_index_search_streams (index, NULL, NULL, "10", NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 0);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams (
+    index, NULL, NULL, NULL, "e0c83381", NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 1);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams (
+    index, NULL, NULL, NULL, "c2c572ec", NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 4);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams (
+    index, NULL, NULL, NULL, "deadbeef", NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 0);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams (
+    index, NULL, NULL, NULL, NULL, "i686");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 0);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams (
+    index, NULL, NULL, NULL, NULL, "x86_64");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 2);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams (
+    index, NULL, NULL, NULL, NULL, "ppc64le");
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 1);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams =
+    modulemd_module_index_search_streams (index, NULL, "2*", NULL, NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 1);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams (
+    index, NULL, "[68]", NULL, NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 2);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams = modulemd_module_index_search_streams (
+    index, NULL, "1.?", NULL, NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 1);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
+  streams =
+    modulemd_module_index_search_streams (index, NULL, "*", NULL, NULL, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 5);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -1387,6 +1507,9 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/modulemd/v2/module/index/defaultdir",
                    test_module_index_read_def_dir);
+
+  g_test_add_func ("/modulemd/v2/module/index/search",
+                   test_modulemd_index_search_streams);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test_data/search_streams/search_streams.yaml
+++ b/modulemd/tests/test_data/search_streams/search_streams.yaml
@@ -1,0 +1,483 @@
+---
+document: modulemd-translations
+version: 1
+data:
+  module: nodejs
+  stream: 8
+  modified: 1
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: nodejs
+  profiles:
+    6: [default]
+    8: [default]
+    9: [default]
+  intents:
+    server:
+      stream: 8
+      profiles:
+        6: [server]
+        8: [server]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: reviewboard
+  stream: 2.5
+  profiles:
+    2.5: [default]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: django
+  profiles:
+    1.6: [default]
+...
+---
+document: modulemd
+version: 2
+data:
+  name: django
+  stream: 1.6
+  version: 20180307130104
+  context: c2c572ec
+  summary: A high-level Python Web framework
+  description: >-
+    Django is a high-level Python Web framework that encourages rapid development
+    and a clean, pragmatic design. It focuses on automating as much as possible and
+    adhering to the DRY (Don't Repeat Yourself) principle.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/django.git?#90c50f8ad1cb5ca41d62632699c375dce6353adf
+      commit: 90c50f8ad1cb5ca41d62632699c375dce6353adf
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+      rpms:
+        python-django:
+          ref: 1c3a01558a435b56f8ef4f8fc0e5c1cd35f006a5
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+  dependencies:
+  - buildrequires:
+      platform: [f28]
+    requires:
+      platform: [f28]
+  references:
+    community: https://www.djangoproject.com
+    documentation: https://docs.djangoproject.com
+    tracker: https://code.djangoproject.com/query
+  profiles:
+    default:
+      rpms:
+      - python2-django
+    python2_development:
+      rpms:
+      - python2-django
+  api:
+    rpms:
+    - python2-django
+  components:
+    rpms:
+      python-django:
+        rationale: The Django python web framework
+        repository: git://pkgs.fedoraproject.org/rpms/python-django
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django
+        ref: 1.6
+  artifacts:
+    rpms:
+    - python-django-bash-completion-0:1.6.11.7-1.module_1560+089ce146.noarch
+    - python2-django-0:1.6.11.7-1.module_1560+089ce146.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: nodejs
+  stream: 6
+  version: 1
+  context: c2c572ec
+  summary: Javascript runtime
+  arch: x86_64
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/nodejs.git?#2d349c5055939081aefa37d71cd77051d235cb79
+      commit: 2d349c5055939081aefa37d71cd77051d235cb79
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+      rpms:
+        nodejs:
+          ref: 374ae23edf3676653fec706a5c81c5cdf019ce11
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+  dependencies:
+  - buildrequires:
+      platform: [f28]
+    requires:
+      platform: [f28]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        repository: git://pkgs.fedoraproject.org/rpms/nodejs
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/nodejs
+        ref: 6
+        buildorder: 10
+  artifacts:
+    rpms:
+    - nodejs-1:6.13.1-1.module_1575+55808bea.x86_64
+    - nodejs-devel-1:6.13.1-1.module_1575+55808bea.x86_64
+    - nodejs-docs-1:6.13.1-1.module_1575+55808bea.noarch
+    - npm-1:3.10.10-1.6.13.1.1.module_1575+55808bea.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: nodejs
+  stream: 8
+  version: 1
+  context: c2c572ec
+  summary: Javascript runtime
+  arch: x86_64
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/nodejs.git?#4dc5da13fa51c5a5cc9f02a81d71416bc6ce787e
+      commit: 4dc5da13fa51c5a5cc9f02a81d71416bc6ce787e
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+      rpms:
+        nodejs:
+          ref: 64f8f82763943f764d25225c2d95ae065490b10a
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+      mbs_options:
+        blocked_pacakges:
+        - blocked1
+        - blocked2
+  dependencies:
+  - buildrequires:
+      platform: [f28]
+    requires:
+      platform: [f28]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        repository: git://pkgs.fedoraproject.org/rpms/nodejs
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/nodejs
+        ref: 8
+        buildorder: 10
+  artifacts:
+    rpms:
+    - nodejs-1:8.10.0-3.module_1572+d7ec111e.x86_64
+    - nodejs-devel-1:8.10.0-3.module_1572+d7ec111e.x86_64
+    - nodejs-docs-1:8.10.0-3.module_1572+d7ec111e.noarch
+    - npm-1:5.6.0-1.8.10.0.3.module_1572+d7ec111e.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: nodejs
+  stream: 9
+  version: 1
+  context: c2c572ec
+  summary: Javascript runtime
+  arch: ppc64le
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/nodejs.git?#3f3665745cb84576f1faa66646cb8c37913ec461
+      commit: 3f3665745cb84576f1faa66646cb8c37913ec461
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+      rpms:
+        nodejs:
+          ref: 65648a2672dc03641b9eaa4d25a8f19d94fd90c3
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 4
+  dependencies:
+  - buildrequires:
+      platform: [f28]
+    requires:
+      platform: [f28]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        repository: git://pkgs.fedoraproject.org/rpms/nodejs
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/nodejs
+        ref: 9
+        buildorder: 10
+  artifacts:
+    rpms:
+    - nodejs-1:9.8.0-1.module_1571+4f4bc63d.x86_64
+    - nodejs-devel-1:9.8.0-1.module_1571+4f4bc63d.x86_64
+    - nodejs-docs-1:9.8.0-1.module_1571+4f4bc63d.noarch
+    - npm-1:5.6.0-1.9.8.0.1.module_1571+4f4bc63d.x86_64
+...
+---
+document: modulemd
+version: 2
+data:
+  name: reviewboard
+  stream: 2.5
+  version: 20180206144254
+  context: e0c83381
+  summary: A web-based code review tool
+  description: >-
+    Review Board is a powerful web-based code review tool that offers developers an
+    easy way to handle code reviews. It scales well from small projects to large companies
+    and offers a variety of tools to take much of the stress and time out of the code
+    review process.
+  license:
+    module:
+    - MIT
+  xmd:
+    mbs:
+      scmurl: https://src.fedoraproject.org/modules/reviewboard.git?#1738e1ce6352c0d4da31ba137cab0b5dc5f30166
+      commit: 1738e1ce6352c0d4da31ba137cab0b5dc5f30166
+      buildrequires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 3
+        django:
+          ref: 14fb96b250feec2e2c883e06255de2c36faa7313
+          stream: 1.6
+          filtered_rpms: []
+          version: 20180117164842
+      rpms:
+        python-django-multiselectfield:
+          ref: 149bf58875fb7b55efe29e1735baf96d44eb99a9
+        ReviewBoard:
+          ref: 5d28213f6a797e5ce28ad05ab23f80fe67353da8
+        python-django-evolution:
+          ref: 512424e1fc4b99f6f74c01a4130a4d9402b56b4e
+        python-django-pipeline:
+          ref: f019137be96cf86f49a81001fef47a0c7ab6aa35
+        python-markdown:
+          ref: 0af9dd03b4822c04be2742b39b5a4d48ef2d2222
+        python-django-haystack:
+          ref: 20fe71a6fc50a83b24578fbaf86e94a4ca584d31
+        python-djblets:
+          ref: d5634779089456ff3d0ac7b78eec81e13ff4c733
+      requires:
+        platform:
+          ref: virtual
+          stream: f28
+          filtered_rpms: []
+          version: 3
+        django:
+          ref: 14fb96b250feec2e2c883e06255de2c36faa7313
+          stream: 1.6
+          filtered_rpms: []
+          version: 20180117164842
+  dependencies:
+  - buildrequires:
+      django: [1.6]
+      platform: [f28]
+    requires:
+      django: [1.6]
+      platform: [f28]
+  references:
+    community: https://www.reviewboard.org
+    documentation: https://www.reviewboard.org/docs
+    tracker: https://hellosplat.com/s/beanbag/tickets/
+  profiles:
+    default:
+      rpms:
+      - ReviewBoard
+    server:
+      rpms:
+      - ReviewBoard
+  api:
+    rpms:
+    - ReviewBoard
+    - python2-djblets
+  components:
+    rpms:
+      ReviewBoard:
+        rationale: The Review Board code review tool
+        repository: git://pkgs.fedoraproject.org/rpms/ReviewBoard
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/ReviewBoard
+        ref: 2.5
+        buildorder: 20
+      python-django-evolution:
+        rationale: A database modification library used and maintained by the Review
+          Board upstream
+        repository: git://pkgs.fedoraproject.org/rpms/python-django-evolution
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django-evolution
+        ref: 0.7
+      python-django-haystack:
+        rationale: An older version of the Haystack search library for Django, needed
+          for compatibility.
+        repository: git://pkgs.fedoraproject.org/rpms/python-django-haystack
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django-haystack
+        ref: 2.4
+      python-django-multiselectfield:
+        rationale: An older version of a mult-select form field needed by Review Board.
+        repository: git://pkgs.fedoraproject.org/rpms/python-django-multiselectfield
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django-multiselectfield
+        ref: 0.1
+      python-django-pipeline:
+        rationale: An older version of this asset-packaging library for Django that
+          is compatible with Review Board.
+        repository: git://pkgs.fedoraproject.org/rpms/python-django-pipeline
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-django-pipeline
+        ref: 1.3
+      python-djblets:
+        rationale: Review Board tool library
+        repository: git://pkgs.fedoraproject.org/rpms/python-djblets
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-djblets
+        ref: 0.9
+        buildorder: 10
+      python-markdown:
+        rationale: An older version of this Markdown implementation that is compatible
+          with Review Board.
+        repository: git://pkgs.fedoraproject.org/rpms/python-markdown
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/python-markdown
+        ref: 2.4
+  artifacts:
+    rpms:
+    - ReviewBoard-0:2.5.17-17.module_d032b812.noarch
+    - python-django-haystack-docs-0:2.4.1-12.module_d032b812.noarch
+    - python2-django-evolution-1:0.7.7-12.module_d032b812.noarch
+    - python2-django-haystack-0:2.4.1-12.module_d032b812.noarch
+    - python2-django-multiselectfield-0:0.1.3-10.module_d032b812.noarch
+    - python2-django-pipeline-0:1.3.27-11.module_d032b812.noarch
+    - python2-djblets-0:0.9.9-13.module_d032b812.noarch
+    - python2-markdown-0:2.4.1-11.module_d032b812.noarch
+    - python3-markdown-0:2.4.1-11.module_d032b812.noarch
+...


### PR DESCRIPTION
Resolves: https://github.com/fedora-modularity/libmodulemd/issues/429

This patch adds the ability to query the `ModuleIndex` for which `ModuleStream` object(s) provide a given RPM nevra (or glob). This will make some DNF lookups easier (which may translate into repoquery enhancements).

There's also a second, minor patch to provide a new macro: `UNUSED()` which allows us to indicate that we are intentionally not using a function argument in the body (such as when we're defining the implementation of a callback function and don't need to use some of the data passed in.)

This set of patches builds atop the patches from PR #430 