### PR TITLE
Add BuildConfig object

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-module-stream.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-stream.h
@@ -30,6 +30,16 @@ G_BEGIN_DECLS
  */
 
 /**
+ * MMD_MAXCONTEXTLEN:
+ *
+ * The ModuleStream v3 specification defines the maximum lenth of the context
+ * field.
+ *
+ * Since: 2.10
+ */
+#define MMD_MAXCONTEXTLEN 10
+
+/**
  * ModulemdModuleStreamVersionEnum:
  * @MD_MODULESTREAM_VERSION_ERROR: Represents an error handling module stream
  * version.

--- a/modulemd/include/private/modulemd-build-config.h
+++ b/modulemd/include/private/modulemd-build-config.h
@@ -1,0 +1,330 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#pragma once
+
+#include <glib-object.h>
+#include "modulemd-2.0/modulemd-buildopts.h"
+#include "private/modulemd-yaml.h"
+
+G_BEGIN_DECLS
+
+/**
+ * SECTION: modulemd-build-config
+ * @title: Modulemd.BuildConfig
+ * @stability: private
+ * @short_description: Internal representation of a module build configuration
+ */
+
+#define MODULEMD_TYPE_BUILD_CONFIG (modulemd_build_config_get_type ())
+
+G_DECLARE_FINAL_TYPE (
+  ModulemdBuildConfig, modulemd_build_config, MODULEMD, BUILD_CONFIG, GObject)
+
+
+/**
+ * modulemd_build_config_new:
+ *
+ * Initialize a new #ModulemdBuildConfig representing a module build
+ * configuration.
+ *
+ * Since: 2.10
+ */
+ModulemdBuildConfig *
+modulemd_build_config_new (void);
+
+
+/**
+ * modulemd_build_config_set_context:
+ * @self: This #ModulemdBuildConfig object.
+ * @context: A string of up to ten alphanumeric characters.
+ *
+ * Set the context that this build configuration produces.
+ *
+ * Note: For consistency in the API, this function does not validate the input
+ * @context. This validation will be performed as part of the
+ * modulemd_build_config_validate() routine where it can be reported cleanly.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_build_config_set_context (ModulemdBuildConfig *self,
+                                   const gchar *context);
+
+
+/**
+ * modulemd_build_config_get_context:
+ * @self: This #ModulemdBuildConfig object.
+ *
+ * Get the context that this build configuration produces.
+ *
+ * Note: This function returns the context as stored internally. If you want to
+ * be sure that it is in the correct format, call
+ * modulemd_build_config_validate() first.
+ *
+ * Returns: (transfer none): The string representing the context that this
+ * build configuration produces.
+ *
+ * Since: 2.10
+ */
+const gchar *
+modulemd_build_config_get_context (ModulemdBuildConfig *self);
+
+
+/**
+ * modulemd_build_config_set_platform:
+ * @self: This #ModulemdBuildConfig object.
+ * @platform: A string of up to ten alphanumeric characters.
+ *
+ * Set the platform that this build configuration applies to.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_build_config_set_platform (ModulemdBuildConfig *self,
+                                    const gchar *platform);
+
+
+/**
+ * modulemd_build_config_get_platform:
+ * @self: This #ModulemdBuildConfig object.
+ *
+ * Get the platform that this build configuration applies to.
+ *
+ * Returns: (transfer none): The string representing the platform that this
+ * build configuration applies to.
+ *
+ * Since: 2.10
+ */
+const gchar *
+modulemd_build_config_get_platform (ModulemdBuildConfig *self);
+
+
+/**
+ * modulemd_build_config_add_runtime_requirement:
+ * @self: (in): This #ModulemdBuildConfig object.
+ * @module_name: (in): The name of the module to depend on.
+ * @stream_name: (in): The name of the module stream to depend on.
+ *
+ * Add a build-time dependency for this module.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_build_config_add_runtime_requirement (ModulemdBuildConfig *self,
+                                               const gchar *module_name,
+                                               const gchar *stream_name);
+
+
+/**
+ * modulemd_build_config_remove_runtime_requirement:
+ * @self: (in): This #ModulemdBuildConfig object.
+ * @module_name: (in): The name of the module to be removed.
+ *
+ * Remove a run-time dependency for this module.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_build_config_remove_runtime_requirement (ModulemdBuildConfig *self,
+                                                  const gchar *module_name);
+
+
+/**
+ * modulemd_build_config_clear_runtime_requirements
+ * @self: (in): This #ModulemdBuildConfig object.
+ *
+ * Remove all run-time dependencies for this module.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_build_config_clear_runtime_requirements (ModulemdBuildConfig *self);
+
+
+/**
+ * modulemd_build_config_get_runtime_requirement_stream:
+ * @self: (in): This #ModulemdBuildConfig object.
+ * @module_name: (in): The name of the module this module depends on.
+ *
+ * Returns: (transfer none): The name of the stream matching this module name
+ * in the run-time dependencies.
+ *
+ * Since: 2.10
+ */
+const gchar *
+modulemd_build_config_get_runtime_requirement_stream (
+  ModulemdBuildConfig *self, const gchar *module_name);
+
+
+/**
+ * modulemd_build_config_get_runtime_modules_as_strv:
+ * @self: (in): This #ModulemdBuildConfig object.
+ *
+ * Returns: (transfer full): An ordered #GStrv list of module names that this
+ * module depends on at run-time.
+ *
+ * Since: 2.10
+ */
+GStrv
+modulemd_build_config_get_runtime_modules_as_strv (ModulemdBuildConfig *self);
+
+
+/**
+ * modulemd_build_config_add_buildtime_requirement:
+ * @self: (in): This #ModulemdBuildConfig object.
+ * @module_name: (in): The name of the module to depend on.
+ * @stream_name: (in): The name of the module stream to depend on.
+ *
+ * Add a build-time dependency for this module.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_build_config_add_buildtime_requirement (ModulemdBuildConfig *self,
+                                                 const gchar *module_name,
+                                                 const gchar *stream_name);
+
+
+/**
+ * modulemd_build_config_remove_buildtime_requirement:
+ * @self: (in): This #ModulemdBuildConfig object.
+ * @module_name: (in): The name of the module to be removed.
+ *
+ * Remove a build-time dependency for this module.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_build_config_remove_buildtime_requirement (ModulemdBuildConfig *self,
+                                                    const gchar *module_name);
+
+
+/**
+ * modulemd_build_config_clear_buildtime_requirements
+ * @self: (in): This #ModulemdBuildConfig object.
+ *
+ * Remove all build-time dependencies for this module.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_build_config_clear_buildtime_requirements (ModulemdBuildConfig *self);
+
+
+/**
+ * modulemd_build_config_get_buildtime_requirement_stream:
+ * @self: (in): This #ModulemdBuildConfig object.
+ * @module_name: (in): The name of the module this module depends on.
+ *
+ * Returns: (transfer none): The name of the stream matching this module name
+ * in the build-time dependencies.
+ *
+ * Since: 2.10
+ */
+const gchar *
+modulemd_build_config_get_buildtime_requirement_stream (
+  ModulemdBuildConfig *self, const gchar *module_name);
+
+
+/**
+ * modulemd_build_config_get_buildtime_modules_as_strv:
+ * @self: (in): This #ModulemdBuildConfig object.
+ *
+ * Returns: (transfer full): An ordered #GStrv list of module names that this
+ * module depends on at build-time.
+ *
+ * Since: 2.10
+ */
+GStrv
+modulemd_build_config_get_buildtime_modules_as_strv (
+  ModulemdBuildConfig *self);
+
+
+/**
+ * modulemd_build_config_set_buildopts:
+ * @self: (in): This #ModulemdBuildConfig object.
+ * @buildopts: (in) (transfer none): A #ModulemdBuildopts object describing
+ * build options that apply globally to components in this module.
+ *
+ * Set build options for this module's components.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_build_config_set_buildopts (ModulemdBuildConfig *self,
+                                     ModulemdBuildopts *buildopts);
+
+
+/**
+ * modulemd_build_config_get_buildopts:
+ * @self: (in): This #ModulemdBuildConfig object.
+ *
+ * Returns: (transfer none): The build options for this module's components.
+ *
+ * Since: 2.10
+ */
+ModulemdBuildopts *
+modulemd_build_config_get_buildopts (ModulemdBuildConfig *self);
+
+
+/**
+ * modulemd_build_config_parse_yaml:
+ * @parser: A #yaml_parser_t positioned at the start of a configuration
+ * entry of a ModulemdPackager v3 YAML document.
+ * @strict: Whether to ignore unknown keys in the YAML
+ * @error: (out): A #GError explaining any failure to complete the parsing
+ *
+ * Returns: (transfer full): A newly-constructed #ModulemdBuildConfig object
+ * populated from the data in the provided YAML. Returns NULL and sets @error
+ * appropriately if the document couldn't be parsed successfully or failed
+ * validation.
+ *
+ * Since: 2.10
+ */
+ModulemdBuildConfig *
+modulemd_build_config_parse_yaml (yaml_parser_t *parser,
+                                  gboolean strict,
+                                  GError **error);
+
+
+/**
+ * modulemd_build_config_validate:
+ * @self: (in): This #ModulemdBuildConfig object.
+ * @error: (out): A #GError explaining any validation failure.
+ *
+ * Determine if this #ModulemdBuildConfig is valid according to the YAML
+ * specification.
+ *
+ * Returns: TRUE if validation passes. Returns FALSE and sets @error
+ * appropriately on validation failure.
+ *
+ * Since: 2.10
+ */
+
+gboolean
+modulemd_build_config_validate (ModulemdBuildConfig *buildconfig,
+                                GError **error);
+
+
+/**
+ * modulemd_build_config_copy:
+ * @self: (in): This #ModulemdBuildConfig object
+ *
+ * Returns: (transfer full): A deep copy of @self
+ *
+ * Since: 2.10
+ */
+ModulemdBuildConfig *
+modulemd_build_config_copy (ModulemdBuildConfig *self);
+G_END_DECLS

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -59,6 +59,7 @@ endif
 
 modulemd_srcs = files(
     'modulemd.c',
+    'modulemd-build-config.c',
     'modulemd-buildopts.c',
     'modulemd-component.c',
     'modulemd-component-module.c',
@@ -119,6 +120,7 @@ modulemd_hdrs = files(
 
 modulemd_priv_hdrs = files(
     'include/private/glib-extensions.h',
+    'include/private/modulemd-build-config.h',
     'include/private/modulemd-buildopts-private.h',
     'include/private/modulemd-component-private.h',
     'include/private/modulemd-component-module-private.h',
@@ -297,6 +299,7 @@ test_utils_lib = library(
 )
 
 c_tests = {
+'buildconfig'         : [ 'tests/test-modulemd-build-config.c' ],
 'buildopts'           : [ 'tests/test-modulemd-buildopts.c' ],
 'common'              : [ 'tests/test-modulemd-common.c' ],
 'component_module'    : [ 'tests/test-modulemd-component-module.c' ],

--- a/modulemd/modulemd-build-config.c
+++ b/modulemd/modulemd-build-config.c
@@ -1,0 +1,491 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#include "modulemd-2.0/modulemd-buildopts.h"
+#include "modulemd-2.0/modulemd-errors.h"
+#include "modulemd-2.0/modulemd-module-stream.h"
+
+#include "private/modulemd-build-config.h"
+#include "private/modulemd-buildopts-private.h"
+#include "private/modulemd-util.h"
+#include "private/modulemd-yaml.h"
+
+struct _ModulemdBuildConfig
+{
+  GObject parent_instance;
+
+  gchar *context;
+  gchar *platform;
+  GHashTable *requires; /* hashtable<string, string> */
+  GHashTable *buildrequires; /* hashtable<string, string> */
+  ModulemdBuildopts *buildopts;
+};
+
+G_DEFINE_TYPE (ModulemdBuildConfig, modulemd_build_config, G_TYPE_OBJECT)
+
+ModulemdBuildConfig *
+modulemd_build_config_new (void)
+{
+  return g_object_new (MODULEMD_TYPE_BUILD_CONFIG, NULL);
+}
+
+static void
+modulemd_build_config_finalize (GObject *object)
+{
+  ModulemdBuildConfig *self = (ModulemdBuildConfig *)object;
+
+  g_clear_pointer (&self->context, g_free);
+  g_clear_pointer (&self->platform, g_free);
+  g_clear_pointer (&self->requires, g_hash_table_unref);
+  g_clear_pointer (&self->buildrequires, g_hash_table_unref);
+  g_clear_object (&self->buildopts);
+
+  G_OBJECT_CLASS (modulemd_build_config_parent_class)->finalize (object);
+}
+
+static void
+modulemd_build_config_class_init (ModulemdBuildConfigClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = modulemd_build_config_finalize;
+}
+
+static void
+modulemd_build_config_init (ModulemdBuildConfig *self)
+{
+  self->requires =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  self->buildrequires =
+    g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+}
+
+
+void
+modulemd_build_config_set_context (ModulemdBuildConfig *self,
+                                   const gchar *context)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+
+  g_clear_pointer (&self->context, g_free);
+
+  if (context)
+    {
+      self->context = g_strdup (context);
+    }
+}
+
+
+const gchar *
+modulemd_build_config_get_context (ModulemdBuildConfig *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self), NULL);
+
+  return self->context;
+}
+
+
+void
+modulemd_build_config_set_platform (ModulemdBuildConfig *self,
+                                    const gchar *platform)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+
+  g_clear_pointer (&self->platform, g_free);
+
+  if (platform)
+    {
+      self->platform = g_strdup (platform);
+    }
+}
+
+
+const gchar *
+modulemd_build_config_get_platform (ModulemdBuildConfig *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self), NULL);
+
+  return self->platform;
+}
+
+
+void
+modulemd_build_config_add_runtime_requirement (ModulemdBuildConfig *self,
+                                               const gchar *module_name,
+                                               const gchar *stream_name)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+  g_return_if_fail (module_name && stream_name);
+
+  g_hash_table_replace (
+    self->requires, g_strdup (module_name), g_strdup (stream_name));
+}
+
+
+void
+modulemd_build_config_remove_runtime_requirement (ModulemdBuildConfig *self,
+                                                  const gchar *module_name)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+  g_return_if_fail (module_name);
+
+  g_hash_table_remove (self->requires, module_name);
+}
+
+
+void
+modulemd_build_config_clear_runtime_requirements (ModulemdBuildConfig *self)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+
+  g_hash_table_remove_all (self->requires);
+}
+
+
+const gchar *
+modulemd_build_config_get_runtime_requirement_stream (
+  ModulemdBuildConfig *self, const gchar *module_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self), NULL);
+
+  return g_hash_table_lookup (self->requires, module_name);
+}
+
+
+GStrv
+modulemd_build_config_get_runtime_modules_as_strv (ModulemdBuildConfig *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->requires);
+}
+
+
+void
+modulemd_build_config_add_buildtime_requirement (ModulemdBuildConfig *self,
+                                                 const gchar *module_name,
+                                                 const gchar *stream_name)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+  g_return_if_fail (module_name && stream_name);
+
+  g_hash_table_replace (
+    self->buildrequires, g_strdup (module_name), g_strdup (stream_name));
+}
+
+
+void
+modulemd_build_config_remove_buildtime_requirement (ModulemdBuildConfig *self,
+                                                    const gchar *module_name)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+  g_return_if_fail (module_name);
+
+  g_hash_table_remove (self->buildrequires, module_name);
+}
+
+
+void
+modulemd_build_config_clear_buildtime_requirements (ModulemdBuildConfig *self)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+
+  g_hash_table_remove_all (self->buildrequires);
+}
+
+
+const gchar *
+modulemd_build_config_get_buildtime_requirement_stream (
+  ModulemdBuildConfig *self, const gchar *module_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self), NULL);
+
+  return g_hash_table_lookup (self->buildrequires, module_name);
+}
+
+
+GStrv
+modulemd_build_config_get_buildtime_modules_as_strv (ModulemdBuildConfig *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->buildrequires);
+}
+
+
+void
+modulemd_build_config_set_buildopts (ModulemdBuildConfig *self,
+                                     ModulemdBuildopts *buildopts)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+
+  g_clear_object (&self->buildopts);
+  if (buildopts)
+    {
+      self->buildopts = modulemd_buildopts_copy (buildopts);
+    }
+}
+
+
+ModulemdBuildopts *
+modulemd_build_config_get_buildopts (ModulemdBuildConfig *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self), NULL);
+
+  return self->buildopts;
+}
+
+
+static void
+modulemd_build_config_replace_runtime_deps (ModulemdBuildConfig *self,
+                                            GHashTable *deps);
+static void
+modulemd_build_config_replace_buildtime_deps (ModulemdBuildConfig *self,
+                                              GHashTable *deps);
+
+
+ModulemdBuildConfig *
+modulemd_build_config_parse_yaml (yaml_parser_t *parser,
+                                  gboolean strict,
+                                  GError **error)
+{
+  MODULEMD_INIT_TRACE ();
+  MMD_INIT_YAML_EVENT (event);
+  gboolean done = FALSE;
+  g_autoptr (ModulemdBuildConfig) buildconfig = NULL;
+  g_autoptr (ModulemdBuildopts) buildopts = NULL;
+  g_autoptr (GError) nested_error = NULL;
+  g_autoptr (GHashTable) deptable = NULL;
+
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  buildconfig = modulemd_build_config_new ();
+
+  /* Read in attributes of this config */
+  while (!done)
+    {
+      YAML_PARSER_PARSE_WITH_EXIT (parser, &event, error);
+
+      switch (event.type)
+        {
+        case YAML_MAPPING_END_EVENT: done = TRUE; break;
+
+        case YAML_SCALAR_EVENT:
+          if (g_str_equal (event.data.scalar.value, "context"))
+            MMD_SET_PARSED_YAML_STRING (
+              parser, error, modulemd_build_config_set_context, buildconfig);
+
+          else if (g_str_equal (event.data.scalar.value, "platform"))
+            MMD_SET_PARSED_YAML_STRING (
+              parser, error, modulemd_build_config_set_platform, buildconfig);
+
+          else if (g_str_equal ((const gchar *)event.data.scalar.value,
+                                "buildrequires"))
+            {
+              deptable =
+                modulemd_yaml_parse_string_string_map (parser, &nested_error);
+              if (!deptable)
+                {
+                  g_propagate_error (error, g_steal_pointer (&nested_error));
+                  return FALSE;
+                }
+              modulemd_build_config_replace_buildtime_deps (buildconfig,
+                                                            deptable);
+              g_clear_pointer (&deptable, g_hash_table_unref);
+            }
+
+          else if (g_str_equal ((const gchar *)event.data.scalar.value,
+                                "requires"))
+            {
+              deptable =
+                modulemd_yaml_parse_string_string_map (parser, &nested_error);
+              if (!deptable)
+                {
+                  g_propagate_error (error, g_steal_pointer (&nested_error));
+                  return FALSE;
+                }
+              modulemd_build_config_replace_runtime_deps (buildconfig,
+                                                          deptable);
+              g_clear_pointer (&deptable, g_hash_table_unref);
+            }
+
+          else if (g_str_equal ((const gchar *)event.data.scalar.value,
+                                "buildopts"))
+            {
+              buildopts =
+                modulemd_buildopts_parse_yaml (parser, strict, &nested_error);
+              if (!buildopts)
+                {
+                  g_propagate_error (error, g_steal_pointer (&nested_error));
+                  return NULL;
+                }
+
+              modulemd_build_config_set_buildopts (buildconfig, buildopts);
+              g_clear_object (&buildopts);
+            }
+
+          else
+            {
+              SKIP_UNKNOWN (parser,
+                            FALSE,
+                            "Unexpected key in build config: %s",
+                            (const gchar *)event.data.scalar.value);
+              break;
+            }
+
+          break;
+
+        default:
+          MMD_YAML_ERROR_EVENT_EXIT (
+            error, event, "Unexpected YAML event in profile");
+          break;
+        }
+      yaml_event_delete (&event);
+    }
+
+  /* Validate the input */
+  if (!modulemd_build_config_validate (buildconfig, &nested_error))
+    {
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return NULL;
+    }
+
+  return g_steal_pointer (&buildconfig);
+}
+
+
+static void
+modulemd_build_config_replace_runtime_deps (ModulemdBuildConfig *self,
+                                            GHashTable *deps)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+
+  if (deps)
+    {
+      g_hash_table_unref (self->requires);
+      self->requires = modulemd_hash_table_deep_str_copy (deps);
+    }
+  else
+    {
+      g_hash_table_remove_all (self->requires);
+    }
+}
+
+
+static void
+modulemd_build_config_replace_buildtime_deps (ModulemdBuildConfig *self,
+                                              GHashTable *deps)
+{
+  g_return_if_fail (MODULEMD_IS_BUILD_CONFIG (self));
+
+  if (deps)
+    {
+      g_hash_table_unref (self->buildrequires);
+      self->buildrequires = modulemd_hash_table_deep_str_copy (deps);
+    }
+  else
+    {
+      g_hash_table_remove_all (self->buildrequires);
+    }
+}
+
+
+gboolean
+modulemd_build_config_validate (ModulemdBuildConfig *buildconfig,
+                                GError **error)
+{
+  gsize i;
+
+  /* Context must be present and be between 1 and MMD_MAXCONTEXTLEN
+   * alphanumeric characters
+   */
+  if (buildconfig->context == NULL || buildconfig->context[0] == '\0')
+    {
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   MMD_ERROR_VALIDATE,
+                   "Empty context in BuildConfig");
+      return FALSE;
+    }
+
+  for (i = 0; i < MMD_MAXCONTEXTLEN; i++)
+    {
+      if (buildconfig->context[i] == '\0')
+        break;
+
+      if (!(g_ascii_isalnum (buildconfig->context[i])))
+        {
+          g_set_error (error,
+                       MODULEMD_ERROR,
+                       MMD_ERROR_VALIDATE,
+                       "Non-alphanumeric character in BuildConfig context");
+          return FALSE;
+        }
+    }
+
+  if (buildconfig->context[i] != '\0')
+    {
+      /* We passed the maximum length without encountering a
+       * NULL-terminator
+       */
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   MMD_ERROR_VALIDATE,
+                   "BuildConfig context exceeds maximum characters");
+      return FALSE;
+    }
+
+  /* The platform value must be set.
+   * In the future, we should probably validate its contents, but this is
+   * not currently defined in the specification.
+   */
+
+  if (!buildconfig->platform)
+    {
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   MMD_ERROR_VALIDATE,
+                   "Unset platform in BuildConfig");
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+
+ModulemdBuildConfig *
+modulemd_build_config_copy (ModulemdBuildConfig *self)
+{
+  g_autoptr (ModulemdBuildConfig) copy = modulemd_build_config_new ();
+
+  modulemd_build_config_set_context (copy,
+                                     modulemd_build_config_get_context (self));
+  modulemd_build_config_set_platform (
+    copy, modulemd_build_config_get_platform (self));
+
+  if (self->requires)
+    {
+      copy->requires = modulemd_hash_table_deep_str_copy (self->requires);
+    }
+
+  if (self->buildrequires)
+    {
+      copy->buildrequires =
+        modulemd_hash_table_deep_str_copy (self->buildrequires);
+    }
+
+  modulemd_build_config_set_buildopts (
+    copy, modulemd_build_config_get_buildopts (self));
+
+  return g_steal_pointer (&copy);
+}

