### PR TITLE
build: Make pygobject override_dir configurable

### DIFF
--- a/bindings/python/meson.build
+++ b/bindings/python/meson.build
@@ -1,3 +1,6 @@
+pygobject_override_dir = get_option('pygobject_override_dir')
+pygobject2_override_dir = get_option('py2_pygobject_override_dir')
+
 get_overridedir = '''
 import os
 import sysconfig
@@ -21,24 +24,28 @@ print(overridedir)
 '''
 
 # Python 3
-ret = run_command([python3, '-c', get_overridedir])
+if pygobject_override_dir == ''
+  ret = run_command([python3, '-c', get_overridedir])
 
-if ret.returncode() != 0
-  error('Failed to determine Python 3 pygobject overridedir')
-else
-  pygobject_override_dir = join_paths(get_option('libdir'), ret.stdout().strip())
+  if ret.returncode() != 0
+    error('Failed to determine Python 3 pygobject overridedir')
+  else
+    pygobject_override_dir = join_paths(get_option('libdir'), ret.stdout().strip())
+  endif
 endif
 
 install_data('gi/overrides/Modulemd.py', install_dir: pygobject_override_dir)
 
 # Python 2
 if with_py2
-  ret2 = run_command([python2, '-c', get_overridedir])
+  if pygobject2_override_dir == ''
+    ret2 = run_command([python2, '-c', get_overridedir])
 
-  if ret2.returncode() != 0
-    error('Failed to determine Python 2 pygobject overridedir')
-  else
-    pygobject2_override_dir = join_paths(get_option('libdir'), ret2.stdout().strip())
+    if ret2.returncode() != 0
+      error('Failed to determine Python 2 pygobject overridedir')
+    else
+      pygobject2_override_dir = join_paths(get_option('libdir'), ret2.stdout().strip())
+    endif
   endif
 
   install_data('gi/overrides/Modulemd.py', install_dir: pygobject2_override_dir)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -39,5 +39,11 @@ option('with_docs', type : 'boolean', value : true,
 option('with_manpages', type : 'feature', value : 'auto',
        description : 'Build manual pages for included executables.')
 
+option('pygobject_override_dir', type : 'string', value : '',
+       description : 'Path to Python 3 PyGObject overrides directory. Leave empty to try to determine it automatically.')
+
+option('py2_pygobject_override_dir', type : 'string', value : '',
+       description : 'Path to Python 2 PyGObject overrides directory. Leave empty to try to determine it automatically.')
+
 option('with_py2', type : 'boolean', value : false,
        description : 'Build Python 2 language bindings and run Python 2 tests.')


### PR DESCRIPTION
On systems that use different prefixes for each package like Nix or Guix, determining the path to install the PyGObject overrides will fail. Let's add a build option for setting it manually.