### PR TITLE
Add Release script

### DIFF
--- a/.make_packit_specfile.sh
+++ b/.make_packit_specfile.sh
@@ -6,9 +6,18 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 pushd $SCRIPT_DIR
 
-# The first version pattern appearing in meson.build must always be libmodulemd's version
-MODULEMD_VERSION=$(grep -E -o "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+" meson.build |head -n1)
+date=$(date +%Y%m%d)
+version_desc=$(git describe --tags --match "*.*")
+version=$(echo $version_desc | cut -d '-' -f2)
+patch_count=$(echo $version_desc | cut -d '-' -f3)
+hash=$(echo $version_desc | cut -d '-' -f4)
 
-./spec_tmpl.sh $MODULEMD_VERSION libmodulemd.spec.in > libmodulemd.spec
+if [ x$patch_count != x ]; then
+    release=0.${date}.${patch_count}git${hash}%{?dist}
+else
+    release=0.${date}%{?dist}
+fi
+
+./spec_tmpl.sh version=$version release=$release template=libmodulemd.spec.in > libmodulemd.spec
 
 popd

--- a/.packit.yml
+++ b/.packit.yml
@@ -2,6 +2,8 @@ specfile_path: libmodulemd.spec
 upstream_package_name: libmodulemd
 downstream_package_name: libmodulemd
 upstream_tag_template: libmodulemd-{version}
+current_version_command:
+  - ./.packit_version.sh
 
 synced_files:
   - .packit.yml

--- a/.packit_version.sh
+++ b/.packit_version.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+git describe --tags --match "*.*"  --abbrev=0 | sed -ne 's/^libmodulemd-//p'

--- a/.travis/archlinux/Dockerfile.deps.tmpl
+++ b/.travis/archlinux/Dockerfile.deps.tmpl
@@ -10,6 +10,7 @@ RUN pacman -Syu --needed --noconfirm \
 	gobject-introspection \
 	gtk-doc \
 	help2man \
+	jq \
 	libyaml \
 	meson \
 	python-gobject \