--- a/modulemd/modulemd-docs.xml
+++ b/modulemd/modulemd-docs.xml
@@ -62,6 +62,7 @@
     </chapter>
     <chapter>
       <title>Modulemd 2.0 Private Object Methods</title>
+       <xi:include href="xml/modulemd-build-config.xml"/>
        <xi:include href="xml/modulemd-buildopts-private.xml"/>
        <xi:include href="xml/modulemd-component-private.xml"/>
        <xi:include href="xml/modulemd-component-module-private.xml"/>

--- a/modulemd/tests/test-modulemd-build-config.c
+++ b/modulemd/tests/test-modulemd-build-config.c
@@ -1,0 +1,733 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <locale.h>
+#include <signal.h>
+
+#include "private/glib-extensions.h"
+#include "private/modulemd-build-config.h"
+#include "private/modulemd-yaml.h"
+#include "private/test-utils.h"
+
+
+static void
+buildconfig_test_construct (void)
+{
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  g_auto (GStrv) requires = NULL;
+
+
+  /* == Test that the new() function works == */
+  bc = modulemd_build_config_new ();
+  g_assert_nonnull (bc);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc));
+
+
+  /* == Verify that it is constructed properly == */
+
+  /* context should be NULL */
+  g_assert_null (modulemd_build_config_get_context (bc));
+
+  /* platform should be NULL */
+  g_assert_null (modulemd_build_config_get_platform (bc));
+
+  /* runtime requires should be empty */
+  requires = modulemd_build_config_get_runtime_modules_as_strv (bc);
+  g_assert_nonnull (requires);
+  g_assert_null (requires[0]);
+  g_clear_pointer (&requires, g_strfreev);
+
+  /* buildtime requires should be empty */
+  requires = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+  g_assert_nonnull (requires);
+  g_assert_null (requires[0]);
+  g_clear_pointer (&requires, g_strfreev);
+
+  /* There should be no associated build options */
+  g_assert_null (modulemd_build_config_get_buildopts (bc));
+}
+
+
+static void
+buildconfig_test_context (void)
+{
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+
+  bc = modulemd_build_config_new ();
+  g_assert_nonnull (bc);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc));
+
+  /* context should be NULL */
+  g_assert_null (modulemd_build_config_get_context (bc));
+
+  /* Set a context value */
+  modulemd_build_config_set_context (bc, "CTX1");
+
+  /* Verify that we can retrieve this value */
+  g_assert_nonnull (modulemd_build_config_get_context (bc));
+  g_assert_cmpstr ("CTX1", ==, modulemd_build_config_get_context (bc));
+
+  /* Unset the context */
+  modulemd_build_config_set_context (bc, NULL);
+
+  /* context should be NULL */
+  g_assert_null (modulemd_build_config_get_context (bc));
+}
+
+
+static void
+buildconfig_test_platform (void)
+{
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+
+  bc = modulemd_build_config_new ();
+  g_assert_nonnull (bc);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc));
+
+  /* platform should be NULL */
+  g_assert_null (modulemd_build_config_get_platform (bc));
+
+  /* Set a platform value */
+  modulemd_build_config_set_platform (bc, "f33");
+
+  /* Verify that we can retrieve this value */
+  g_assert_nonnull (modulemd_build_config_get_platform (bc));
+  g_assert_cmpstr ("f33", ==, modulemd_build_config_get_platform (bc));
+
+  /* Unset the platform */
+  modulemd_build_config_set_platform (bc, NULL);
+
+  /* platform should be NULL */
+  g_assert_null (modulemd_build_config_get_platform (bc));
+}
+
+
+static void
+buildconfig_test_requires (void)
+{
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  g_auto (GStrv) required_modules = NULL;
+
+
+  bc = modulemd_build_config_new ();
+  g_assert_nonnull (bc);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc));
+
+  /* Add a runtime requirement */
+  modulemd_build_config_add_runtime_requirement (bc, "framework", "1.0");
+
+  /* Confirm that it was added */
+  required_modules = modulemd_build_config_get_runtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_nonnull (required_modules[0]);
+  g_assert_cmpstr ("framework", ==, required_modules[0]);
+  g_assert_cmpstr (
+    "1.0",
+    ==,
+    modulemd_build_config_get_runtime_requirement_stream (bc, "framework"));
+  g_assert_null (required_modules[1]);
+  g_clear_pointer (&required_modules, g_strfreev);
+
+  /* Add another requirement */
+  modulemd_build_config_add_runtime_requirement (bc, "docbuilder", "rolling");
+
+  /* Confirm that it was added */
+  required_modules = modulemd_build_config_get_runtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_nonnull (required_modules[0]);
+  g_assert_cmpstr ("docbuilder", ==, required_modules[0]);
+  g_assert_cmpstr (
+    "rolling",
+    ==,
+    modulemd_build_config_get_runtime_requirement_stream (bc, "docbuilder"));
+  g_assert_nonnull (required_modules[1]);
+  g_assert_cmpstr ("framework", ==, required_modules[1]);
+  g_assert_cmpstr (
+    "1.0",
+    ==,
+    modulemd_build_config_get_runtime_requirement_stream (bc, "framework"));
+  g_assert_null (required_modules[2]);
+  g_clear_pointer (&required_modules, g_strfreev);
+
+  /* Replace a dependency with a different stream */
+  modulemd_build_config_add_runtime_requirement (bc, "docbuilder", "stable");
+
+  /* Confirm that it was added */
+  required_modules = modulemd_build_config_get_runtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_nonnull (required_modules[0]);
+  g_assert_cmpstr ("docbuilder", ==, required_modules[0]);
+  g_assert_cmpstr (
+    "stable",
+    ==,
+    modulemd_build_config_get_runtime_requirement_stream (bc, "docbuilder"));
+  g_assert_nonnull (required_modules[1]);
+  g_assert_cmpstr ("framework", ==, required_modules[1]);
+  g_assert_cmpstr (
+    "1.0",
+    ==,
+    modulemd_build_config_get_runtime_requirement_stream (bc, "framework"));
+  g_assert_null (required_modules[2]);
+  g_clear_pointer (&required_modules, g_strfreev);
+
+  /* Remove a dependency */
+  modulemd_build_config_remove_runtime_requirement (bc, "framework");
+
+  /* Confirm that it was removed */
+  required_modules = modulemd_build_config_get_runtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_nonnull (required_modules[0]);
+  g_assert_cmpstr ("docbuilder", ==, required_modules[0]);
+  g_assert_cmpstr (
+    "stable",
+    ==,
+    modulemd_build_config_get_runtime_requirement_stream (bc, "docbuilder"));
+  g_assert_null (required_modules[1]);
+  g_clear_pointer (&required_modules, g_strfreev);
+
+  /* Remove a nonexistent dependency */
+  modulemd_build_config_remove_runtime_requirement (bc, "notpresent");
+
+  /* Confirm that nothing changed */
+  required_modules = modulemd_build_config_get_runtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_nonnull (required_modules[0]);
+  g_assert_cmpstr ("docbuilder", ==, required_modules[0]);
+  g_assert_cmpstr (
+    "stable",
+    ==,
+    modulemd_build_config_get_runtime_requirement_stream (bc, "docbuilder"));
+  g_assert_null (required_modules[1]);
+  g_clear_pointer (&required_modules, g_strfreev);
+
+
+  /* Clear all the requirements */
+  modulemd_build_config_clear_runtime_requirements (bc);
+
+  required_modules = modulemd_build_config_get_runtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_null (required_modules[0]);
+  g_clear_pointer (&required_modules, g_strfreev);
+}
+
+
+static void
+buildconfig_test_buildrequires (void)
+{
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  g_auto (GStrv) required_modules = NULL;
+
+
+  bc = modulemd_build_config_new ();
+  g_assert_nonnull (bc);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc));
+
+  /* Add a buildtime requirement */
+  modulemd_build_config_add_buildtime_requirement (bc, "framework", "1.0");
+
+  /* Confirm that it was added */
+  required_modules = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_nonnull (required_modules[0]);
+  g_assert_cmpstr ("framework", ==, required_modules[0]);
+  g_assert_cmpstr (
+    "1.0",
+    ==,
+    modulemd_build_config_get_buildtime_requirement_stream (bc, "framework"));
+  g_assert_null (required_modules[1]);
+  g_clear_pointer (&required_modules, g_strfreev);
+
+  /* Add another requirement */
+  modulemd_build_config_add_buildtime_requirement (
+    bc, "docbuilder", "rolling");
+
+  /* Confirm that it was added */
+  required_modules = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_nonnull (required_modules[0]);
+  g_assert_cmpstr ("docbuilder", ==, required_modules[0]);
+  g_assert_cmpstr (
+    "rolling",
+    ==,
+    modulemd_build_config_get_buildtime_requirement_stream (bc, "docbuilder"));
+  g_assert_nonnull (required_modules[1]);
+  g_assert_cmpstr ("framework", ==, required_modules[1]);
+  g_assert_cmpstr (
+    "1.0",
+    ==,
+    modulemd_build_config_get_buildtime_requirement_stream (bc, "framework"));
+  g_assert_null (required_modules[2]);
+  g_clear_pointer (&required_modules, g_strfreev);
+
+  /* Replace a dependency with a different stream */
+  modulemd_build_config_add_buildtime_requirement (bc, "docbuilder", "stable");
+
+  /* Confirm that it was added */
+  required_modules = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_nonnull (required_modules[0]);
+  g_assert_cmpstr ("docbuilder", ==, required_modules[0]);
+  g_assert_cmpstr (
+    "stable",
+    ==,
+    modulemd_build_config_get_buildtime_requirement_stream (bc, "docbuilder"));
+  g_assert_nonnull (required_modules[1]);
+  g_assert_cmpstr ("framework", ==, required_modules[1]);
+  g_assert_cmpstr (
+    "1.0",
+    ==,
+    modulemd_build_config_get_buildtime_requirement_stream (bc, "framework"));
+  g_assert_null (required_modules[2]);
+  g_clear_pointer (&required_modules, g_strfreev);
+
+  /* Remove a dependency */
+  modulemd_build_config_remove_buildtime_requirement (bc, "framework");
+
+  /* Confirm that it was removed */
+  required_modules = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_nonnull (required_modules[0]);
+  g_assert_cmpstr ("docbuilder", ==, required_modules[0]);
+  g_assert_cmpstr (
+    "stable",
+    ==,
+    modulemd_build_config_get_buildtime_requirement_stream (bc, "docbuilder"));
+  g_assert_null (required_modules[1]);
+  g_clear_pointer (&required_modules, g_strfreev);
+
+  /* Remove a nonexistent dependency */
+  modulemd_build_config_remove_buildtime_requirement (bc, "notpresent");
+
+  /* Confirm that nothing changed */
+  required_modules = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_nonnull (required_modules[0]);
+  g_assert_cmpstr ("docbuilder", ==, required_modules[0]);
+  g_assert_cmpstr (
+    "stable",
+    ==,
+    modulemd_build_config_get_buildtime_requirement_stream (bc, "docbuilder"));
+  g_assert_null (required_modules[1]);
+  g_clear_pointer (&required_modules, g_strfreev);
+
+
+  /* Clear all the requirements */
+  modulemd_build_config_clear_buildtime_requirements (bc);
+
+  required_modules = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+  g_assert_nonnull (required_modules);
+  g_assert_null (required_modules[0]);
+  g_clear_pointer (&required_modules, g_strfreev);
+}
+
+
+static void
+buildconfig_test_buildopts (void)
+{
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  g_autoptr (ModulemdBuildopts) opts = NULL;
+  ModulemdBuildopts *retrieved = NULL;
+
+  bc = modulemd_build_config_new ();
+  g_assert_nonnull (bc);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc));
+
+  g_assert_null (modulemd_build_config_get_buildopts (bc));
+
+  /* Create a buildopts object to store */
+  opts = modulemd_buildopts_new ();
+  modulemd_buildopts_set_rpm_macros (opts, "%global test 1");
+  modulemd_build_config_set_buildopts (bc, opts);
+
+  retrieved = modulemd_build_config_get_buildopts (bc);
+  g_assert_nonnull (retrieved);
+  g_assert_true (modulemd_buildopts_equals (opts, retrieved));
+
+  /* Confirm we're getting back a copy and not the same pointer */
+  g_assert_false (opts == retrieved);
+
+  /* Unset the buildopts */
+  modulemd_build_config_set_buildopts (bc, NULL);
+  g_assert_null (modulemd_build_config_get_buildopts (bc));
+}
+
+
+static void
+buildconfig_test_parse_yaml (void)
+{
+  MMD_INIT_YAML_EVENT (event);
+  MMD_INIT_YAML_PARSER (parser);
+  g_autofree gchar *yaml_path = NULL;
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  ModulemdBuildopts *opts = NULL;
+  g_autoptr (FILE) yaml_stream = NULL;
+  g_autoptr (GError) error = NULL;
+  g_auto (GStrv) dep_modules = NULL;
+
+  /* Verify a valid YAML file */
+  yaml_path = g_strdup_printf ("%s/buildconfig/good_bc.yaml",
+                               g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (yaml_path);
+
+  yaml_stream = g_fopen (yaml_path, "rbe");
+  g_assert_nonnull (yaml_stream);
+
+  yaml_parser_set_input_file (&parser, yaml_stream);
+
+  parser_skip_headers (&parser);
+
+  bc = modulemd_build_config_parse_yaml (&parser, TRUE, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (bc);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc));
+
+
+  g_assert_nonnull (modulemd_build_config_get_context (bc));
+  g_assert_cmpstr ("CTX1", ==, modulemd_build_config_get_context (bc));
+
+
+  g_assert_nonnull (modulemd_build_config_get_platform (bc));
+  g_assert_cmpstr ("f32", ==, modulemd_build_config_get_platform (bc));
+
+
+  dep_modules = modulemd_build_config_get_runtime_modules_as_strv (bc);
+
+  g_assert_nonnull (dep_modules);
+  g_assert_nonnull (dep_modules[0]);
+  g_assert_cmpstr ("appframework", ==, dep_modules[0]);
+  g_assert_null (dep_modules[1]);
+  g_assert_cmpstr (
+    "v2",
+    ==,
+    modulemd_build_config_get_runtime_requirement_stream (bc, "appframework"));
+  g_clear_pointer (&dep_modules, &g_strfreev);
+
+
+  dep_modules = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+
+  g_assert_nonnull (dep_modules);
+  g_assert_nonnull (dep_modules[0]);
+  g_assert_cmpstr ("appframework", ==, dep_modules[0]);
+  g_assert_nonnull (dep_modules[1]);
+  g_assert_cmpstr ("doctool", ==, dep_modules[1]);
+  g_assert_null (dep_modules[2]);
+  g_assert_cmpstr ("v1",
+                   ==,
+                   modulemd_build_config_get_buildtime_requirement_stream (
+                     bc, "appframework"));
+  g_assert_cmpstr (
+    "rolling",
+    ==,
+    modulemd_build_config_get_buildtime_requirement_stream (bc, "doctool"));
+  g_clear_pointer (&dep_modules, &g_strfreev);
+
+
+  /* Test that we constructed a ModulemdBuildopts object.
+   * We don't need to check all of its values because that's already done in
+   * the buildopts tests
+   */
+  opts = modulemd_build_config_get_buildopts (bc);
+  g_assert_nonnull (opts);
+  g_assert_true (MODULEMD_IS_BUILDOPTS (opts));
+}
+
+
+static void
+buildconfig_test_parse_yaml_unknown_key (void)
+{
+  MMD_INIT_YAML_EVENT (event);
+  MMD_INIT_YAML_PARSER (parser);
+  g_autofree gchar *yaml_path = NULL;
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  ModulemdBuildopts *opts = NULL;
+  g_autoptr (FILE) yaml_stream = NULL;
+  g_autoptr (GError) error = NULL;
+  g_auto (GStrv) dep_modules = NULL;
+
+  /* Read a good YAML file with an unknown key */
+  yaml_path = g_strdup_printf ("%s/buildconfig/unknown_key.yaml",
+                               g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (yaml_path);
+
+
+  /* First try it in non-strict mode */
+  yaml_stream = g_fopen (yaml_path, "rbe");
+  g_assert_nonnull (yaml_stream);
+
+  yaml_parser_set_input_file (&parser, yaml_stream);
+
+  parser_skip_headers (&parser);
+
+  bc = modulemd_build_config_parse_yaml (&parser, FALSE, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (bc);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc));
+
+
+  g_assert_nonnull (modulemd_build_config_get_context (bc));
+  g_assert_cmpstr ("CTX1", ==, modulemd_build_config_get_context (bc));
+
+
+  g_assert_nonnull (modulemd_build_config_get_platform (bc));
+  g_assert_cmpstr ("f32", ==, modulemd_build_config_get_platform (bc));
+
+
+  dep_modules = modulemd_build_config_get_runtime_modules_as_strv (bc);
+
+  g_assert_nonnull (dep_modules);
+  g_assert_nonnull (dep_modules[0]);
+  g_assert_cmpstr ("appframework", ==, dep_modules[0]);
+  g_assert_null (dep_modules[1]);
+  g_assert_cmpstr (
+    "v2",
+    ==,
+    modulemd_build_config_get_runtime_requirement_stream (bc, "appframework"));
+  g_clear_pointer (&dep_modules, &g_strfreev);
+
+
+  dep_modules = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+
+  g_assert_nonnull (dep_modules);
+  g_assert_nonnull (dep_modules[0]);
+  g_assert_cmpstr ("appframework", ==, dep_modules[0]);
+  g_assert_nonnull (dep_modules[1]);
+  g_assert_cmpstr ("doctool", ==, dep_modules[1]);
+  g_assert_null (dep_modules[2]);
+  g_assert_cmpstr ("v1",
+                   ==,
+                   modulemd_build_config_get_buildtime_requirement_stream (
+                     bc, "appframework"));
+  g_assert_cmpstr (
+    "rolling",
+    ==,
+    modulemd_build_config_get_buildtime_requirement_stream (bc, "doctool"));
+  g_clear_pointer (&dep_modules, &g_strfreev);
+
+
+  /* Test that we constructed a ModulemdBuildopts object.
+   * We don't need to check all of its values because that's already done in
+   * the buildopts tests
+   */
+  opts = modulemd_build_config_get_buildopts (bc);
+  g_assert_nonnull (opts);
+  g_assert_true (MODULEMD_IS_BUILDOPTS (opts));
+  g_clear_object (&bc);
+
+
+  /* This should fail in strict mode */
+  MMD_INIT_YAML_PARSER (strictparser);
+  yaml_stream = g_fopen (yaml_path, "rbe");
+  g_assert_nonnull (yaml_stream);
+
+  yaml_parser_set_input_file (&strictparser, yaml_stream);
+
+  parser_skip_headers (&strictparser);
+
+  bc = modulemd_build_config_parse_yaml (&strictparser, TRUE, &error);
+  g_assert_error (error, MODULEMD_YAML_ERROR, MMD_YAML_ERROR_UNKNOWN_ATTR);
+  g_assert_null (bc);
+}
+
+
+static void
+buildconfig_test_parse_yaml_no_context (void)
+{
+  MMD_INIT_YAML_EVENT (event);
+  MMD_INIT_YAML_PARSER (parser);
+  g_autofree gchar *yaml_path = NULL;
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  g_autoptr (FILE) yaml_stream = NULL;
+  g_autoptr (GError) error = NULL;
+
+  /* Read a YAML file that is missing context */
+  yaml_path = g_strdup_printf ("%s/buildconfig/no_context.yaml",
+                               g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (yaml_path);
+
+  yaml_stream = g_fopen (yaml_path, "rbe");
+  g_assert_nonnull (yaml_stream);
+
+  yaml_parser_set_input_file (&parser, yaml_stream);
+
+  parser_skip_headers (&parser);
+
+  bc = modulemd_build_config_parse_yaml (&parser, TRUE, &error);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
+  g_assert_null (bc);
+}
+
+
+static void
+buildconfig_test_parse_yaml_short_context (void)
+{
+  MMD_INIT_YAML_EVENT (event);
+  MMD_INIT_YAML_PARSER (parser);
+  g_autofree gchar *yaml_path = NULL;
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  g_autoptr (FILE) yaml_stream = NULL;
+  g_autoptr (GError) error = NULL;
+
+  /* Read a YAML file with an empty context */
+  yaml_path = g_strdup_printf ("%s/buildconfig/short_context.yaml",
+                               g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (yaml_path);
+
+  yaml_stream = g_fopen (yaml_path, "rbe");
+  g_assert_nonnull (yaml_stream);
+
+  yaml_parser_set_input_file (&parser, yaml_stream);
+
+  parser_skip_headers (&parser);
+
+  bc = modulemd_build_config_parse_yaml (&parser, TRUE, &error);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
+  g_assert_null (bc);
+}
+
+
+static void
+buildconfig_test_parse_yaml_long_context (void)
+{
+  MMD_INIT_YAML_EVENT (event);
+  MMD_INIT_YAML_PARSER (parser);
+  g_autofree gchar *yaml_path = NULL;
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  g_autoptr (FILE) yaml_stream = NULL;
+  g_autoptr (GError) error = NULL;
+
+  /* Read a YAML file that has a context that is too long */
+  yaml_path = g_strdup_printf ("%s/buildconfig/long_context.yaml",
+                               g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (yaml_path);
+
+  yaml_stream = g_fopen (yaml_path, "rbe");
+  g_assert_nonnull (yaml_stream);
+
+  yaml_parser_set_input_file (&parser, yaml_stream);
+
+  parser_skip_headers (&parser);
+
+  bc = modulemd_build_config_parse_yaml (&parser, TRUE, &error);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
+  g_assert_null (bc);
+}
+
+
+static void
+buildconfig_test_parse_yaml_nonalphanum (void)
+{
+  MMD_INIT_YAML_EVENT (event);
+  MMD_INIT_YAML_PARSER (parser);
+  g_autofree gchar *yaml_path = NULL;
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  g_autoptr (FILE) yaml_stream = NULL;
+  g_autoptr (GError) error = NULL;
+
+  /* Read a YAML file that has a context with a disallowed character */
+  yaml_path = g_strdup_printf ("%s/buildconfig/nonalphanum_context.yaml",
+                               g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (yaml_path);
+
+  yaml_stream = g_fopen (yaml_path, "rbe");
+  g_assert_nonnull (yaml_stream);
+
+  yaml_parser_set_input_file (&parser, yaml_stream);
+
+  parser_skip_headers (&parser);
+
+  bc = modulemd_build_config_parse_yaml (&parser, TRUE, &error);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
+  g_assert_null (bc);
+}
+
+
+static void
+buildconfig_test_parse_yaml_no_platform (void)
+{
+  MMD_INIT_YAML_EVENT (event);
+  MMD_INIT_YAML_PARSER (parser);
+  g_autofree gchar *yaml_path = NULL;
+  g_autoptr (ModulemdBuildConfig) bc = NULL;
+  g_autoptr (FILE) yaml_stream = NULL;
+  g_autoptr (GError) error = NULL;
+
+  /* Read a YAML file that is missing platform */
+  yaml_path = g_strdup_printf ("%s/buildconfig/no_platform.yaml",
+                               g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (yaml_path);
+
+  yaml_stream = g_fopen (yaml_path, "rbe");
+  g_assert_nonnull (yaml_stream);
+
+  yaml_parser_set_input_file (&parser, yaml_stream);
+
+  parser_skip_headers (&parser);
+
+  bc = modulemd_build_config_parse_yaml (&parser, TRUE, &error);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
+  g_assert_null (bc);
+}
+
+
+int
+main (int argc, char *argv[])
+{
+  setlocale (LC_ALL, "");
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
+
+  g_test_add_func ("/modulemd/v2/buildconfig/construct",
+                   buildconfig_test_construct);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/context",
+                   buildconfig_test_context);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/platform",
+                   buildconfig_test_platform);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/requires",
+                   buildconfig_test_requires);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/buildrequires",
+                   buildconfig_test_buildrequires);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/buildopts",
+                   buildconfig_test_buildopts);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/yaml/parse",
+                   buildconfig_test_parse_yaml);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/yaml/parse/bad/unknown_key",
+                   buildconfig_test_parse_yaml_unknown_key);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/yaml/parse/bad/context/none",
+                   buildconfig_test_parse_yaml_no_context);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/yaml/parse/bad/context/short",
+                   buildconfig_test_parse_yaml_short_context);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/yaml/parse/bad/context/long",
+                   buildconfig_test_parse_yaml_long_context);
+
+  g_test_add_func (
+    "/modulemd/v2/buildconfig/yaml/parse/bad/context/nonalphanum",
+    buildconfig_test_parse_yaml_nonalphanum);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/yaml/parse/bad/platform/none",
+                   buildconfig_test_parse_yaml_no_platform);
+
+  return g_test_run ();
+}

