### PR TITLE
Add YAML emit capabilities to BuildConfig object

### DIFF
--- a/modulemd/include/private/modulemd-build-config.h
+++ b/modulemd/include/private/modulemd-build-config.h
@@ -299,6 +299,25 @@ modulemd_build_config_parse_yaml (yaml_parser_t *parser,
 
 
 /**
+ * modulemd_build_config_emit_yaml:
+ * @self: This #ModulemdBuildConfig object.
+ * @emitter: (inout): A libyaml emitter object positioned where a BuidConfig
+ * belongs in the YAML document.
+ * @error: (out): A #GError that will return the reason for an emission or
+ * validation error.
+ *
+ * Returns: TRUE if the BuildConfig was emitted successfully. FALSE and sets
+ * @error appropriately if the YAML could not be emitted.
+ *
+ * Since: 2.10
+ */
+gboolean
+modulemd_build_config_emit_yaml (ModulemdBuildConfig *self,
+                                 yaml_emitter_t *emitter,
+                                 GError **error);
+
+
+/**
  * modulemd_build_config_validate:
  * @self: (in): This #ModulemdBuildConfig object.
  * @error: (out): A #GError explaining any validation failure.

--- a/modulemd/include/private/modulemd-build-config.h
+++ b/modulemd/include/private/modulemd-build-config.h
@@ -346,4 +346,20 @@ modulemd_build_config_validate (ModulemdBuildConfig *buildconfig,
  */
 ModulemdBuildConfig *
 modulemd_build_config_copy (ModulemdBuildConfig *self);
+
+/**
+ * modulemd_build_config_equals:
+ * @self_1: A pointer to a #ModulemdBuildConfig object.
+ * @self_2: A pointer to a #ModulemdBuildConfig object.
+ *
+ * Returns: TRUE, if @self_1 and @self_2 are pointers to #ModulemdBuildConfig
+ * objects containing equivalent data. FALSE, otherwise.
+ *
+ * Since: 2.10
+ */
+
+gboolean
+modulemd_build_config_equals (ModulemdBuildConfig *self_1,
+                              ModulemdBuildConfig *self_2);
+
 G_END_DECLS

--- a/modulemd/include/private/modulemd-yaml.h
+++ b/modulemd/include/private/modulemd-yaml.h
@@ -171,9 +171,9 @@ mmd_yaml_get_event_name (yaml_event_type_t type);
  * Since: 2.0
  */
 #define MMD_INIT_YAML_STRING(_emitter, _string)                               \
-  g_autoptr (modulemd_yaml_string) yaml_string =                              \
+  g_autoptr (modulemd_yaml_string) _string =                                  \
     g_malloc0_n (1, sizeof (modulemd_yaml_string));                           \
-  yaml_emitter_set_output (_emitter, write_yaml_string, (void *)yaml_string)
+  yaml_emitter_set_output (_emitter, write_yaml_string, (void *)_string)
 
 /**
  * MMD_REINIT_YAML_STRING:
@@ -191,8 +191,8 @@ mmd_yaml_get_event_name (yaml_event_type_t type);
   yaml_emitter_delete (_emitter);                                             \
   yaml_emitter_initialize (_emitter);                                         \
   g_clear_pointer (&_string, modulemd_yaml_string_free);                      \
-  yaml_string = g_malloc0_n (1, sizeof (modulemd_yaml_string));               \
-  yaml_emitter_set_output (_emitter, write_yaml_string, (void *)yaml_string)
+  _string = g_malloc0_n (1, sizeof (modulemd_yaml_string));                   \
+  yaml_emitter_set_output (_emitter, write_yaml_string, (void *)_string)
 
 /**
  * YAML_PARSER_PARSE_WITH_EXIT_FULL:

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -335,7 +335,7 @@ foreach name, sources : c_tests
     )
     test(name + '_debug', exe,
          env : test_env,
-         timeout : 60,
+         timeout : 120,
          suite : ['ci', 'ci_valgrind', 'c', 'c_debug'])
     test(name + '_release', exe,
          env : test_release_env,

--- a/modulemd/modulemd-build-config.c
+++ b/modulemd/modulemd-build-config.c
@@ -544,3 +544,51 @@ modulemd_build_config_copy (ModulemdBuildConfig *self)
 
   return g_steal_pointer (&copy);
 }
+
+
+gboolean
+modulemd_build_config_equals (ModulemdBuildConfig *self_1,
+                              ModulemdBuildConfig *self_2)
+{
+  if (!self_1 && !self_2)
+    {
+      return TRUE;
+    }
+
+  if (!self_1 || !self_2)
+    {
+      return FALSE;
+    }
+
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self_1), FALSE);
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self_2), FALSE);
+
+  if (g_strcmp0 (self_1->context, self_2->context) != 0)
+    {
+      return FALSE;
+    }
+
+  if (g_strcmp0 (self_1->platform, self_2->platform) != 0)
+    {
+      return FALSE;
+    }
+
+  if (!modulemd_hash_table_equals (
+        self_1->requires, self_2->requires, g_str_equal))
+    {
+      return FALSE;
+    }
+
+  if (!modulemd_hash_table_equals (
+        self_1->buildrequires, self_2->buildrequires, g_str_equal))
+    {
+      return FALSE;
+    }
+
+  if (!modulemd_buildopts_equals (self_1->buildopts, self_2->buildopts))
+    {
+      return FALSE;
+    }
+
+  return TRUE;
+}

--- a/modulemd/tests/test-modulemd-build-config.c
+++ b/modulemd/tests/test-modulemd-build-config.c
@@ -759,6 +759,261 @@ buildconfig_test_emit_yaml (void)
 }
 
 
+static void
+buildconfig_test_equals (void)
+{
+  g_autoptr (ModulemdBuildConfig) bc_1 = NULL;
+  g_autoptr (ModulemdBuildConfig) bc_2 = NULL;
+  g_autoptr (ModulemdBuildopts) opts = NULL;
+
+  /* with no properties */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+
+  g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with same contexts */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_set_context (bc_1, "CTX1");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_set_context (bc_2, "CTX1");
+
+  g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with different contexts */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_set_context (bc_1, "CTX1");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_set_context (bc_2, "CTX2");
+
+  g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with same platforms */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_set_platform (bc_1, "f33");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_set_platform (bc_2, "f33");
+
+  g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with different platforms */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_set_platform (bc_1, "f33");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_set_platform (bc_2, "f32");
+
+  g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with same buildtime requirements */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_add_buildtime_requirement (
+    bc_1, "buildmod1", "stream1");
+  modulemd_build_config_add_buildtime_requirement (
+    bc_1, "buildmod2", "stream2");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_add_buildtime_requirement (
+    bc_2, "buildmod1", "stream1");
+  modulemd_build_config_add_buildtime_requirement (
+    bc_2, "buildmod2", "stream2");
+
+  g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with different buildtime requirements */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_add_buildtime_requirement (
+    bc_1, "buildmod1", "stream1");
+  modulemd_build_config_add_buildtime_requirement (
+    bc_1, "buildmod2", "stream2");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_add_buildtime_requirement (
+    bc_2, "buildmod1", "stream1");
+  modulemd_build_config_add_buildtime_requirement (
+    bc_2, "buildmod2", "stream2");
+  modulemd_build_config_add_buildtime_requirement (
+    bc_2, "buildmod3", "stream3");
+
+  g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with same runtime requirements */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_add_runtime_requirement (bc_1, "runmod1", "stream3");
+  modulemd_build_config_add_runtime_requirement (bc_1, "runmod2", "stream4");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_add_runtime_requirement (bc_2, "runmod1", "stream3");
+  modulemd_build_config_add_runtime_requirement (bc_2, "runmod2", "stream4");
+
+  g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with different runtime requirements */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_add_runtime_requirement (bc_1, "runmod1", "stream3");
+  modulemd_build_config_add_runtime_requirement (bc_1, "runmod2", "stream4");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_add_runtime_requirement (bc_2, "runmod1", "stream3");
+  modulemd_build_config_add_runtime_requirement (bc_2, "runmod2", "stream4");
+  modulemd_build_config_add_runtime_requirement (bc_2, "runmod3", "stream5");
+
+  g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with same buildtime and runtime requirements */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_add_buildtime_requirement (
+    bc_1, "buildmod1", "stream1");
+  modulemd_build_config_add_buildtime_requirement (
+    bc_1, "buildmod2", "stream2");
+  modulemd_build_config_add_runtime_requirement (bc_1, "runmod1", "stream3");
+  modulemd_build_config_add_runtime_requirement (bc_1, "runmod2", "stream4");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_add_buildtime_requirement (
+    bc_2, "buildmod1", "stream1");
+  modulemd_build_config_add_buildtime_requirement (
+    bc_2, "buildmod2", "stream2");
+  modulemd_build_config_add_runtime_requirement (bc_2, "runmod1", "stream3");
+  modulemd_build_config_add_runtime_requirement (bc_2, "runmod2", "stream4");
+
+  g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with different buildtime and same runtime requirements */
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_add_buildtime_requirement (
+    bc_1, "buildmod1", "stream1");
+  modulemd_build_config_add_buildtime_requirement (
+    bc_1, "buildmod2", "stream2");
+  modulemd_build_config_add_buildtime_requirement (
+    bc_1, "buildmod3", "stream8");
+  modulemd_build_config_add_runtime_requirement (bc_1, "runmod1", "stream3");
+  modulemd_build_config_add_runtime_requirement (bc_1, "runmod2", "stream4");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_add_buildtime_requirement (
+    bc_2, "buildmod1", "stream1");
+  modulemd_build_config_add_buildtime_requirement (
+    bc_2, "buildmod2", "stream2");
+  modulemd_build_config_add_runtime_requirement (bc_2, "runmod1", "stream3");
+  modulemd_build_config_add_runtime_requirement (bc_2, "runmod2", "stream4");
+
+  g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+
+  /* with same buildopts */
+  opts = modulemd_buildopts_new ();
+  modulemd_buildopts_set_rpm_macros (opts, "%global test 1");
+
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_set_buildopts (bc_1, opts);
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_set_buildopts (bc_2, opts);
+
+  g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+  g_clear_object (&opts);
+
+  /* with different buildopts */
+  opts = modulemd_buildopts_new ();
+  modulemd_buildopts_set_rpm_macros (opts, "%global test 1");
+
+  bc_1 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_1);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_1));
+  modulemd_build_config_set_buildopts (bc_1, opts);
+
+  g_clear_object (&opts);
+  opts = modulemd_buildopts_new ();
+  modulemd_buildopts_set_rpm_macros (opts, "%global test 2");
+
+  bc_2 = modulemd_build_config_new ();
+  g_assert_nonnull (bc_2);
+  g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
+  modulemd_build_config_set_buildopts (bc_2, opts);
+
+  g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_clear_object (&bc_1);
+  g_clear_object (&bc_2);
+  g_clear_object (&opts);
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -809,6 +1064,8 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/modulemd/v2/buildconfig/yaml/emit",
                    buildconfig_test_emit_yaml);
+
+  g_test_add_func ("/modulemd/v2/buildconfig/equals", buildconfig_test_equals);
 
   return g_test_run ();
 }


### PR DESCRIPTION
I found it worth my time to add this while working on the StreamV2 to StreamV3 upgrade dependency stream expansion so I could visualize the data structures.

I also happened to notice and fix a small issue with the implementation of the `MMD_INIT_YAML_STRING()` and `MMD_REINIT_YAML_STRING()` macros.
