### PR TITLE
Relax handling of differing content for the same NSVCA

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-module-index-merger.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-index-merger.h
@@ -46,10 +46,9 @@ G_BEGIN_DECLS
  *
  * When merging module streams, entries will be deduplicated based on whether
  * they share the same module name, stream name, version number, and context.
- * At present, libmodulemd does not interrogate more closely to determine if
- * they have the same content, so if the repository configuration is broken and
- * there exists two #ModulemdModuleStream entries that have different content
- * for the same NSVC, the behavior is undefined.
+ * If the repository configuration is broken and there exists two
+ * #ModulemdModuleStream entries that have different content for the same
+ * NSVCA, the behavior is undefined.
  *
  * Merging #ModulemdDefaults entries behaves as follows (note that this
  * behavior has changed slightly as of 2.8.1):

--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -1375,6 +1375,7 @@ modulemd_module_index_merge (ModulemdModuleIndex *from,
   guint i;
   g_autoptr (GPtrArray) translated_stream_names = NULL;
   gchar *translated_stream_name = NULL;
+  g_autofree gchar *nsvca = NULL;
 
 
   /* Loop through each module in the Index */
@@ -1400,13 +1401,17 @@ modulemd_module_index_merge (ModulemdModuleIndex *from,
       for (i = 0; i < streams->len; i++)
         {
           stream = g_ptr_array_index (streams, i);
+          nsvca = modulemd_module_stream_get_NSVCA_as_string (stream);
 
           if (!modulemd_module_index_add_module_stream (
                 into, stream, &nested_error))
             {
-              g_propagate_error (error, g_steal_pointer (&nested_error));
-              return FALSE;
+              g_info ("Could not add stream %s due to %s",
+                      nsvca,
+                      nested_error->message);
+              g_clear_error (&nested_error);
             }
+          g_clear_pointer (&nsvca, g_free);
         }
 
 

--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -335,13 +335,15 @@ modulemd_module_add_stream (ModulemdModule *self,
 
       if (!modulemd_module_stream_equals (old, stream))
         {
+          g_autofree gchar *nsvca =
+            modulemd_module_stream_get_NSVCA_as_string (stream);
           /* The two streams have matching NSVCA, but differ in content */
           g_set_error (error,
                        MODULEMD_ERROR,
                        MMD_ERROR_VALIDATE,
                        "Encountered two streams with matching NSVCA %s but "
                        "differing content",
-                       modulemd_module_stream_get_NSVCA_as_string (stream));
+                       nsvca);
           return MD_MODULESTREAM_VERSION_ERROR;
         }
 

--- a/modulemd/tests/test_data/merger/conflict_base.yaml
+++ b/modulemd/tests/test_data/merger/conflict_base.yaml
@@ -1,0 +1,64 @@
+---
+document: modulemd
+version: 2
+data:
+  name: nodejs
+  stream: 12
+  version: 202002251200
+  context: deadbeef
+  arch: x86_64
+  summary: Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome''s JavaScript runtime for easily building
+    fast, scalable network applications. Node.js uses an event-driven, non-blocking
+    I/O model that makes it lightweight and efficient, perfect for data-intensive
+    real-time applications that run across distributed devices.
+  license:
+    module:
+    - MIT
+  dependencies:
+  - buildrequires:
+      platform: [ ]
+    requires:
+      platform: [ ]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      libuv:
+        rationale: Platform abstraction layer for Node.js
+        ref: 1
+      http-parser:
+        rationale: Needed for parsing HTTP requests
+        ref: master
+      nghttp2:
+        rationale: Needed for HTTP2 support
+        ref: master
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        ref: 10
+        buildafter:
+        - libuv
+        - http-parser
+        - nghttp2
+...


### PR DESCRIPTION
There are some released and unfixable repositories out there that
have conflicting content for the same NSVCAs. To enable libmodulemd2
to be used against those repos, log a warning and skip any such
conflicts while merging. We expressly leave the result as
undefined for that NSVCA.

https://github.com/fedora-modularity/libmodulemd/issues/459

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>