--- a/modulemd/tests/test_data/buildconfig/good_bc.yaml
+++ b/modulemd/tests/test_data/buildconfig/good_bc.yaml
@@ -1,0 +1,19 @@
+---
+context: CTX1
+platform: f32
+buildrequires:
+  appframework: v1
+  doctool: rolling
+requires:
+  appframework: v2
+buildopts:
+  rpms:
+    macros: |
+      %demomacro 1
+      %demomacro2 %{demomacro}23
+    whitelist:
+    - fooscl-1-bar
+    - fooscl-1-baz
+    - xxx
+    - xyz
+...

--- a/modulemd/tests/test_data/buildconfig/long_context.yaml
+++ b/modulemd/tests/test_data/buildconfig/long_context.yaml
@@ -1,0 +1,19 @@
+---
+context: CTX1234567890
+platform: f32
+buildrequires:
+  appframework: v1
+  doctool: rolling
+requires:
+  appframework: v2
+buildopts:
+  rpms:
+    macros: |
+      %demomacro 1
+      %demomacro2 %{demomacro}23
+    whitelist:
+    - fooscl-1-bar
+    - fooscl-1-baz
+    - xxx
+    - xyz
+...

--- a/modulemd/tests/test_data/buildconfig/no_context.yaml
+++ b/modulemd/tests/test_data/buildconfig/no_context.yaml
@@ -1,0 +1,18 @@
+---
+platform: f32
+buildrequires:
+  appframework: v1
+  doctool: rolling
+requires:
+  appframework: v2
+buildopts:
+  rpms:
+    macros: |
+      %demomacro 1
+      %demomacro2 %{demomacro}23
+    whitelist:
+    - fooscl-1-bar
+    - fooscl-1-baz
+    - xxx
+    - xyz
+...

