### PR TITLE
Improved documentation for deprecated methods.

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-component-rpm.h
+++ b/modulemd/include/modulemd-2.0/modulemd-component-rpm.h
@@ -71,7 +71,7 @@ modulemd_component_rpm_add_restricted_arch (ModulemdComponentRpm *self,
  * Indicate that this RPM component is available on all arches.
  *
  * Since: 2.0
- * Deprecated: 2.9
+ * Deprecated: 2.9: Use modulemd_component_rpm_clear_arches() instead.
  */
 MMD_DEPRECATED_FOR (modulemd_component_rpm_clear_arches)
 void
@@ -126,7 +126,7 @@ modulemd_component_rpm_add_multilib_arch (ModulemdComponentRpm *self,
  * Indicate that this RPM component is multilib on no architectures.
  *
  * Since: 2.0
- * Deprecated: 2.9
+ * Deprecated: 2.9: Use modulemd_component_rpm_clear_multilib_arches() instead.
  */
 MMD_DEPRECATED_FOR (modulemd_component_rpm_clear_multilib_arches)
 void

--- a/modulemd/include/modulemd-2.0/modulemd-module-stream-v1.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-stream-v1.h
@@ -760,7 +760,7 @@ modulemd_module_stream_v1_get_servicelevel (ModulemdModuleStreamV1 *self,
  * a wrapper for `modulemd_module_stream_v1_add_servicelevel("rawhide", eol)`.
  *
  * Since: 2.0
- * Deprecated: 2.0
+ * Deprecated: 2.0: Use modulemd_module_stream_v1_add_servicelevel() instead.
  */
 MMD_DEPRECATED_FOR (modulemd_module_stream_v1_add_servicelevel)
 void
@@ -778,7 +778,7 @@ modulemd_module_stream_v1_set_eol (ModulemdModuleStreamV1 *self, GDate *eol);
  * level.
  *
  * Since: 2.0
- * Deprecated: 2.0
+ * Deprecated: 2.0: Use modulemd_module_stream_v1_get_servicelevel() instead.
  */
 MMD_DEPRECATED_FOR (modulemd_module_stream_v1_get_servicelevel)
 GDate *

--- a/modulemd/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module.h
@@ -125,7 +125,7 @@ modulemd_module_get_streams_by_stream_name_as_list (ModulemdModule *self,
  * Returns: (transfer none): The requested stream object or NULL if no match was found.
  *
  * Since: 2.0
- * Deprecated: 2.2
+ * Deprecated: 2.2: Use modulemd_module_get_stream_by_NSVCA() instead.
  */
 MMD_DEPRECATED_FOR (modulemd_module_get_stream_by_NSVCA)
 ModulemdModuleStream *


### PR DESCRIPTION
gtk-doc actually pulls in the text after the deprecation version and includes it in the generated docs. `MMD_DEPRECATED_FOR()` only appears at compile time.