### PR TITLE
Drop clang-tidy formatter

### DIFF
--- a/.travis/archlinux/travis-tasks.sh
+++ b/.travis/archlinux/travis-tasks.sh
@@ -11,7 +11,6 @@ pushd /builddir/
 meson --buildtype=debug \
       -Dtest_dirty_git=false \
       -Ddeveloper_build=false \
-      -Dskip_clang_tidy=true \
       -Dpython_name=python3 \
       -Drpmio=disabled \
       travis

--- a/.travis/centos/travis-tasks.sh
+++ b/.travis/centos/travis-tasks.sh
@@ -8,7 +8,7 @@ set -x
 # CentOS 7 doesn't have autopep8, so we'll drop the requirement for it
 # This implementation will still allow it to occur if autopep8 still shows
 # up later.
-COMMON_MESON_ARGS="-Dtest_dirty_git=false -Ddeveloper_build=false -Dpython_name=python3.6 -Dskip_clang_tidy=true"
+COMMON_MESON_ARGS="-Dtest_dirty_git=false -Ddeveloper_build=false -Dpython_name=python3.6"
 
 pushd /builddir/
 

--- a/.travis/fedora/travis-tasks.sh
+++ b/.travis/fedora/travis-tasks.sh
@@ -5,7 +5,7 @@ set -e
 set -x
 
 PROCESSORS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
-COMMON_MESON_ARGS="-Dtest_dirty_git=${DIRTY_REPO_CHECK:-true} -Dskip_clang_tidy=${SKIP_CLANG_TIDY:-true}"
+COMMON_MESON_ARGS="-Dtest_dirty_git=${DIRTY_REPO_CHECK:-true}"
 RETRY_CMD=/builddir/.travis/retry-command.sh
 
 pushd /builddir/

--- a/.travis/mageia/travis-tasks.sh
+++ b/.travis/mageia/travis-tasks.sh
@@ -5,7 +5,7 @@ set -e
 set -x
 
 
-COMMON_MESON_ARGS="-Dtest_dirty_git=${DIRTY_REPO_CHECK:-true} -Ddeveloper_build=false -Dskip_clang_tidy=true"
+COMMON_MESON_ARGS="-Dtest_dirty_git=${DIRTY_REPO_CHECK:-true} -Ddeveloper_build=false"
 
 
 pushd /builddir/

--- a/.travis/openmandriva/travis-tasks.sh
+++ b/.travis/openmandriva/travis-tasks.sh
@@ -4,7 +4,7 @@
 set -e
 set -x
 
-COMMON_MESON_ARGS="-Dtest_dirty_git=false -Ddeveloper_build=false -Dskip_clang_tidy=false -Dwith_docs=false"
+COMMON_MESON_ARGS="-Dtest_dirty_git=false -Ddeveloper_build=false -Dwith_docs=false"
 
 pushd /builddir/
 

--- a/.travis/opensuse/travis-tasks.sh
+++ b/.travis/opensuse/travis-tasks.sh
@@ -5,7 +5,7 @@ set -e
 set -x
 
 
-COMMON_MESON_ARGS="-Dtest_dirty_git=false -Ddeveloper_build=false -Dpython_name=python3 -Dskip_clang_tidy=true"
+COMMON_MESON_ARGS="-Dtest_dirty_git=false -Ddeveloper_build=false -Dpython_name=python3"
 
 
 pushd /builddir/

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,9 +21,6 @@ option('python_name', type : 'string',
 option('rpmio', type : 'feature', value : 'enabled',
        description : 'Use the rpmio library to automatically decompress gzip, bzip2 and xz YAML streams.')
 
-option('skip_clang_tidy', type : 'boolean', value : false,
-       description : 'Do not use the clang-tidy utility for code formatting.')
-
 option('skip_formatters', type : 'boolean', value : false,
        description : 'Do not do any automatic formatting of source code.')
 

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -14,7 +14,6 @@
 developer_build = get_option('developer_build')
 test_dirty_git = get_option('test_dirty_git')
 test_installed_lib = get_option('test_installed_lib')
-skip_clang_tidy = get_option('skip_clang_tidy')
 skip_formatters = get_option('skip_formatters')
 skip_introspection = get_option('skip_introspection')
 
@@ -22,46 +21,13 @@ skip_introspection = get_option('skip_introspection')
 clang_simple_version_script = find_program ('clang_simple_version.sh')
 
 if skip_formatters
-    clang_tidy = disabler()
     clang_format = disabler()
     python_formatter = disabler()
     pycodestyle = disabler()
 else
-    if skip_clang_tidy
-        clang_tidy = disabler()
-    else
-        clang_tidy = find_program('clang-tidy', required: false)
-    endif
-
-    if clang_tidy.found()
-        ret = run_command (clang_simple_version_script, clang_tidy.path())
-        if ret.returncode() != 0
-            warning('Unable to determine clang-tidy version.')
-            clang_tidy = disabler()
-        else
-            clang_tidy_version = ret.stdout().strip()
-
-            # Older versions of clang_tidy have issues with producing changes that
-            # do not compile. Only use this tool if we have a sufficiently new
-            # version.
-            if not clang_tidy_version.version_compare('>=9.0.0')
-                warning('clang-tidy version too old: ' +
-                        clang_tidy_version +
-                        ' < 9.0.0')
-                clang_tidy = disabler()
-            endif
-        endif
-    else
-        clang_tidy = disabler()
-    endif
-
-    if clang_tidy.found()
+    clang_format = find_program('clang-format', required: developer_build)
+    if not clang_format.found()
         clang_format = disabler()
-    else
-        clang_format = find_program('clang-format', required: developer_build)
-        if not clang_format.found()
-            clang_format = disabler()
-        endif
     endif
 
     python_formatter = find_program('black', required : developer_build)
@@ -418,15 +384,6 @@ clang_files = modulemd_srcs + modulemd_hdrs + modulemd_priv_hdrs + modulemd_vali
 clang_args = [ '-i' ]
 test('clang_format', clang_format,
      args : clang_args + clang_files)
-
-clang_tidy_args = [ '-p', meson.build_root(),
-                    '--checks=*,-llvm-header-guard,-bugprone-macro-parentheses',
-                    '--format-style=file',
-                    '--fix',
-                    '--fix-errors' ]
-test('clang_tidy', clang_tidy,
-     args: clang_tidy_args + clang_files,
-     timeout: 300)
 
 
 # Fake test to ensure that the python tests are formatted according to PEP8


### PR DESCRIPTION
It's unreliable and segfaults in CI frequently. Disable it.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>