### PR TITLE
Deprecate _reset_ methods in favor of _clear_ methods

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-component-rpm.h
+++ b/modulemd/include/modulemd-2.0/modulemd-component-rpm.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "modulemd-component.h"
+#include "modulemd-deprecated.h"
 #include <glib-object.h>
 
 G_BEGIN_DECLS
@@ -53,7 +54,7 @@ modulemd_component_rpm_new (const gchar *key);
  *
  * Restrict the list of architectures on which this RPM will be available. It
  * may be called any number of times to indicate support on additional
- * architectures. Use modulemd_component_rpm_reset_arches() to return to "all
+ * architectures. Use modulemd_component_rpm_clear_arches() to return to "all
  * architectures".
  *
  * Since: 2.0
@@ -70,9 +71,23 @@ modulemd_component_rpm_add_restricted_arch (ModulemdComponentRpm *self,
  * Indicate that this RPM component is available on all arches.
  *
  * Since: 2.0
+ * Deprecated: 2.9
  */
+MMD_DEPRECATED_FOR (modulemd_component_rpm_clear_arches)
 void
 modulemd_component_rpm_reset_arches (ModulemdComponentRpm *self);
+
+
+/**
+ * modulemd_component_rpm_clear_arches:
+ * @self: This #ModulemdComponentRpm object.
+ *
+ * Indicate that this RPM component is available on all arches.
+ *
+ * Since: 2.9
+ */
+void
+modulemd_component_rpm_clear_arches (ModulemdComponentRpm *self);
 
 
 /**
@@ -94,7 +109,7 @@ modulemd_component_rpm_get_arches_as_strv (ModulemdComponentRpm *self);
  * @arch: An architecture on which this package should be multilib.
  *
  * Add an architecture on which this RPM will be multilib. It may be called
- * any number of times. Use modulemd_component_rpm_reset_multilib_arches() to
+ * any number of times. Use modulemd_component_rpm_clear_multilib_arches() to
  * return to "no architectures".
  *
  * Since: 2.0
@@ -111,9 +126,23 @@ modulemd_component_rpm_add_multilib_arch (ModulemdComponentRpm *self,
  * Indicate that this RPM component is multilib on no architectures.
  *
  * Since: 2.0
+ * Deprecated: 2.9
  */
+MMD_DEPRECATED_FOR (modulemd_component_rpm_clear_multilib_arches)
 void
 modulemd_component_rpm_reset_multilib_arches (ModulemdComponentRpm *self);
+
+
+/**
+ * modulemd_component_rpm_clear_multilib_arches:
+ * @self: This #ModulemdComponentRpm object.
+ *
+ * Indicate that this RPM component is multilib on no architectures.
+ *
+ * Since: 2.9
+ */
+void
+modulemd_component_rpm_clear_multilib_arches (ModulemdComponentRpm *self);
 
 
 /**

--- a/modulemd/modulemd-component-rpm.c
+++ b/modulemd/modulemd-component-rpm.c
@@ -369,8 +369,16 @@ modulemd_component_rpm_add_restricted_arch (ModulemdComponentRpm *self,
 }
 
 
+/* Deprecated in favor of modulemd_component_rpm_clear_arches() */
 void
 modulemd_component_rpm_reset_arches (ModulemdComponentRpm *self)
+{
+  modulemd_component_rpm_clear_arches (self);
+}
+
+
+void
+modulemd_component_rpm_clear_arches (ModulemdComponentRpm *self)
 {
   g_return_if_fail (MODULEMD_IS_COMPONENT_RPM (self));
 
@@ -397,9 +405,16 @@ modulemd_component_rpm_add_multilib_arch (ModulemdComponentRpm *self,
   g_hash_table_add (self->multilib, g_strdup (arch));
 }
 
-
+/* Deprecated in favor of modulemd_component_rpm_clear_multilib_arches() */
 void
 modulemd_component_rpm_reset_multilib_arches (ModulemdComponentRpm *self)
+{
+  modulemd_component_rpm_clear_multilib_arches (self);
+}
+
+
+void
+modulemd_component_rpm_clear_multilib_arches (ModulemdComponentRpm *self)
 {
   g_return_if_fail (MODULEMD_IS_COMPONENT_RPM (self));
 

--- a/modulemd/tests/test-modulemd-component-rpm.c
+++ b/modulemd/tests/test-modulemd-component-rpm.c
@@ -279,6 +279,54 @@ component_rpm_test_copy (void)
 
 
 static void
+component_rpm_test_arches (void)
+{
+  g_autoptr (ModulemdComponentRpm) r = NULL;
+  g_auto (GStrv) list = NULL;
+
+  r = modulemd_component_rpm_new ("testmodule");
+  modulemd_component_rpm_add_restricted_arch (r, "x86_64");
+  modulemd_component_rpm_add_restricted_arch (r, "i686");
+  modulemd_component_rpm_add_multilib_arch (r, "ppc64le");
+  modulemd_component_rpm_add_multilib_arch (r, "s390x");
+  g_assert_nonnull (r);
+  g_assert_true (MODULEMD_IS_COMPONENT_RPM (r));
+
+  list = modulemd_component_rpm_get_arches_as_strv (r);
+  g_assert_cmpint (g_strv_length (list), ==, 2);
+  g_assert_cmpstr (list[0], ==, "i686");
+  g_assert_cmpstr (list[1], ==, "x86_64");
+  g_clear_pointer (&list, g_strfreev);
+
+  list = modulemd_component_rpm_get_multilib_arches_as_strv (r);
+  g_assert_cmpint (g_strv_length (list), ==, 2);
+  g_assert_cmpstr (list[0], ==, "ppc64le");
+  g_assert_cmpstr (list[1], ==, "s390x");
+  g_clear_pointer (&list, g_strfreev);
+
+  // Test rpm_clear_arches
+  modulemd_component_rpm_clear_arches (r);
+  list = modulemd_component_rpm_get_arches_as_strv (r);
+  g_assert_cmpint (g_strv_length (list), ==, 0);
+  g_clear_pointer (&list, g_strfreev);
+  list = modulemd_component_rpm_get_multilib_arches_as_strv (r);
+  g_assert_cmpint (g_strv_length (list), ==, 2);
+  g_clear_pointer (&list, g_strfreev);
+
+  // Test rpm_clear_multilib_arches
+  modulemd_component_rpm_clear_multilib_arches (r);
+  list = modulemd_component_rpm_get_arches_as_strv (r);
+  g_assert_cmpint (g_strv_length (list), ==, 0);
+  g_clear_pointer (&list, g_strfreev);
+  list = modulemd_component_rpm_get_multilib_arches_as_strv (r);
+  g_assert_cmpint (g_strv_length (list), ==, 0);
+  g_clear_pointer (&list, g_strfreev);
+
+  g_clear_object (&r);
+}
+
+
+static void
 component_rpm_test_emit_yaml (void)
 {
   g_autoptr (ModulemdComponentRpm) r = NULL;
@@ -455,6 +503,9 @@ main (int argc, char *argv[])
                    component_rpm_test_equals);
 
   g_test_add_func ("/modulemd/v2/component/rpm/copy", component_rpm_test_copy);
+
+  g_test_add_func ("/modulemd/v2/component/rpm/arches",
+                   component_rpm_test_arches);
 
   g_test_add_func ("/modulemd/v2/component/rpm/yaml/emit",
                    component_rpm_test_emit_yaml);


### PR DESCRIPTION
Resolves #400.

Also adds tests for the replacement methods. (There weren't any for the old methods.)