### PR TITLE
CI: Fix installation of dependencies on openSUSE Tumbleweed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,4 +101,3 @@ jobs:
   allow_failures:
     - name: "Fedora rawhide x86_64"
     - name: "Fedora rawhide aarch64"
-    - name: "openSUSE tumbleweed"

--- a/.travis/opensuse/Dockerfile.deps.tmpl
+++ b/.travis/opensuse/Dockerfile.deps.tmpl
@@ -5,9 +5,9 @@ MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 RUN sed -i /etc/zypp/zypp.conf \
         -e "s/rpm.install.excludedocs = yes/rpm.install.excludedocs = no/"
 
-RUN zypper install --no-confirm --no-recommends \
+RUN zypper install --no-confirm --no-recommends --capability \
 	clang \
-	clang-checker \
+	clang-tools \
 	createrepo_c \
 	elinks \
 	file-devel \
@@ -23,9 +23,6 @@ RUN zypper install --no-confirm --no-recommends \
 	meson \
 	ninja \
 	pkgconf \
-	python-devel \
-	python-gobject \
-	python2-six \
 	python3-autopep8 \
 	python3-devel \
 	python3-GitPython \


### PR DESCRIPTION
The clang-checker packages were renamed and recently the legacy
Provides were dropped.

In addition, Python 2 is now gone from openSUSE Tumbleweed.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>