### PR TITLE
Don't check GPG keys in Fedora tests

### DIFF
--- a/.travis/coverity/Dockerfile.tmpl
+++ b/.travis/coverity/Dockerfile.tmpl
@@ -2,7 +2,7 @@ FROM fedora-modularity/libmodulemd-deps-fedora:@RELEASE@
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
-RUN dnf -y --setopt=install_weak_deps=False install rsync \
+RUN dnf -y --setopt=install_weak_deps=False --nogpgcheck install rsync \
     && dnf -y clean all
 
 ARG TARBALL

--- a/.travis/docs/Dockerfile.tmpl
+++ b/.travis/docs/Dockerfile.tmpl
@@ -2,7 +2,7 @@ FROM fedora-modularity/libmodulemd-deps-fedora:@RELEASE@
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
-RUN dnf -y --setopt=install_weak_deps=False install rsync \
+RUN dnf -y --setopt=install_weak_deps=False --nogpgcheck install rsync \
     && dnf -y clean all
 
 ARG TARBALL

--- a/.travis/fedora/Dockerfile.deps.tmpl
+++ b/.travis/fedora/Dockerfile.deps.tmpl
@@ -2,7 +2,8 @@ FROM @IMAGE@
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
-RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags=''  --skip-broken install \
+RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' \
+           --nogpgcheck --skip-broken install \
 	python3-black \
 	clang \
 	clang-analyzer \


### PR DESCRIPTION
There's always a period after Fedora branches where the keys are
wrong in the container images, which breaks the tests. Since these
are disposable containers used only for testing, just skip checking
the GPG signatures entirely to avoid this breakage.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>