--- a/modulemd/tests/test_data/buildconfig/no_platform.yaml
+++ b/modulemd/tests/test_data/buildconfig/no_platform.yaml
@@ -1,0 +1,18 @@
+---
+context: CTX1
+buildrequires:
+  appframework: v1
+  doctool: rolling
+requires:
+  appframework: v2
+buildopts:
+  rpms:
+    macros: |
+      %demomacro 1
+      %demomacro2 %{demomacro}23
+    whitelist:
+    - fooscl-1-bar
+    - fooscl-1-baz
+    - xxx
+    - xyz
+...

--- a/modulemd/tests/test_data/buildconfig/nonalphanum_context.yaml
+++ b/modulemd/tests/test_data/buildconfig/nonalphanum_context.yaml
@@ -1,0 +1,19 @@
+---
+context: CTX_1
+platform: f32
+buildrequires:
+  appframework: v1
+  doctool: rolling
+requires:
+  appframework: v2
+buildopts:
+  rpms:
+    macros: |
+      %demomacro 1
+      %demomacro2 %{demomacro}23
+    whitelist:
+    - fooscl-1-bar
+    - fooscl-1-baz
+    - xxx
+    - xyz
+...

--- a/modulemd/tests/test_data/buildconfig/short_context.yaml
+++ b/modulemd/tests/test_data/buildconfig/short_context.yaml
@@ -1,0 +1,19 @@
+---
+context: ""
+platform: f32
+buildrequires:
+  appframework: v1
+  doctool: rolling
+requires:
+  appframework: v2
+buildopts:
+  rpms:
+    macros: |
+      %demomacro 1
+      %demomacro2 %{demomacro}23
+    whitelist:
+    - fooscl-1-bar
+    - fooscl-1-baz
+    - xxx
+    - xyz
+...

--- a/modulemd/tests/test_data/buildconfig/unknown_key.yaml
+++ b/modulemd/tests/test_data/buildconfig/unknown_key.yaml
@@ -1,0 +1,20 @@
+---
+context: CTX1
+platform: f32
+unknown: key
+buildrequires:
+  appframework: v1
+  doctool: rolling
+requires:
+  appframework: v2
+buildopts:
+  rpms:
+    macros: |
+      %demomacro 1
+      %demomacro2 %{demomacro}23
+    whitelist:
+    - fooscl-1-bar
+    - fooscl-1-baz
+    - xxx
+    - xyz
+...


### PR DESCRIPTION
Create the basic object type and getters/setters.

Create the YAML parser.

Create unit tests for BuildConfig.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>