### PR TITLE
Assorted Cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,11 @@ jobs:
 
 
     - stage: Fedora x86_64
-      name: "Fedora 30 x86_64"
+      name: "Fedora 31 x86_64"
       script: ./.travis/travis-fedora.sh
       arch: amd64
 
-    - name: "Fedora 31 x86_64"
+    - name: "Fedora 32 x86_64"
       script: ./.travis/travis-fedora.sh
       arch: amd64
 
@@ -81,10 +81,10 @@ jobs:
       arch: amd64
 
     - stage: Fedora aarch64
-      name: "Fedora 30 aarch64"
+      name: "Fedora 31 aarch64"
       script: ./.travis/travis-fedora.sh
       arch: arm64
-    - name: "Fedora 31 aarch64"
+    - name: "Fedora 32 aarch64"
       script: ./.travis/travis-fedora.sh
       arch: arm64
     - name: "Fedora rawhide aarch64"

--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -45,17 +45,17 @@ class ModulemdUtil(object):
         return GLib.Variant.new_boolean(b)
 
     @staticmethod
-    def variant_list(l):
+    def variant_list(vl):
         """ Converts a list to a GLib.Variant
         """
 
         # If this is a zero-length array, handle it specially
-        if len(l) == 0:
+        if len(vl) == 0:
             return GLib.Variant.new_array(GLib.VariantType("v"))
 
         # Build the array from each entry
         builder = GLib.VariantBuilder(GLib.VariantType("a*"))
-        for item in l:
+        for item in vl:
             if item is None:
                 item = ""
             builder.add_value(ModulemdUtil.python_to_variant(item))

--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -39,9 +39,6 @@ BuildRequires:  python-gobject-base
 %endif
 BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-gobject-base
-%ifarch %{valgrind_arches}
-BuildRequires:  valgrind
-%endif
 BuildRequires:  help2man
 
 
@@ -101,7 +98,6 @@ Development files for libmodulemd.
 
 %build
 %meson -Ddeveloper_build=false \
-       -Dskip_formatters=true \
        %{meson_python_flags}
 
 %meson_build
@@ -110,15 +106,6 @@ Development files for libmodulemd.
 %check
 
 export LC_CTYPE=C.utf8
-
-%ifarch %{power64} s390x
-# Valgrind is broken on ppc64[le] with GCC7:
-# https://bugs.kde.org/show_bug.cgi?id=386945
-export MMD_SKIP_VALGRIND=1
-%endif
-%ifnarch %{valgrind_arches}
-export MMD_SKIP_VALGRIND=1
-%endif
 
 # Don't run tests on ARM for now. There are problems with
 # performance on the builders and often these time out.

--- a/libmodulemd.spec.in
+++ b/libmodulemd.spec.in
@@ -1,5 +1,4 @@
-# Python 2 is dead on F31+
-%if ( 0%{?fedora} && 0%{?fedora} <= 30 ) || ( 0%{?rhel} && 0%{?rhel} <= 7)
+%if  0%{?rhel} && 0%{?rhel} <= 7
   %global meson_python_flags -Dwith_py2=true
   %global build_python2 1
 %else

--- a/meson.build
+++ b/meson.build
@@ -245,7 +245,7 @@ if meson.version().version_compare('>=0.53')
              'Generate Manpages': manpages_status,
              'Generate HTML Documentation': get_option('with_docs'),
              'Python 2 Support': get_option('with_py2'),
-             'Skip Formatters': get_option('skip_formatters'),
+             'Skip Formatters': skip_formatters,
              'Skip Introspection': get_option('skip_introspection'),
              'Test Dirty Git': get_option('test_dirty_git'),
              'Test Installed Library': get_option('test_installed_lib'),

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -11,12 +11,15 @@
 
 # -- Configuration Options -- #
 
-developer_build = get_option('developer_build')
 test_dirty_git = get_option('test_dirty_git')
 test_installed_lib = get_option('test_installed_lib')
 skip_formatters = get_option('skip_formatters')
 skip_introspection = get_option('skip_introspection')
+developer_build = get_option('developer_build')
 
+if not developer_build
+    skip_formatters = true
+endif
 
 clang_simple_version_script = find_program ('clang_simple_version.sh')
 
@@ -42,9 +45,13 @@ else
     endif
 endif
 
-valgrind = find_program('valgrind', required: developer_build)
+if developer_build
+    valgrind = find_program('valgrind')
 
-if not valgrind.found()
+    if not valgrind.found()
+        valgrind = disabler()
+    endif
+else
     valgrind = disabler()
 endif
 


### PR DESCRIPTION
* Fix the `-Ddeveloper_build=false` behavior to match its definition in `meson_options.txt`
* Remove F30 from CI and add F32 now that the latter is released
* Fix bad variable naming in python bindings (E741) detected on Mandriva.