### PR TITLE
Handle NULL nsvca_patterns for globs

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-index.h
@@ -403,9 +403,9 @@ modulemd_module_index_search_streams (ModulemdModuleIndex *self,
 /**
  * modulemd_module_index_search_streams_by_nsvca_glob:
  * @self: This #ModulemdModuleIndex object.
- * @nsvca_pattern: (not nullable): A [glob](https://www.mankier.com/3/glob)
+ * @nsvca_pattern: (nullable): A [glob](https://www.mankier.com/3/glob)
  * pattern to match against the NSVCA strings of the #ModulemdModuleStream
- * objects in this module.
+ * objects in this module. If NULL, this will match all NSVCAs.
  *
  * Returns: (transfer container) (element-type ModulemdModuleStream): The list
  * of stream objects matching all of the requested parameters. This function

--- a/modulemd/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module.h
@@ -196,9 +196,9 @@ modulemd_module_search_streams_by_glob (ModulemdModule *self,
 /**
  * modulemd_module_search_streams_by_nsvca_glob:
  * @self: This #ModulemdModule object.
- * @nsvca_pattern: (not nullable): A [glob](https://www.mankier.com/3/glob)
+ * @nsvca_pattern: (nullable): A [glob](https://www.mankier.com/3/glob)
  * pattern to match against the NSVCA strings of the #ModulemdModuleStream
- * objects in this module.
+ * objects in this module. If NULL, this will match all NSVCAs.
  *
  * Returns: (transfer container) (element-type ModulemdModuleStream): An array
  * of #ModulemdModuleStream objects whose NSVCA string matches the provided

--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -527,7 +527,6 @@ modulemd_module_search_streams_by_nsvca_glob (ModulemdModule *self,
   g_autofree gchar *nsvca = NULL;
 
   g_return_val_if_fail (MODULEMD_IS_MODULE (self), NULL);
-  g_return_val_if_fail (nsvca_pattern, NULL);
 
   /* Assume the worst-case scenario that all streams match to spare us extra
    * mallocs.
@@ -540,7 +539,7 @@ modulemd_module_search_streams_by_nsvca_glob (ModulemdModule *self,
         (ModulemdModuleStream *)g_ptr_array_index (self->streams, i);
 
       nsvca = modulemd_module_stream_get_NSVCA_as_string (under_consideration);
-      if (modulemd_fnmatch (nsvca_pattern, nsvca))
+      if (nsvca_pattern == NULL || modulemd_fnmatch (nsvca_pattern, nsvca))
         {
           g_ptr_array_add (matching_streams, under_consideration);
         }

--- a/modulemd/tests/test-modulemd-module.c
+++ b/modulemd/tests/test-modulemd-module.c
@@ -591,6 +591,11 @@ module_test_search_streams_by_nsvca_glob (void)
   g_assert_cmpint (streams->len, ==, 3);
   g_clear_pointer (&streams, g_ptr_array_unref);
 
+  streams = modulemd_module_search_streams_by_nsvca_glob (module, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 3);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
   streams = modulemd_module_search_streams_by_nsvca_glob (module, "nodejs*");
   g_assert_nonnull (streams);
   g_assert_cmpint (streams->len, ==, 3);

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -1504,6 +1504,11 @@ test_module_index_search_streams_by_nsvca_glob (void)
   g_assert_cmpint (streams->len, ==, 5);
   g_clear_pointer (&streams, g_ptr_array_unref);
 
+  streams = modulemd_module_index_search_streams_by_nsvca_glob (index, NULL);
+  g_assert_nonnull (streams);
+  g_assert_cmpint (streams->len, ==, 5);
+  g_clear_pointer (&streams, g_ptr_array_unref);
+
   streams =
     modulemd_module_index_search_streams_by_nsvca_glob (index, "nodejs*");
   g_assert_nonnull (streams);


### PR DESCRIPTION
NULL should be treated as a shortcut for "everything matches", to
avoid having to pass "*" and call fnmatch()

Fixes: https://github.com/fedora-modularity/libmodulemd/issues/458

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>