### PR TITLE
Make python overrides path detection more robust and allow setting them explicitly

### DIFF
--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 # This file is part of libmodulemd
 # Copyright (C) 2016 Red Hat, Inc.
 # Copyright (C) 2017-2018 Stephen Gallagher

--- a/bindings/python/meson.build
+++ b/bindings/python/meson.build
@@ -1,44 +1,23 @@
-get_overridedir = '''
-import os
-import sysconfig
-
-libdir = sysconfig.get_config_var('SCRIPTDIR')
-
-if not libdir:
-  libdir = '/usr/lib'
-
-try:
-  import gi
-  overridedir = gi._overridesdir
-except ImportError:
-  purelibdir = sysconfig.get_path('purelib')
-  overridedir = os.path.join(purelibdir, 'gi', 'overrides')
-
-if overridedir.startswith(libdir): # Should always be True..
-  overridedir = overridedir[len(libdir) + 1:]
-
-print(overridedir)
-'''
-
 # Python 3
-ret = run_command([python3, '-c', get_overridedir])
+if gobject_overrides_dir_py3 == ''
+  ret = run_command([python3, '-c', 'import gi; print(gi._overridesdir)'])
 
 if ret.returncode() != 0
   error('Failed to determine Python 3 pygobject overridedir')
 else
-  pygobject_override_dir = join_paths(get_option('libdir'), ret.stdout().strip())
+  pygobject_override_dir = ret.stdout().strip()
 endif
 
 install_data('gi/overrides/Modulemd.py', install_dir: pygobject_override_dir)
 
 # Python 2
 if with_py2
-  ret2 = run_command([python2, '-c', get_overridedir])
+  ret2 = run_command([python2, '-c', 'import gi; print(gi._overridesdir)'])
 
   if ret2.returncode() != 0
     error('Failed to determine Python 2 pygobject overridedir')
   else
-    pygobject2_override_dir = join_paths(get_option('libdir'), ret2.stdout().strip())
+    pygobject2_override_dir = ret2.stdout().strip()
   endif
 
   install_data('gi/overrides/Modulemd.py', install_dir: pygobject2_override_dir)

--- a/bindings/python/meson.build
+++ b/bindings/python/meson.build
@@ -1,24 +1,30 @@
+gobject_overrides_dir_py3 = get_option('gobject_overrides_dir_py3')
+gobject_overrides_dir_py2 = get_option('gobject_overrides_dir_py2')
+
 # Python 3
 if gobject_overrides_dir_py3 == ''
   ret = run_command([python3, '-c', 'import gi; print(gi._overridesdir)'])
 
-if ret.returncode() != 0
-  error('Failed to determine Python 3 pygobject overridedir')
-else
-  pygobject_override_dir = ret.stdout().strip()
+  if ret.returncode() != 0
+    error('Failed to determine Python 3 pygobject overridedir')
+  else
+    gobject_overrides_dir_py3 = ret.stdout().strip()
+  endif
 endif
 
-install_data('gi/overrides/Modulemd.py', install_dir: pygobject_override_dir)
+install_data('gi/overrides/Modulemd.py', install_dir: gobject_overrides_dir_py3)
 
 # Python 2
 if with_py2
-  ret2 = run_command([python2, '-c', 'import gi; print(gi._overridesdir)'])
+  if gobject_overrides_dir_py2 == ''
+    ret2 = run_command([python2, '-c', 'import gi; print(gi._overridesdir)'])
 
-  if ret2.returncode() != 0
-    error('Failed to determine Python 2 pygobject overridedir')
-  else
-    pygobject2_override_dir = ret2.stdout().strip()
+    if ret2.returncode() != 0
+      error('Failed to determine Python 2 pygobject overridedir')
+    else
+      gobject_overrides_dir_py2 = ret2.stdout().strip()
+    endif
   endif
 
-  install_data('gi/overrides/Modulemd.py', install_dir: pygobject2_override_dir)
+  install_data('gi/overrides/Modulemd.py', install_dir: gobject_overrides_dir_py2)
 endif

