### PR TITLE
valgrind suppressions file for Python tests

### DIFF
--- a/contrib/valgrind/libmodulemd-python.supp
+++ b/contrib/valgrind/libmodulemd-python.supp
@@ -1,0 +1,80 @@
+# libmodulemd valgrind suppressions file
+#
+# This provides a list of suppressions for libmodulemd for valgrind for
+# the false positives that are reported when running under valgrind.
+#
+# Pass this suppression file to valgrind using --suppressions=/path/to/this-file.supp
+#
+# See http://valgrind.org/docs/manual/manual-core.html#manual-core.suppress
+# for details about the format of this file.
+#
+# Also see https://wiki.wxwidgets.org/Parse_valgrind_suppressions.sh for a
+# handy script to extract suppression entries from the valgrind test log.
+#
+{
+   Handle PyMalloc confusing valgrind
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:_PyObject_GC_New
+}
+{
+   Handle PyMalloc confusing valgrind
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:_PyObject_GC_NewVar
+}
+{
+   Handle PyMalloc confusing valgrind
+   Memcheck:Leak
+   fun:realloc
+   ...
+   fun:_PyObject_GC_Resize
+}
+{
+   Handle PyMalloc confusing valgrind
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:_PyMem_RawWcsdup
+   obj:/usr/lib64/libpython3.7m.so.1.0
+   fun:_Py_InitializeCore
+   obj:/usr/lib64/libpython3.7m.so.1.0
+   obj:/usr/lib64/libpython3.7m.so.1.0
+   fun:_Py_UnixMain
+   fun:(below main)
+}
+{
+   Handle PyMalloc confusing valgrind
+   Memcheck:Cond
+   fun:PyUnicode_Decode
+   fun:PyUnicode_FromEncodedObject
+   obj:/usr/lib64/libpython3.7m.so.1.0
+   fun:_PyObject_FastCallKeywords
+   obj:/usr/lib64/libpython3.7m.so.1.0
+   fun:_PyEval_EvalFrameDefault
+   fun:_PyFunction_FastCallDict
+   fun:_PyObject_Call_Prepend
+   obj:/usr/lib64/libpython3.7m.so.1.0
+   fun:_PyObject_FastCallKeywords
+   obj:/usr/lib64/libpython3.7m.so.1.0
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   Handle PyMalloc confusing valgrind
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:g_malloc
+   fun:g_strdup
+   obj:/usr/lib64/python3.7/site-packages/gi/_gi.cpython-37m-x86_64-linux-gnu.so
+   obj:/usr/lib64/python3.7/site-packages/gi/_gi.cpython-37m-x86_64-linux-gnu.so
+   obj:/usr/lib64/python3.7/site-packages/gi/_gi.cpython-37m-x86_64-linux-gnu.so
+   obj:/usr/lib64/python3.7/site-packages/gi/_gi.cpython-37m-x86_64-linux-gnu.so
+   obj:/usr/lib64/python3.7/site-packages/gi/_gi.cpython-37m-x86_64-linux-gnu.so
+   fun:PyObject_SetAttr
+   fun:_PyEval_EvalFrameDefault
+   fun:_PyFunction_FastCallKeywords
+   obj:/usr/lib64/libpython3.7m.so.1.0
+}

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -413,12 +413,16 @@ foreach name, script : python_tests
           env : py_test_release_env,
           args : files(script))
 
+    valgrind_tests += name + '_python3_debug'
+
     test (name + '_python2_debug', python2,
           env : py_test_env,
           args : files(script))
     test (name + '_python2_release', python2,
           env : py_test_release_env,
           args : files(script))
+
+    valgrind_tests += name + '_python2_debug'
 endforeach
 
 


### PR DESCRIPTION
Progress towards #333.

Valgrind failures for Python scripts are currently considered non-fatal if `MMD_IGNORE_PYTHON_VALGRIND` is set in the environment--which is currently done in `modulemd/meson.build`.

The big question is... what should be included in the suppression file? For starters, I included a few from the `valgrind-python.supp` file included in the Python 2 and 3 installs that were prevalent when running the tests.

Also, am I allowed to include `contrib/valgrind/grindmerge` here? It's a handy script I found for extracting and merging suppression entries from the test logfile.