### PR TITLE
Update travis build scripts to use common launcher function

### DIFF
--- a/.travis/archlinux/Dockerfile.deps.tmpl
+++ b/.travis/archlinux/Dockerfile.deps.tmpl
@@ -1,4 +1,4 @@
-FROM @IMAGE@
+FROM __IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 

--- a/.travis/archlinux/Dockerfile.tmpl
+++ b/.travis/archlinux/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM fedora-modularity/libmodulemd-deps-@RELEASE@
+FROM __DEPS_IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 

--- a/.travis/centos/Dockerfile.deps.tmpl
+++ b/.travis/centos/Dockerfile.deps.tmpl
@@ -1,9 +1,9 @@
-FROM @IMAGE@
+FROM __IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
 RUN yum -y install epel-release \
-ifelse(eval(_RELEASE_ >= 8), 1, `dnl
+ifelse(eval(__RELEASE__ >= 8), 1, `dnl
     && yum -y install dnf-plugins-core \
     && yum config-manager --enable PowerTools \
 ')dnl
@@ -27,7 +27,7 @@ ifelse(eval(_RELEASE_ >= 8), 1, `dnl
 	pkgconfig \
 	python2-devel \
 	python2-six \
-ifelse(eval(_RELEASE_ < 8), 1, `dnl
+ifelse(eval(__RELEASE__ < 8), 1, `dnl
 	python-gobject-base \
 	python36-gobject-base \
 ',`dnl

--- a/.travis/centos/Dockerfile.tmpl
+++ b/.travis/centos/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM fedora-modularity/libmodulemd-deps-@RELEASE@
+FROM __DEPS_IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 

--- a/.travis/coverity/Dockerfile.tmpl
+++ b/.travis/coverity/Dockerfile.tmpl
@@ -1,9 +1,15 @@
-FROM fedora-modularity/libmodulemd-deps-fedora:@RELEASE@
+FROM __DEPS_IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
-RUN dnf -y --setopt=install_weak_deps=False --nogpgcheck install rsync \
-    && dnf -y clean all
+RUN yum -y --setopt=install_weak_deps=False --setopt=tsflags='' \
+           --nogpgcheck install \
+        rsync \
+        ruby \
+        rubygems \
+        "rubygem(json)" \
+        wget \
+    && yum -y clean all
 
 ARG TARBALL
 

--- a/.travis/coverity/travis-tasks.sh
+++ b/.travis/coverity/travis-tasks.sh
@@ -4,6 +4,17 @@
 set -e
 set -x
 
+if [ -e /usr/lib/os-release ]; then
+    source /usr/lib/os-release
+    case "${ID-unknown} ${VERSION_ID-unknown}" in
+    "centos 7")
+        COMMON_MESON_ARGS="-Dtest_dirty_git=false -Ddeveloper_build=false -Dpython_name=python3.6"
+        ;;
+    "centos "*)
+        COMMON_MESON_ARGS="-Dtest_dirty_git=false -Ddeveloper_build=false"
+        ;;
+    esac
+fi
 
 pushd /builddir/
 

--- a/.travis/docs/Dockerfile.tmpl
+++ b/.travis/docs/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM fedora-modularity/libmodulemd-deps-fedora:@RELEASE@
+FROM __DEPS_IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 

--- a/.travis/fedora/Dockerfile.deps.tmpl
+++ b/.travis/fedora/Dockerfile.deps.tmpl
@@ -1,4 +1,4 @@
-FROM @IMAGE@
+FROM __IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 

--- a/.travis/fedora/Dockerfile.tmpl
+++ b/.travis/fedora/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM fedora-modularity/libmodulemd-deps-@RELEASE@
+FROM __DEPS_IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 

--- a/.travis/mageia/Dockerfile.deps.tmpl
+++ b/.travis/mageia/Dockerfile.deps.tmpl
@@ -1,4 +1,4 @@
-FROM @IMAGE@
+FROM __IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 

--- a/.travis/mageia/Dockerfile.tmpl
+++ b/.travis/mageia/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM fedora-modularity/libmodulemd-deps-@RELEASE@
+FROM __DEPS_IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 

--- a/.travis/openmandriva/Dockerfile.deps.tmpl
+++ b/.travis/openmandriva/Dockerfile.deps.tmpl
@@ -1,4 +1,4 @@
-FROM @IMAGE@
+FROM __IMAGE__
 
 MAINTAINER Tomasz Paweł Gajc <tpgxyz@gmail.com>
 

--- a/.travis/openmandriva/Dockerfile.tmpl
+++ b/.travis/openmandriva/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM fedora-modularity/libmodulemd-deps-@RELEASE@
+FROM __DEPS_IMAGE__
 
 MAINTAINER Tomasz Paweł Gajc <tpgxyz@gmail.com>
 

--- a/.travis/opensuse/Dockerfile.deps.tmpl
+++ b/.travis/opensuse/Dockerfile.deps.tmpl
@@ -1,4 +1,4 @@
-FROM @IMAGE@
+FROM __IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 

--- a/.travis/opensuse/Dockerfile.tmpl
+++ b/.travis/opensuse/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM fedora-modularity/libmodulemd-deps-@RELEASE@
+FROM __DEPS_IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 

--- a/.travis/travis-common.inc
+++ b/.travis/travis-common.inc
@@ -43,7 +43,7 @@ function common_finalize {
 
     rm -f $MMD_TARBALL_PATH \
           $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE \
-          $SCRIPT_DIR/$MMD_OS/Dockerfile-$MMD_RELEASE
+          $SCRIPT_DIR/$MMD_OS/Dockerfile.test.$MMD_RELEASE
 
     return $exitcode
 }
@@ -53,6 +53,9 @@ trap common_finalize EXIT
 
 function mmd_run_docker_tests {
     local os release repository image
+    local deps_template deps_image
+    local test_template test_image
+    local oci_extra_args
     local "${@}"
 
     if [ -z $SCRIPT_DIR ]; then
@@ -64,12 +67,15 @@ function mmd_run_docker_tests {
     release=${release-rawhide}
     repository=${repository-registry.fedoraproject.org}
 
-
     # Lower-case the os and release for the container registry
     MMD_OS=${os,,}
     MMD_RELEASE=${release,,}
-
     image=${image-$MMD_OS:$MMD_RELEASE}
+
+    deps_template=${deps_template-$MMD_OS/Dockerfile.deps.tmpl}
+    test_template=${test_template-$MMD_OS/Dockerfile.tmpl}
+    deps_image=${deps_image-libmodulemd-deps-$MMD_OS:$MMD_RELEASE}
+    test_image=${test_image-libmodulemd-$MMD_OS:$MMD_RELEASE}
 
     # Create an archive of the current checkout
     MMD_TARBALL_PATH=`mktemp -p $SCRIPT_DIR tarball-XXXXXX.tar.bz2`
@@ -79,23 +85,30 @@ function mmd_run_docker_tests {
     git ls-files |xargs tar cfj $MMD_TARBALL_PATH .git
     popd
 
-    sed -e "s#@IMAGE@#$repository/$image#" $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.tmpl \
-        | m4 -D_RELEASE_=$release \
+    m4  -D__IMAGE__="$repository/$image" \
+        -D__OS__=$os \
+        -D__RELEASE__=$release \
+        $SCRIPT_DIR/${deps_template} \
         > $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE
-    sed -e "s/@RELEASE@/$MMD_OS:$MMD_RELEASE/" $SCRIPT_DIR/$MMD_OS/Dockerfile.tmpl \
-        | m4 -D_RELEASE_=$release \
-        > $SCRIPT_DIR/$MMD_OS/Dockerfile-$MMD_RELEASE
+
+    m4  -D__DEPS_IMAGE__="fedora-modularity/${deps_image}" \
+        -D__OS__=$os \
+        -D__RELEASE__=$release \
+        $SCRIPT_DIR/${test_template} \
+        > $SCRIPT_DIR/$MMD_OS/Dockerfile.test.$MMD_RELEASE
 
     $MMD_BUILDAH $MMD_LAYERS_TRUE \
         -f $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE \
-        -t fedora-modularity/libmodulemd-deps-$MMD_OS:$MMD_RELEASE .
+        -t fedora-modularity/${deps_image} .
 
     $MMD_BUILDAH $MMD_LAYERS_FALSE \
-        -f $SCRIPT_DIR/$MMD_OS/Dockerfile-$MMD_RELEASE \
-        -t fedora-modularity/libmodulemd-$MMD_OS:$MMD_RELEASE \
+        -f $SCRIPT_DIR/$MMD_OS/Dockerfile.test.$MMD_RELEASE \
+        -t fedora-modularity/${test_image} \
         --build-arg TARBALL=${TARBALL} .
 
-    $MMD_OCI run --rm fedora-modularity/libmodulemd-$MMD_OS:$MMD_RELEASE
+    eval $MMD_OCI run \
+        ${oci_extra_args} \
+        --rm fedora-modularity/${test_image}
 }
 
 set +x

--- a/.travis/travis-coverity.sh
+++ b/.travis/travis-coverity.sh
@@ -8,58 +8,21 @@ source $SCRIPT_DIR/travis-common.inc
 set -e
 set -x
 
-function coverity_finalize {
-    exitcode=$?
+os=centos
+release=8
+repository=docker.io
 
-    # Make sure to delete the Dockerfile.deps from fedora
-    rm -f $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE
+# Override the standard tests with the Coverity scan
+mmd_run_docker_tests \
+    os=$os \
+    release=$release \
+    repository=$repository \
+    test_template="coverity/Dockerfile.tmpl" \
+    test_image="libmodulemd-coverity" \
+    oci_extra_args="
+        -e COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN
+        -e TRAVIS=$TRAVIS
+        -e TRAVIS_COMMIT='$TRAVIS_COMMIT'
+    "
 
-    common_finalize
-
-    return $exitcode
-}
-
-trap coverity_finalize EXIT
-
-# Always run the Coverity scan on the oldest supported Fedora
-# because it generally lags behind with GCC compatibility.
-MMD_OS=fedora
-MMD_RELEASE=31
-MMD_IMAGE=fedora/fedora:${MMD_RELEASE}-$(uname -m)
-repository="quay.io"
-
-# Create an archive of the current checkout
-MMD_TARBALL_PATH=`mktemp -p $SCRIPT_DIR tarball-XXXXXX.tar.bz2`
-TARBALL=`basename $MMD_TARBALL_PATH`
-
-pushd $SCRIPT_DIR/..
-git ls-files |xargs tar cfj $MMD_TARBALL_PATH .git
-popd
-
-sed -e "s#@IMAGE@#$repository/${MMD_IMAGE}#" \
-    $SCRIPT_DIR/fedora/Dockerfile.deps.tmpl > $SCRIPT_DIR/coverity/Dockerfile.deps.$MMD_RELEASE
-
-sed -e "s#@RELEASE@#${MMD_RELEASE}#" $SCRIPT_DIR/coverity/Dockerfile.tmpl \
-    | m4 -D_RELEASE_=$release \
-    > $SCRIPT_DIR/coverity/Dockerfile-$MMD_RELEASE
-
-$RETRY_CMD $MMD_BUILDAH $MMD_LAYERS_TRUE \
-    -f $SCRIPT_DIR/coverity/Dockerfile.deps.$MMD_RELEASE \
-    -t fedora-modularity/libmodulemd-deps-$MMD_OS:$MMD_RELEASE .
-
-$RETRY_CMD $MMD_BUILDAH $MMD_LAYERS_FALSE \
-    -f $SCRIPT_DIR/coverity/Dockerfile-$MMD_RELEASE \
-    -t fedora-modularity/libmodulemd-coverity \
-    --build-arg TARBALL=$TARBALL .
-
-rm -f $MMD_TARBALL_PATH $SCRIPT_DIR/fedora/Dockerfile.deps.$MMD_RELEASE $SCRIPT_DIR/fedora/Dockerfile-$MMD_RELEASE
-
-# Override the standard tasks with the Coverity scan
-$RETRY_CMD $MMD_OCI run \
-    -e COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN \
-    -e TRAVIS=$TRAVIS \
-    -e TRAVIS_COMMIT="$TRAVIS_COMMIT" \
-    --rm fedora-modularity/libmodulemd-coverity
-
-popd
-
+popd # $SCRIPT_DIR


### PR DESCRIPTION
This enhances the travis build scripts and Dockerfile templates so that the common `mmd_run_docker_tests()` launcher function can also launch the Coverity scan.

This enhancement made it a simple matter to switch the Coverity scan to run on CentOS 8 instead of Fedora.

The travis document generation script was also able to take advantage of this enhancement.