--- a/.travis/centos/Dockerfile.deps.tmpl
+++ b/.travis/centos/Dockerfile.deps.tmpl
@@ -20,6 +20,7 @@ ifelse(eval(_RELEASE_ >= 8), 1, `dnl
 	gobject-introspection-devel \
 	gtk-doc \
 	help2man \
+	jq \
 	libyaml-devel \
 	meson \
 	ninja-build \

--- a/.travis/fedora/Dockerfile.deps.tmpl
+++ b/.travis/fedora/Dockerfile.deps.tmpl
@@ -20,6 +20,7 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags=''  --skip-broken i
 	gobject-introspection-devel \
 	gtk-doc \
 	help2man \
+	jq \
 	libyaml-devel \
 	meson \
 	ninja-build \

--- a/.travis/mageia/Dockerfile.deps.tmpl
+++ b/.travis/mageia/Dockerfile.deps.tmpl
@@ -17,6 +17,7 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	gobject-introspection-devel \
 	gtk-doc \
 	help2man \
+	jq \
 	libyaml-devel \
 	meson \
 	ninja-build \

--- a/.travis/openmandriva/Dockerfile.deps.tmpl
+++ b/.travis/openmandriva/Dockerfile.deps.tmpl
@@ -7,6 +7,7 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	clang-analyzer \
 	cmake \
 	help2man \
+	jq \
 	meson \
 	ninja \
 	rpmdevtools \

--- a/.travis/opensuse/Dockerfile.deps.tmpl
+++ b/.travis/opensuse/Dockerfile.deps.tmpl
@@ -18,6 +18,7 @@ RUN zypper install --no-confirm --no-recommends \
 	gobject-introspection-devel \
 	gtk-doc \
 	help2man \
+	jq \
 	libyaml-devel \
 	meson \
 	ninja \

--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -9,7 +9,7 @@
 
 Name:           libmodulemd
 Version:        @VERSION@
-Release:        0%{?dist}.@DATETIME@
+Release:        @RELEASE@
 Summary:        Module metadata manipulation library
 
 License:        MIT

--- a/meson.build
+++ b/meson.build
@@ -62,7 +62,7 @@ magic = cc.find_library('magic', required : with_libmagic)
 glib = dependency('glib-2.0')
 glib_prefix = glib.get_pkgconfig_variable('prefix')
 
-sh = find_program('sh')
+bash = find_program('bash')
 sed = find_program('sed')
 test = find_program('test')
 
@@ -144,9 +144,9 @@ spec_target = custom_target(
     capture: true,
     build_by_default: true,
     build_always_stale: true,
-    command: [sh, spec_tmpl,
-              meson.project_version(),
-              '@INPUT@'],
+    command: [bash, spec_tmpl,
+              'version=' + meson.project_version(),
+              'template=@INPUT@'],
     input: specfile_template,
     output: 'libmodulemd.spec',
     depends: rpmsetup_target,

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -270,6 +270,7 @@ install_headers(
 test_release_env = environment()
 test_release_env.set('LC_ALL', 'C')
 test_release_env.set ('MESON_SOURCE_ROOT', meson.source_root())
+test_release_env.set ('MESON_BUILD_ROOT', meson.build_root())
 test_release_env.set ('TEST_DATA_PATH', meson.source_root() + '/modulemd/tests/test_data')
 
 # Test env with fatal warnings and criticals
@@ -302,6 +303,12 @@ py_test_release_env.set('G_DEBUG', 'fatal-warnings,fatal-criticals')
 
 valgrind_tests = []
 
+
+# Make sure we remembered to bump the version number since the last release
+version_test = find_program('tests/test-version.sh')
+if developer_build
+    test('version', version_test, env : test_env)
+endif
 
 # --- Test utility library --- #
 test_utils_lib = library(

--- a/modulemd/tests/test-version.sh
+++ b/modulemd/tests/test-version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+
+set -x
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $MESON_BUILD_ROOT
+
+function error_out {
+    local code message
+    local "${@}"
+
+    echo $message 1>&2
+    exit $code
+}
+
+function common_finalize {
+    exitcode=$?
+
+    return $exitcode
+}
+
+trap common_finalize EXIT
+
+jq --version >/dev/null || error_out code=127 message="Install 'jq' to use this script"
+
+# Get the previous tag for this branch
+OLDTAG=$(git describe --first-parent --abbrev=0)
+
+# Get the version that will be tagged
+NEWVERSION=$(meson introspect $MESON_BUILD_ROOT --projectinfo |jq -r .version)
+NEWTAG=libmodulemd-$NEWVERSION
+
+if [ $NEWTAG = $OLDTAG ]; then
+    error_out code=2 message="Version is already tagged. Update meson.build with the new version."
+fi
+

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $SCRIPT_DIR
+
+function error_out {
+    local code message
+    local "${@}"
+
+    echo $message 1>&2
+    exit $code
+}
+
+TMPDIR=$(mktemp -d MODULEMD_XXXXXX --tmpdir)
+
+function common_finalize {
+    exitcode=$?
+
+    rm -Rf $TMPDIR
+
+    return $exitcode
+}
+
+trap common_finalize EXIT
+
+hub --version >/dev/null || error_out code=127 message="Install 'hub' to use this script"
+jq --version >/dev/null || error_out code=127 message="Install 'jq' to use this script"
+
+# Make sure the current user has logged in before or prompt them for credentials
+echo "Logging into Github"
+hub api "https://api.github.com/user" || error_out code=1 message="Invalid credentials"
+
+# Get the previous tag for this branch
+OLDTAG=$(git describe --first-parent --abbrev=0)
+
+# Configure the build directory
+meson --buildtype=release -Dskip_formatters=true -Ddeveloper_build=false $TMPDIR
+MMD_SKIP_VALGRIND=True ninja -C $TMPDIR dist
+
+# Get the version that will be tagged
+NEWVERSION=$(meson introspect $TMPDIR --projectinfo |jq -r ".version")
+NEWTAG=libmodulemd-$NEWVERSION
+
+if [ $NEWTAG = $OLDTAG ]; then
+    error_out code=2 message="Version is already tagged. Update meson.build with the new version."
+fi
+
+echo ==========
+echo Tagging $NEWTAG
+echo ==========
+
+echo Tagging $NEWTAG > $TMPDIR/tag_header
+echo >> $TMPDIR/tag_header
+git shortlog $OLDTAG.. >> $TMPDIR/shortlog || error_out code=3 message="Couldn't find the previous tag"
+cat $TMPDIR/tag_header $TMPDIR/shortlog > $TMPDIR/tag_message
+
+git tag -s -F $TMPDIR/tag_message $NEWTAG || error_out code=4 message="Couldn't create new signed tag for the release"
+
+# Make sure everything is up-to-date on Github
+git push --follow-tags || error_out code=5 message="Couldn't push the new tags to Github"
+
+echo "libmodulemd $NEWVERSION" > $TMPDIR/github_message
+echo >> $TMPDIR/github_message
+sed -E "s/      / * /g" $TMPDIR/shortlog | sed  -E "s/(.*):\$/\# \1/g" >> $TMPDIR/github_message
+
+hub release create -a $TMPDIR/meson-dist/modulemd-$NEWVERSION.tar.xz \
+                   -a $TMPDIR/meson-dist/modulemd-$NEWVERSION.tar.xz.sha256sum \
+                   -F $TMPDIR/github_message \
+                   $NEWTAG || error_out code=10 message="Couldn't publish the release"
+

--- a/spec_tmpl.sh
+++ b/spec_tmpl.sh
@@ -1,8 +1,14 @@
-#!/usr/bin/sh
+#!/bin/bash
 
-version=$1
-template=$2
-datetime=$(date +%Y%m%d%H%M%S)
+function main {
+    local template version release
+    local "${@}"
 
-sed -e "s/@VERSION@/$version/" \
-    -e "s/@DATETIME@/$datetime/" $template
+    datetime=$(date +%Y%m%d%H%M%S)
+    release=${release:-0.$datetime%\{?dist\}}
+
+    sed -e "s/@VERSION@/$version/" \
+        -e "s/@RELEASE@/$release/" $template
+}
+
+main "${@}"


### PR DESCRIPTION
Add a script to perform upstream releases.

Also includes a new test to ensure that we update the version in `meson.build` after a release to avoid the occasional issue where CI ends up performing the installed-library tests against the Fedora version rather than the upstream version.