### PR TITLE
ModuleStreamV1: Fix memory leak

### DIFF
--- a/modulemd/modulemd-module-stream-v1.c
+++ b/modulemd/modulemd-module-stream-v1.c
@@ -1923,6 +1923,7 @@ modulemd_module_stream_v1_parse_licenses (yaml_parser_t *parser,
               set = modulemd_yaml_parse_string_set (parser, &nested_error);
               modulemd_module_stream_v1_replace_content_licenses (modulestream,
                                                                   set);
+              g_clear_pointer (&set, g_hash_table_unref);
             }
           else
             {


### PR DESCRIPTION
We didn't catch this in the C tests because it only appears when the `data.license.content` field appears before the `data.license.module` field in the module metadata and only for ModuleStreamV1. In all of the input files used for V1 in the C tests, `data.license.content` was either omitted or came after `data.license.module`.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>