--- a/meson.build
+++ b/meson.build
@@ -174,3 +174,80 @@ configure_file(
 
 subdir('modulemd')
 subdir('bindings/python')
+
+if meson.version().version_compare('>=0.53')
+    if magic.found()
+        if with_libmagic.enabled()
+            magic_status = 'Enabled'
+        elif with_libmagic.auto()
+            magic_status = 'Enabled (autodetected)'
+        else
+            error('libmagic state is unknown')
+        endif
+    else
+        if with_libmagic.disabled()
+            magic_status = 'Disabled'
+        elif with_libmagic.auto()
+            magic_status = 'Disabled (autodetection could not locate libmagic)'
+        else
+            error('libmagic state is unknown')
+        endif
+    endif
+
+    if rpm.found()
+        if with_rpmio.enabled()
+            rpmio_status = 'Enabled'
+        elif with_rpmio.auto()
+            rpmio_status = 'Enabled (autodetected)'
+        else
+            error('rpmio state is unknown')
+        endif
+    else
+        if with_rpmio.disabled()
+            rpmio_status = 'Disabled'
+        elif with_rpmio.auto()
+            rpmio_status = 'Disabled (autodetection could not locate librpm)'
+        else
+            error('rpmio state is unknown')
+        endif
+    endif
+
+    if help2man.found()
+        if with_manpages.enabled()
+            manpages_status = 'Enabled'
+        elif with_manpages.auto()
+            manpages_status = 'Enabled (autodetected)'
+        else
+            error('manpages state is unknown')
+        endif
+    else
+        if with_manpages.disabled()
+            manpages_status = 'Disabled'
+        elif with_rpmio.auto()
+            manpages_status = 'Disabled (autodetection could not locate help2man)'
+        else
+            error('manpages state is unknown')
+        endif
+    endif
+
+    summary({'prefix': get_option('prefix'),
+             'bindir': get_option('bindir'),
+             'libdir': get_option('libdir'),
+             'datadir': get_option('datadir'),
+             'Python 2 GObject Overrides': gobject_overrides_dir_py2,
+             'Python 3 GObject Overrides': gobject_overrides_dir_py3
+            }, section: 'Directories')
+
+    summary({'Developer Build': get_option('developer_build'),
+             'libmagic Support': magic_status,
+             'Custom Python': get_option('python_name'),
+             'RPMIO Support': rpmio_status,
+             'Generate Manpages': manpages_status,
+             'Generate HTML Documentation': get_option('with_docs'),
+             'Python 2 Support': get_option('with_py2'),
+             'Skip Formatters': get_option('skip_formatters'),
+             'Skip Introspection': get_option('skip_introspection'),
+             'Test Dirty Git': get_option('test_dirty_git'),
+             'Test Installed Library': get_option('test_installed_lib'),
+            }, section: 'Build Configuration')
+endif

--- a/meson.build
+++ b/meson.build
@@ -82,7 +82,9 @@ endif
 
 with_manpages = get_option('with_manpages')
 help2man = find_program('help2man', required: with_manpages)
-
+if not help2man.found()
+    help2man = disabler()
+endif
 
 # Check whether this version of glib has the GDate autoptr defined
 gdate_check = '''#include <glib.h>

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -41,3 +41,9 @@ option('with_manpages', type : 'feature', value : 'auto',
 
 option('with_py2', type : 'boolean', value : false,
        description : 'Build Python 2 language bindings and run Python 2 tests.')
+
+option('gobject_overrides_dir_py2', type : 'string',
+       description : 'Path to Python 2 PyGObject overrides directory. Leave empty to determine it automatically.')
+
+option('gobject_overrides_dir_py3', type : 'string',
+       description : 'Path to Python 3 PyGObject overrides directory. Leave empty to determine it automatically.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,8 @@
 # This program is free software.
 # For more information on the license, see COPYING.
 # For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+#
+# REMEMBER TO UPDATE THE SUMMARY() IN meson.build when adding options here
 
 option('developer_build', type : 'boolean', value : true,
        description : 'Enables automatic code formatters and memory leak checks. This option should be set to FALSE for release builds.')


### PR DESCRIPTION
The original auto-detection was copied from another project and
was compatible with very old (<3.0) pygobject. Since we aren't
supporting any version that old, we can simplify the detection
and make it work for systems that don't necessarily use the
/usr/lib[64]/pythonX.Y/gi/overrides path, such as NixOS and
Guix.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

Closes #467 
