### PR TITLE
Implement PackagerV3 mapping to StreamV2/StreamV3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -198,6 +198,7 @@ if meson.version().version_compare('>=0.53')
 
     summary({'Developer Build': get_option('developer_build'),
              'libmagic Support': magic_status,
+             'Default Stream MD Version': default_stream_mdversion,
              'Custom Python': get_option('python_name'),
              'RPMIO Support': rpmio_status,
              'Generate Manpages': manpages_status,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,6 +14,9 @@
 option('developer_build', type : 'boolean', value : true,
        description : 'Enables automatic code formatters and memory leak checks. This option should be set to FALSE for release builds.')
 
+option('default_stream_mdversion', type : 'integer', min : 2, max : 3, value : 2,
+       description : 'The default module stream metadata version to use.')
+
 option('libmagic', type : 'feature', value : 'enabled',
        description : 'Enables the use of libmagic to detect compression of YAML files.')
 

--- a/modulemd/include/modulemd-2.0/modulemd.h
+++ b/modulemd/include/modulemd-2.0/modulemd.h
@@ -287,6 +287,37 @@ G_BEGIN_DECLS
 const gchar *
 modulemd_get_version (void);
 
+/**
+ * modulemd_set_default_stream_mdversion:
+ * @mdversion: (in): The default stream metadata version to set.
+ *
+ * Used to set the default module stream metadata version to use when creating a
+ * new #ModulemdModuleIndex, when reading a modulemd-packager v3 document
+ * directly to a #ModulemdModuleStream object, etc.
+ *
+ * Warning: May not be thread-safe.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_set_default_stream_mdversion (
+  ModulemdModuleStreamVersionEnum mdversion);
+
+/**
+ * modulemd_get_default_stream_mdversion:
+ *
+ * Returns: The default module stream metadata version to use when creating a
+ * new #ModulemdModuleIndex, when reading a modulemd-packager v3 document
+ * directly to a #ModulemdModuleStream object, etc.
+ *
+ * If a default stream metadata version has not been explicitly set using
+ * modulemd_set_default_stream_mdversion(), the value returned will be a compile-time
+ * default.
+ *
+ * Since: 2.10
+ */
+ModulemdModuleStreamVersionEnum
+modulemd_get_default_stream_mdversion (void);
 
 /**
  * modulemd_load_file:

--- a/modulemd/include/private/modulemd-packager-v3.h
+++ b/modulemd/include/private/modulemd-packager-v3.h
@@ -20,7 +20,10 @@
 #include "modulemd-2.0/modulemd-profile.h"
 #include "modulemd-2.0/modulemd-subdocument-info.h"
 
+#include "private/modulemd-module-stream-v2-private.h"
+#include "private/modulemd-module-stream-v3-private.h"
 #include "private/modulemd-build-config.h"
+#include "private/modulemd-module-index-private.h"
 
 G_BEGIN_DECLS
 
@@ -713,6 +716,100 @@ modulemd_packager_v3_get_module_component (ModulemdPackagerV3 *self,
 ModulemdComponentRpm *
 modulemd_packager_v3_get_rpm_component (ModulemdPackagerV3 *self,
                                         const gchar *component_name);
+
+
+/**
+ * modulemd_packager_v3_to_defaults:
+ * @self: (in): This #ModulemdPackagerV3 object.
+ * @defaults_ptr: (out): (transfer-full): A pointer to a pointer to a new
+ * #ModulemdDefaults object. Must be a valid pointer to a NULL object when
+ * called.
+ * @error: (out): A #GError that will return the reason for a conversion error.
+ *
+ * Sets @defaults_ptr to point to a newly-allocated #ModulemdDefaults object
+ * corresponding to the #ModulemdPackagerV3 object @self if @self contains any
+ * profiles marked as default. Leaves @defaults_ptr pointing to NULL if @self
+ * contained no default profiles.
+ *
+ * Returns: TRUE if the conversion succeeded, including the case where there
+ * @self contains no default profiles. FALSE otherwise and @error will be set.
+ *
+ * Since: 2.10
+ */
+gboolean
+modulemd_packager_v3_to_defaults (ModulemdPackagerV3 *self,
+                                  ModulemdDefaults **defaults,
+                                  GError **error);
+
+/**
+ * modulemd_packager_v3_to_stream_v2:
+ * @self: (in): This #ModulemdPackagerV3 object.
+ * @error: (out): A #GError that will return the reason for a conversion error.
+ *
+ * Returns: (transfer full): A newly-allocated #ModulemdModuleStreamV2 object
+ * corresponding to the #ModulemdPackagerV3 object @self. NULL if there was an
+ * error doing the mapping and sets @error appropriately.
+ *
+ * Since: 2.10
+ */
+ModulemdModuleStreamV2 *
+modulemd_packager_v3_to_stream_v2 (ModulemdPackagerV3 *self, GError **error);
+
+/**
+ * modulemd_packager_v3_to_stream_v2_ext:
+ * @self: (in): This #ModulemdPackagerV3 object.
+ * @error: (out): A #GError that will return the reason for a conversion error.
+ *
+ * Note: If buildopts (#ModulemdBuildopts) are in use in one or more build
+ * configurations in the #ModulemdPackagerV3 object @self, only the buildopts
+ * present in the first listed configuration (if any) will be applied to the
+ * #ModulemdModuleStreamV2 object in the returned index.
+ *
+ * Returns: (transfer full): A newly-allocated #ModulemdModuleIndex object
+ * containing a #ModulemdModuleStreamV2 object and possibly a
+ * #ModulemdDefaults object corresponding to the #ModulemdPackagerV3 object
+ * @self. NULL if there was an error doing the mapping and sets @error
+ * appropriately.
+ *
+ * Since: 2.10
+ */
+ModulemdModuleIndex *
+modulemd_packager_v3_to_stream_v2_ext (ModulemdPackagerV3 *self,
+                                       GError **error);
+
+/**
+ * modulemd_packager_v3_to_stream_v3:
+ * @self: (in): This #ModulemdPackagerV3 object.
+ * @error: (out): A #GError that will return the reason for a conversion error.
+ *
+ * This will fail if the #ModulemdPackagerV3 object maps to multiple
+ * #ModulemdModuleStreamV3 objects.
+ *
+ * Returns: (transfer full): A newly-allocated #ModulemdModuleStreamV3 object
+ * corresponding to the #ModulemdPackagerV3 object @self. NULL if there was an
+ * error doing the mapping and sets @error appropriately.
+ *
+ * Since: 2.10
+ */
+ModulemdModuleStreamV3 *
+modulemd_packager_v3_to_stream_v3 (ModulemdPackagerV3 *self, GError **error);
+
+/**
+ * modulemd_packager_v3_to_stream_v2_ext:
+ * @self: (in): This #ModulemdPackagerV3 object.
+ * @error: (out): A #GError that will return the reason for a conversion error.
+ *
+ * Returns: (transfer full): A newly-allocated #ModulemdModuleIndex object
+ * containing one or more #ModulemdModuleStreamV3 objects and possibly a
+ * #ModulemdDefaults object corresponding to the #ModulemdPackagerV3 object
+ * @self. NULL if there was an error doing the mapping and sets @error
+ * appropriately.
+ *
+ * Since: 2.10
+ */
+ModulemdModuleIndex *
+modulemd_packager_v3_to_stream_v3_ext (ModulemdPackagerV3 *self,
+                                       GError **error);
 
 
 /**

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -16,6 +16,7 @@ test_installed_lib = get_option('test_installed_lib')
 skip_formatters = get_option('skip_formatters')
 skip_introspection = get_option('skip_introspection')
 developer_build = get_option('developer_build')
+default_stream_mdversion = get_option('default_stream_mdversion')
 
 if not developer_build
     skip_formatters = true
@@ -170,6 +171,7 @@ enums = gnome.mkenums_simple ('modulemd-enums', sources : modulemd_hdrs)
 
 cdata = configuration_data()
 cdata.set_quoted('LIBMODULEMD_VERSION', libmodulemd_version)
+cdata.set('DEFAULT_STREAM_MDVERSION', default_stream_mdversion)
 cdata.set('HAVE_RPMIO', rpm.found())
 cdata.set('HAVE_LIBMAGIC', magic.found())
 cdata.set('HAVE_GDATE_AUTOPTR', has_gdate_autoptr)

--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -142,6 +142,7 @@ add_subdoc (ModulemdModuleIndex *self,
 {
   g_autoptr (GError) nested_error = NULL;
   g_autoptr (ModulemdModuleStream) stream = NULL;
+  g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (ModulemdPackagerV3) packager = NULL;
   g_autoptr (ModulemdTranslation) translation = NULL;
   g_autoptr (ModulemdObsoletes) obsoletes = NULL;
@@ -168,9 +169,40 @@ add_subdoc (ModulemdModuleIndex *self,
         {
           packager = modulemd_packager_v3_parse_yaml (subdoc, error);
 
-          /* TODO: Determine which stream version to convert the packager
-           * object into and do so here.
+          /* Determine which stream version to convert the packager
+           * object into and do so.
            */
+          if (self->stream_mdversion < MD_MODULESTREAM_VERSION_THREE)
+            {
+              index = modulemd_packager_v3_to_stream_v2_ext (packager,
+                                                             &nested_error);
+            }
+          else
+            {
+              index = modulemd_packager_v3_to_stream_v3_ext (packager,
+                                                             &nested_error);
+            }
+
+          if (!index)
+            {
+              g_propagate_error (error, g_steal_pointer (&nested_error));
+              return FALSE;
+            }
+
+          if (autogen_module_name)
+            {
+              /* TODO: generate module/stream names if needed for streams in index */
+            }
+
+          /* merge index with override = FALSE and strict_default_streams = TRUE */
+          if (!modulemd_module_index_merge (
+                index, self, FALSE, TRUE, &nested_error))
+            {
+              g_propagate_error (error, g_steal_pointer (&nested_error));
+              return FALSE;
+            }
+
+          g_clear_object (&index);
           break;
         }
 
@@ -534,6 +566,15 @@ dump_streams (ModulemdModule *module, yaml_emitter_t *emitter, GError **error)
         {
           if (!modulemd_module_stream_v2_emit_yaml (
                 MODULEMD_MODULE_STREAM_V2 (stream), emitter, error))
+            {
+              return FALSE;
+            }
+        }
+      else if (modulemd_module_stream_get_mdversion (stream) ==
+               MD_MODULESTREAM_VERSION_THREE)
+        {
+          if (!modulemd_module_stream_v3_emit_yaml (
+                MODULEMD_MODULE_STREAM_V3 (stream), emitter, error))
             {
               return FALSE;
             }

--- a/modulemd/modulemd-packager-v3.c
+++ b/modulemd/modulemd-packager-v3.c
@@ -15,6 +15,7 @@
 #include "private/modulemd-component-private.h"
 #include "private/modulemd-component-module-private.h"
 #include "private/modulemd-component-rpm-private.h"
+#include "private/modulemd-defaults-v1-private.h"
 #include "private/modulemd-module-stream-private.h"
 #include "private/modulemd-packager-v3.h"
 #include "private/modulemd-profile-private.h"
@@ -153,9 +154,9 @@ modulemd_packager_v3_copy (ModulemdPackagerV3 *self)
   COPY_HASHTABLE_BY_VALUE_ADDER (
     copy, self, profiles, modulemd_packager_v3_add_profile);
 
-  modulemd_packager_v3_replace_rpm_api(copy, self->rpm_api);
+  modulemd_packager_v3_replace_rpm_api (copy, self->rpm_api);
 
-  modulemd_packager_v3_replace_rpm_filters(copy, self->rpm_filters);
+  modulemd_packager_v3_replace_rpm_filters (copy, self->rpm_filters);
 
   COPY_HASHTABLE_BY_VALUE_ADDER (
     copy, self, rpm_components, modulemd_packager_v3_add_component);
@@ -735,6 +736,450 @@ modulemd_packager_v3_get_rpm_component (ModulemdPackagerV3 *self,
   g_return_val_if_fail (MODULEMD_IS_PACKAGER_V3 (self), NULL);
 
   return g_hash_table_lookup (self->rpm_components, component_name);
+}
+
+
+gboolean
+modulemd_packager_v3_to_defaults (ModulemdPackagerV3 *self,
+                                  ModulemdDefaults **defaults_ptr,
+                                  GError **error)
+{
+  g_autoptr (ModulemdDefaultsV1) defaults = NULL;
+  ModulemdProfile *profile;
+  g_autoptr (GError) nested_error = NULL;
+  GHashTableIter iter;
+  gpointer value;
+
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+  g_return_val_if_fail (defaults_ptr == NULL || *defaults_ptr == NULL, FALSE);
+  g_return_val_if_fail (MODULEMD_IS_PACKAGER_V3 (self), FALSE);
+
+  g_hash_table_iter_init (&iter, self->profiles);
+  while (g_hash_table_iter_next (&iter, NULL, &value))
+    {
+      profile = MODULEMD_PROFILE (value);
+      if (modulemd_profile_is_default (profile))
+        {
+          if (!defaults)
+            {
+              defaults = modulemd_defaults_v1_new (self->module_name);
+            }
+          modulemd_defaults_v1_add_default_profile_for_stream (
+            defaults,
+            self->stream_name,
+            modulemd_profile_get_name (profile),
+            NULL);
+        }
+    }
+
+  if (!defaults)
+    {
+      return TRUE;
+    }
+
+  if (!modulemd_defaults_validate (MODULEMD_DEFAULTS (defaults),
+                                   &nested_error))
+    {
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return FALSE;
+    }
+
+  *defaults_ptr = MODULEMD_DEFAULTS (g_steal_pointer (&defaults));
+  return TRUE;
+}
+
+ModulemdModuleStreamV2 *
+modulemd_packager_v3_to_stream_v2 (ModulemdPackagerV3 *self, GError **error)
+{
+  g_autoptr (ModulemdModuleStreamV2) v2_stream = NULL;
+  g_autoptr (ModulemdDependencies) deps = NULL;
+  g_autoptr (ModulemdProfile) profile = NULL;
+  g_auto (GStrv) modules = NULL;
+  g_auto (GStrv) contexts = NULL;
+  g_autoptr (GError) nested_error = NULL;
+  ModulemdBuildopts *buildopts = NULL;
+  ModulemdBuildConfig *bc;
+  GHashTableIter iter;
+  gpointer value;
+
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+  g_return_val_if_fail (MODULEMD_IS_PACKAGER_V3 (self), NULL);
+
+  v2_stream = modulemd_module_stream_v2_new (
+    modulemd_packager_v3_get_module_name (self),
+    modulemd_packager_v3_get_stream_name (self));
+
+  modulemd_module_stream_v2_set_summary (
+    v2_stream, modulemd_packager_v3_get_summary (self));
+
+  modulemd_module_stream_v2_set_description (
+    v2_stream, modulemd_packager_v3_get_description (self));
+
+  MODULEMD_REPLACE_SET (v2_stream->module_licenses, self->module_licenses);
+
+  modulemd_module_stream_v2_set_xmd (v2_stream,
+                                     modulemd_packager_v3_get_xmd (self));
+
+  modulemd_module_stream_v2_set_community (
+    v2_stream, modulemd_packager_v3_get_community (self));
+
+  modulemd_module_stream_v2_set_documentation (
+    v2_stream, modulemd_packager_v3_get_documentation (self));
+
+  modulemd_module_stream_v2_set_tracker (
+    v2_stream, modulemd_packager_v3_get_tracker (self));
+
+  g_hash_table_iter_init (&iter, self->profiles);
+  while (g_hash_table_iter_next (&iter, NULL, &value))
+    {
+      profile = modulemd_profile_copy (MODULEMD_PROFILE (value));
+      modulemd_profile_unset_default (profile);
+      modulemd_module_stream_v2_add_profile (v2_stream, profile);
+      g_clear_object (&profile);
+    }
+
+  modulemd_module_stream_v2_replace_rpm_api (v2_stream, self->rpm_api);
+
+  modulemd_module_stream_v2_replace_rpm_filters (v2_stream, self->rpm_filters);
+
+  COPY_HASHTABLE_BY_VALUE_ADDER (
+    v2_stream, self, rpm_components, modulemd_module_stream_v2_add_component);
+
+  COPY_HASHTABLE_BY_VALUE_ADDER (v2_stream,
+                                 self,
+                                 module_components,
+                                 modulemd_module_stream_v2_add_component);
+
+
+  /* get the list of packager build configuration contexts */
+  contexts = modulemd_packager_v3_get_build_config_contexts_as_strv (self);
+
+  /* If there is exactly one build configuration, use it for the stream */
+  /* context. Otherwise, leave the stream context unset. */
+  if (g_strv_length (contexts) == 1)
+    {
+      modulemd_module_stream_set_context (MODULEMD_MODULE_STREAM (v2_stream),
+                                          contexts[0]);
+    }
+
+  /* map each BuildConfig object to a Dependencies object */
+  for (guint i = 0; i < g_strv_length (contexts); i++)
+    {
+      bc = modulemd_packager_v3_get_build_config (self, contexts[i]);
+
+      if (i == 0)
+        {
+          /* Use the buildopts from the first build configuration to */
+          /* set the stream buildopts. */
+          buildopts = modulemd_build_config_get_buildopts (bc);
+        }
+
+      deps = modulemd_dependencies_new ();
+
+      modulemd_dependencies_add_buildtime_stream (
+        deps, "platform", modulemd_build_config_get_platform (bc));
+      modulemd_dependencies_add_runtime_stream (
+        deps, "platform", modulemd_build_config_get_platform (bc));
+
+      modules = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+      for (guint j = 0; j < g_strv_length (modules); j++)
+        {
+          modulemd_dependencies_add_buildtime_stream (
+            deps,
+            modules[j],
+            modulemd_build_config_get_buildtime_requirement_stream (
+              bc, modules[j]));
+        }
+      g_clear_pointer (&modules, g_strfreev);
+
+      modules = modulemd_build_config_get_runtime_modules_as_strv (bc);
+      for (guint j = 0; j < g_strv_length (modules); j++)
+        {
+          modulemd_dependencies_add_runtime_stream (
+            deps,
+            modules[j],
+            modulemd_build_config_get_runtime_requirement_stream (bc,
+                                                                  modules[j]));
+        }
+      g_clear_pointer (&modules, g_strfreev);
+
+      modulemd_module_stream_v2_add_dependencies (v2_stream, deps);
+      g_clear_object (&deps);
+    }
+  g_clear_pointer (&contexts, g_strfreev);
+
+  if (buildopts)
+    {
+      modulemd_module_stream_v2_set_buildopts (v2_stream, buildopts);
+    }
+
+  if (!modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (v2_stream),
+                                        &nested_error))
+    {
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return NULL;
+    }
+
+  return g_steal_pointer (&v2_stream);
+}
+
+ModulemdModuleIndex *
+modulemd_packager_v3_to_stream_v2_ext (ModulemdPackagerV3 *self,
+                                       GError **error)
+{
+  g_autoptr (ModulemdModuleIndex) index = NULL;
+  g_autoptr (ModulemdModuleStreamV2) v2_stream = NULL;
+  g_autoptr (ModulemdDefaults) defaults = NULL;
+  g_autoptr (GError) nested_error = NULL;
+
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+  g_return_val_if_fail (MODULEMD_IS_PACKAGER_V3 (self), NULL);
+
+  v2_stream = modulemd_packager_v3_to_stream_v2 (self, &nested_error);
+  if (!v2_stream)
+    {
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return NULL;
+    }
+
+  index = modulemd_module_index_new ();
+  if (!modulemd_module_index_add_module_stream (
+        index, MODULEMD_MODULE_STREAM (v2_stream), &nested_error))
+    {
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return NULL;
+    }
+
+  g_clear_object (&v2_stream);
+
+  if (!modulemd_packager_v3_to_defaults (self, &defaults, &nested_error))
+    {
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return NULL;
+    }
+
+  if (defaults)
+    {
+      if (!modulemd_module_index_add_defaults (index, defaults, &nested_error))
+        {
+          g_propagate_error (error, g_steal_pointer (&nested_error));
+          return NULL;
+        }
+
+      g_clear_object (&defaults);
+    }
+
+  return g_steal_pointer (&index);
+}
+
+ModulemdModuleStreamV3 *
+modulemd_packager_v3_to_stream_v3 (ModulemdPackagerV3 *self, GError **error)
+{
+  g_autoptr (ModulemdModuleIndex) index = NULL;
+  g_auto (GStrv) module_names = NULL;
+  ModulemdModule *module = NULL;
+  GPtrArray *module_streams = NULL;
+  ModulemdModuleStream *stream = NULL;
+  g_autoptr (ModulemdModuleStream) stream_copy = NULL;
+  g_autoptr (GError) nested_error = NULL;
+
+
+  index = modulemd_packager_v3_to_stream_v3_ext (self, &nested_error);
+  if (!index)
+    {
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return NULL;
+    }
+
+  module_names = modulemd_module_index_get_module_names_as_strv (index);
+  if (!module_names || g_strv_length (module_names) != 1)
+    {
+      g_set_error_literal (
+        error,
+        MODULEMD_ERROR,
+        MMD_ERROR_UPGRADE,
+        "PackagerV3 to StreamV3 must return a single module.");
+      return NULL;
+    }
+
+  module = modulemd_module_index_get_module (index, module_names[0]);
+  module_streams = modulemd_module_get_all_streams (module);
+
+  if (module_streams->len != 1)
+    {
+      g_set_error_literal (
+        error,
+        MODULEMD_ERROR,
+        MMD_ERROR_UPGRADE,
+        "PackagerV3 to StreamV3 must return a single stream.");
+      return NULL;
+    }
+
+  stream = g_ptr_array_index (module_streams, 0);
+  stream_copy = modulemd_module_stream_copy (stream, NULL, NULL);
+
+  g_clear_pointer (&module_names, g_strfreev);
+  g_clear_object (&index);
+
+  /* return the single stream */
+  return MODULEMD_MODULE_STREAM_V3 (g_steal_pointer (&stream_copy));
+}
+
+ModulemdModuleIndex *
+modulemd_packager_v3_to_stream_v3_ext (ModulemdPackagerV3 *self,
+                                       GError **error)
+{
+  g_autoptr (ModulemdModuleIndex) index = NULL;
+  g_autoptr (ModulemdModuleStreamV3) v3_stream = NULL;
+  g_autoptr (ModulemdDefaults) defaults = NULL;
+  g_autoptr (ModulemdProfile) profile = NULL;
+  g_auto (GStrv) modules = NULL;
+  g_autoptr (GError) nested_error = NULL;
+  GHashTableIter bc_iter;
+  gpointer bc_key;
+  gpointer bc_value;
+  GHashTableIter p_iter;
+  gpointer p_value;
+  gchar *context;
+  ModulemdBuildConfig *bc;
+  ModulemdBuildopts *bo;
+
+
+  g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+  g_return_val_if_fail (MODULEMD_IS_PACKAGER_V3 (self), NULL);
+
+  index = modulemd_module_index_new ();
+
+  g_hash_table_iter_init (&bc_iter, self->build_configs);
+  while (g_hash_table_iter_next (&bc_iter, &bc_key, &bc_value))
+    {
+      context = (gchar *)bc_key;
+      bc = MODULEMD_BUILD_CONFIG (bc_value);
+
+      /* create a new StreamV3 for each BuildConfig in PackagerV3 */
+
+      v3_stream =
+        modulemd_module_stream_v3_new (self->module_name, self->stream_name);
+
+      /* copy per-BuildConfig properties to the new StreamV3 */
+
+      modulemd_module_stream_set_context (MODULEMD_MODULE_STREAM (v3_stream),
+                                          context);
+
+      modulemd_module_stream_v3_set_platform (
+        v3_stream, modulemd_build_config_get_platform (bc));
+
+      modules = modulemd_build_config_get_runtime_modules_as_strv (bc);
+      for (guint i = 0; i < g_strv_length (modules); i++)
+        {
+          modulemd_module_stream_v3_add_runtime_requirement (
+            v3_stream,
+            modules[i],
+            modulemd_build_config_get_runtime_requirement_stream (bc,
+                                                                  modules[i]));
+        }
+      g_clear_pointer (&modules, g_strfreev);
+
+      modules = modulemd_build_config_get_buildtime_modules_as_strv (bc);
+      for (guint i = 0; i < g_strv_length (modules); i++)
+        {
+          modulemd_module_stream_v3_add_buildtime_requirement (
+            v3_stream,
+            modules[i],
+            modulemd_build_config_get_buildtime_requirement_stream (
+              bc, modules[i]));
+        }
+      g_clear_pointer (&modules, g_strfreev);
+
+      bo = modulemd_build_config_get_buildopts (bc);
+      if (bo)
+        {
+          modulemd_module_stream_v3_set_buildopts (v3_stream, bo);
+        }
+
+      /* copy remaining general properties from PackagerV3 to StreamV3 */
+
+      modulemd_module_stream_v3_set_summary (
+        v3_stream, modulemd_packager_v3_get_summary (self));
+
+      modulemd_module_stream_v3_set_description (
+        v3_stream, modulemd_packager_v3_get_description (self));
+
+      modulemd_module_stream_v3_replace_module_licenses (
+        v3_stream, self->module_licenses);
+
+      modulemd_module_stream_v3_set_xmd (v3_stream,
+                                         modulemd_packager_v3_get_xmd (self));
+
+      modulemd_module_stream_v3_set_community (
+        v3_stream, modulemd_packager_v3_get_community (self));
+
+      modulemd_module_stream_v3_set_documentation (
+        v3_stream, modulemd_packager_v3_get_documentation (self));
+
+      modulemd_module_stream_v3_set_tracker (
+        v3_stream, modulemd_packager_v3_get_tracker (self));
+
+      modulemd_module_stream_v3_replace_rpm_api (v3_stream, self->rpm_api);
+
+      modulemd_module_stream_v3_replace_rpm_filters (v3_stream,
+                                                     self->rpm_filters);
+
+      g_hash_table_iter_init (&p_iter, self->profiles);
+      while (g_hash_table_iter_next (&p_iter, NULL, &p_value))
+        {
+          profile = modulemd_profile_copy (MODULEMD_PROFILE (p_value));
+          modulemd_profile_unset_default (profile);
+          modulemd_module_stream_v3_add_profile (v3_stream, profile);
+          g_clear_object (&profile);
+        }
+
+      /* Internal Data Structures: With add on value */
+      COPY_HASHTABLE_BY_VALUE_ADDER (v3_stream,
+                                     self,
+                                     rpm_components,
+                                     modulemd_module_stream_v3_add_component);
+      COPY_HASHTABLE_BY_VALUE_ADDER (v3_stream,
+                                     self,
+                                     module_components,
+                                     modulemd_module_stream_v3_add_component);
+
+      if (!modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (v3_stream),
+                                            &nested_error))
+        {
+          g_propagate_error (error, g_steal_pointer (&nested_error));
+          return NULL;
+        }
+
+      /* add the StreamV3 object to the index */
+      if (!modulemd_module_index_add_module_stream (
+            index, MODULEMD_MODULE_STREAM (v3_stream), &nested_error))
+        {
+          g_propagate_error (error, g_steal_pointer (&nested_error));
+          return NULL;
+        }
+
+      g_clear_object (&v3_stream);
+    }
+
+  if (!modulemd_packager_v3_to_defaults (self, &defaults, &nested_error))
+    {
+      g_propagate_error (error, g_steal_pointer (&nested_error));
+      return NULL;
+    }
+
+  if (defaults)
+    {
+      if (!modulemd_module_index_add_defaults (index, defaults, &nested_error))
+        {
+          g_propagate_error (error, g_steal_pointer (&nested_error));
+          return NULL;
+        }
+
+      g_clear_object (&defaults);
+    }
+
+  return g_steal_pointer (&index);
 }
 
 

--- a/modulemd/modulemd-profile.c
+++ b/modulemd/modulemd-profile.c
@@ -118,6 +118,11 @@ modulemd_profile_copy (ModulemdProfile *self)
   g_hash_table_unref (p->rpms);
   p->rpms = g_hash_table_ref (self->rpms);
 
+  if (modulemd_profile_is_default (self))
+    {
+      modulemd_profile_set_default (p);
+    }
+
   return g_steal_pointer (&p);
 }
 
@@ -517,6 +522,12 @@ modulemd_profile_emit_yaml (ModulemdProfile *self,
                                       "Failed to emit profile rpms: ");
           return FALSE;
         }
+    }
+
+  /* Only output default if it's TRUE */
+  if (modulemd_profile_is_default (self))
+    {
+      EMIT_KEY_VALUE (emitter, error, "default", "true");
     }
 
   ret = mmd_emitter_end_mapping (emitter, &nested_error);

--- a/modulemd/modulemd.c
+++ b/modulemd/modulemd.c
@@ -20,6 +20,27 @@ modulemd_get_version (void)
   return LIBMODULEMD_VERSION;
 }
 
+
+static ModulemdModuleStreamVersionEnum default_mdversion =
+  (ModulemdModuleStreamVersionEnum)DEFAULT_STREAM_MDVERSION;
+
+void
+modulemd_set_default_stream_mdversion (
+  ModulemdModuleStreamVersionEnum mdversion)
+{
+  g_return_if_fail (mdversion >= MD_MODULESTREAM_VERSION_ONE &&
+                    mdversion <= MD_MODULESTREAM_VERSION_LATEST);
+
+  default_mdversion = mdversion;
+}
+
+ModulemdModuleStreamVersionEnum
+modulemd_get_default_stream_mdversion (void)
+{
+  return default_mdversion;
+}
+
+
 static ModulemdModuleIndex *
 verify_load (int ret,
              ModulemdModuleIndex *idx,

--- a/modulemd/tests/test-modulemd-common.c
+++ b/modulemd/tests/test-modulemd-common.c
@@ -29,6 +29,46 @@ test_modulemd_get_version (void)
 
 
 static void
+test_modulemd_default_stream_mdversion (void)
+{
+  ModulemdModuleStreamVersionEnum mdv;
+  ModulemdModuleStreamVersionEnum default_mdv;
+
+  /* get the default version */
+  default_mdv = modulemd_get_default_stream_mdversion ();
+  /* make sure we can set it to the default value */
+  modulemd_set_default_stream_mdversion (default_mdv);
+
+  /* set a known valid version and make sure we get that version back */
+  modulemd_set_default_stream_mdversion (MD_MODULESTREAM_VERSION_TWO);
+
+  mdv = modulemd_get_default_stream_mdversion ();
+  g_assert_cmpint (MD_MODULESTREAM_VERSION_TWO, ==, mdv);
+
+  /* set another known valid version and make sure we get that version back */
+  modulemd_set_default_stream_mdversion (MD_MODULESTREAM_VERSION_THREE);
+
+  mdv = modulemd_get_default_stream_mdversion ();
+  g_assert_cmpint (MD_MODULESTREAM_VERSION_THREE, ==, mdv);
+
+  /* attempt to set a bad version */
+  modulemd_test_signal = 0;
+  signal (SIGTRAP, modulemd_test_signal_handler);
+  modulemd_set_default_stream_mdversion (MD_MODULESTREAM_VERSION_UNSET);
+  g_assert_cmpint (modulemd_test_signal, ==, SIGTRAP);
+
+  /* attempt to set another bad version */
+  modulemd_test_signal = 0;
+  signal (SIGTRAP, modulemd_test_signal_handler);
+  modulemd_set_default_stream_mdversion (99);
+  g_assert_cmpint (modulemd_test_signal, ==, SIGTRAP);
+
+  /* reset default to avoid unexpected results from other tests */
+  modulemd_set_default_stream_mdversion (default_mdv);
+}
+
+
+static void
 test_modulemd_load_file (void)
 {
   g_autofree gchar *yaml_file = NULL;
@@ -161,6 +201,10 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/modulemd/v2/common/get_version",
                    test_modulemd_get_version);
+
+  g_test_add_func ("/modulemd/v2/common/default_mdversion",
+                   test_modulemd_default_stream_mdversion);
+
   g_test_add_func ("/modulemd/v2/common/load_file", test_modulemd_load_file);
   g_test_add_func ("/modulemd/v2/common/load_string",
                    test_modulemd_load_string);

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -18,6 +18,7 @@
 #include <yaml.h>
 
 #include "config.h"
+#include "modulemd.h"
 #include "modulemd-defaults.h"
 #include "modulemd-obsoletes.h"
 #include "modulemd-module-index.h"
@@ -389,6 +390,7 @@ module_index_test_stream_upgrade (void)
   g_autoptr (GError) error = NULL;
 
   /* Construct an Index with some objects */
+  modulemd_set_default_stream_mdversion (MD_MODULESTREAM_VERSION_ONE);
   index = modulemd_module_index_new ();
 
   /* Add some streams */

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -1663,6 +1663,27 @@ module_packager_v2_sanity (void)
 
 
 static void
+module_packager_v3_sanity (void)
+{
+  g_autoptr (ModulemdModuleStream) stream = NULL;
+  g_autoptr (GError) error = NULL;
+
+  g_autofree gchar *packagerV3Path = g_strdup_printf (
+    "%s/yaml_specs/modulemd_packager_v3.yaml", g_getenv ("MESON_SOURCE_ROOT"));
+  stream = modulemd_module_stream_read_file (
+    packagerV3Path, TRUE, NULL, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (stream);
+
+  /* confirm packager v3 document was returned as stream v2 */
+  g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (stream));
+
+  g_clear_object (&stream);
+  g_clear_pointer (&packagerV3Path, g_free);
+}
+
+
+static void
 module_stream_v1_test_rpm_artifacts (void)
 {
   g_autoptr (ModulemdModuleStreamV1) stream = NULL;
@@ -4785,6 +4806,9 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/modulemd/v2/packager/v2_sanity",
                    module_packager_v2_sanity);
+
+  g_test_add_func ("/modulemd/v2/packager/v3_sanity",
+                   module_packager_v3_sanity);
 
   g_test_add_func ("/modulemd/v2/modulestream/upgrade_v1_to_v2",
                    module_stream_test_upgrade_v1_to_v2);

--- a/modulemd/tests/test-modulemd-packager-v3.c
+++ b/modulemd/tests/test-modulemd-packager-v3.c
@@ -173,9 +173,15 @@ validate_spec (ModulemdPackagerV3 *packager)
   g_assert_null (strv[2]);
   g_clear_pointer (&strv, g_strfreev);
 
-  g_assert_cmpstr ("http://www.example.com/", ==, modulemd_packager_v3_get_community (packager));
-  g_assert_cmpstr ("http://www.example.com/", ==, modulemd_packager_v3_get_documentation (packager));
-  g_assert_cmpstr ("http://www.example.com/", ==, modulemd_packager_v3_get_tracker (packager));
+  g_assert_cmpstr ("http://www.example.com/",
+                   ==,
+                   modulemd_packager_v3_get_community (packager));
+  g_assert_cmpstr ("http://www.example.com/",
+                   ==,
+                   modulemd_packager_v3_get_documentation (packager));
+  g_assert_cmpstr ("http://www.example.com/",
+                   ==,
+                   modulemd_packager_v3_get_tracker (packager));
 
   strv = modulemd_packager_v3_get_profile_names_as_strv (packager);
   g_assert_nonnull (strv);
@@ -255,6 +261,192 @@ packager_test_parse_spec_copy (void)
 }
 
 
+static void
+packager_test_map_to_stream_v2 (void)
+{
+  g_autoptr (ModulemdPackagerV3) packager = NULL;
+  g_autoptr (ModulemdModuleStreamV2) v2_stream = NULL;
+  g_autoptr (ModulemdModuleIndex) index = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *yaml_str = NULL;
+  g_autofree gchar *expected_path = NULL;
+  g_autofree gchar *expected_str = NULL;
+
+  packager = read_spec ();
+
+  v2_stream = modulemd_packager_v3_to_stream_v2 (packager, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (v2_stream);
+  g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (v2_stream));
+  g_clear_object (&v2_stream);
+
+  index = modulemd_packager_v3_to_stream_v2_ext (packager, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (index);
+  g_assert_true (MODULEMD_IS_MODULE_INDEX (index));
+
+  yaml_str = modulemd_module_index_dump_to_string (index, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (yaml_str);
+
+  g_debug ("YAML dump of index from PackageV3 to StreamV2 mapping:\n%s",
+           yaml_str);
+
+  expected_path = g_strdup_printf ("%s/upgrades/packager_v3_to_stream_v2.yaml",
+                                   g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (expected_path);
+  g_assert_true (
+    g_file_get_contents (expected_path, &expected_str, NULL, &error));
+  g_assert_no_error (error);
+  g_assert_nonnull (expected_str);
+
+  g_assert_cmpstr (expected_str, ==, yaml_str);
+
+  g_clear_object (&index);
+  g_clear_pointer (&yaml_str, g_free);
+  g_clear_pointer (&expected_path, g_free);
+  g_clear_pointer (&expected_str, g_free);
+}
+
+static void
+packager_test_map_to_stream_v3 (void)
+{
+  g_autoptr (ModulemdPackagerV3) packager = NULL;
+  g_autoptr (ModulemdModuleStreamV3) v3_stream = NULL;
+  g_autoptr (ModulemdModuleIndex) index = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *yaml_str = NULL;
+  g_autofree gchar *expected_path = NULL;
+  g_autofree gchar *expected_str = NULL;
+
+  packager = read_spec ();
+
+  v3_stream = modulemd_packager_v3_to_stream_v3 (packager, &error);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_UPGRADE);
+  g_assert_null (v3_stream);
+  g_clear_error (&error);
+
+  index = modulemd_packager_v3_to_stream_v3_ext (packager, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (index);
+  g_assert_true (MODULEMD_IS_MODULE_INDEX (index));
+
+  yaml_str = modulemd_module_index_dump_to_string (index, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (yaml_str);
+
+  g_debug ("YAML dump of index from PackageV3 to StreamV3 mapping:\n%s",
+           yaml_str);
+
+  expected_path = g_strdup_printf ("%s/upgrades/packager_v3_to_stream_v3.yaml",
+                                   g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (expected_path);
+  g_assert_true (
+    g_file_get_contents (expected_path, &expected_str, NULL, &error));
+  g_assert_no_error (error);
+  g_assert_nonnull (expected_str);
+
+  g_assert_cmpstr (expected_str, ==, yaml_str);
+
+  g_clear_object (&index);
+  g_clear_pointer (&yaml_str, g_free);
+  g_clear_pointer (&expected_path, g_free);
+  g_clear_pointer (&expected_str, g_free);
+}
+
+static void
+packager_test_read_to_index (void)
+{
+  gboolean ret;
+  g_autoptr (ModulemdModuleIndex) index = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GPtrArray) failures = NULL;
+  g_autofree gchar *yaml_path = NULL;
+  g_autofree gchar *yaml_str = NULL;
+  g_autofree gchar *expected_path = NULL;
+  g_autofree gchar *expected_str = NULL;
+
+  index = modulemd_module_index_new ();
+
+  /* The modulemd-packager v3 definition */
+  yaml_path = g_strdup_printf ("%s/yaml_specs/modulemd_packager_v3.yaml",
+                               g_getenv ("MESON_SOURCE_ROOT"));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  g_assert_true (ret);
+  g_assert_no_error (error);
+  g_assert_cmpint (failures->len, ==, 0);
+  g_clear_pointer (&yaml_path, g_free);
+  g_clear_pointer (&failures, g_ptr_array_unref);
+
+  g_assert_cmpint (MD_MODULESTREAM_VERSION_TWO,
+                   ==,
+                   modulemd_module_index_get_stream_mdversion (index));
+
+  yaml_str = modulemd_module_index_dump_to_string (index, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (yaml_str);
+
+  g_debug ("packager_test_read_to_index() dump of v2 index:\n%s", yaml_str);
+
+  /* the index should contain the packager v2 document converted to stream v2 */
+  expected_path = g_strdup_printf ("%s/upgrades/packager_v3_to_stream_v2.yaml",
+                                   g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (expected_path);
+  g_assert_true (
+    g_file_get_contents (expected_path, &expected_str, NULL, &error));
+  g_assert_no_error (error);
+  g_assert_nonnull (expected_str);
+  g_clear_pointer (&expected_path, g_free);
+
+  g_assert_cmpstr (expected_str, ==, yaml_str);
+
+  g_clear_object (&index);
+  g_clear_pointer (&yaml_str, g_free);
+  g_clear_pointer (&expected_str, g_free);
+
+  /* create new empty index and immediately upgrade it to modulemd v3 */
+  index = modulemd_module_index_new ();
+  ret = modulemd_module_index_upgrade_streams (
+    index, MD_MODULESTREAM_VERSION_THREE, &error);
+  g_assert_true (ret);
+  g_assert_no_error (error);
+
+  /* The modulemd-packager v3 definition */
+  yaml_path = g_strdup_printf ("%s/yaml_specs/modulemd_packager_v3.yaml",
+                               g_getenv ("MESON_SOURCE_ROOT"));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  g_assert_true (ret);
+  g_assert_no_error (error);
+  g_assert_cmpint (failures->len, ==, 0);
+  g_clear_pointer (&yaml_path, g_free);
+  g_clear_pointer (&failures, g_ptr_array_unref);
+
+  yaml_str = modulemd_module_index_dump_to_string (index, &error);
+  g_assert_no_error (error);
+  g_assert_nonnull (yaml_str);
+
+  g_debug ("packager_test_read_to_index() dump of v3 index:\n%s", yaml_str);
+
+  /* the index should contain the packager v2 document converted to stream v3 */
+  expected_path = g_strdup_printf ("%s/upgrades/packager_v3_to_stream_v3.yaml",
+                                   g_getenv ("TEST_DATA_PATH"));
+  g_assert_nonnull (expected_path);
+  g_assert_true (
+    g_file_get_contents (expected_path, &expected_str, NULL, &error));
+  g_assert_no_error (error);
+  g_assert_nonnull (expected_str);
+  g_clear_pointer (&expected_path, g_free);
+
+  g_assert_cmpstr (expected_str, ==, yaml_str);
+
+  g_clear_object (&index);
+  g_clear_pointer (&yaml_str, g_free);
+  g_clear_pointer (&expected_str, g_free);
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -271,6 +463,15 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/modulemd/v2/packager/yaml/spec/copy",
                    packager_test_parse_spec_copy);
+
+  g_test_add_func ("/modulemd/v2/packager/to_stream_v2",
+                   packager_test_map_to_stream_v2);
+
+  g_test_add_func ("/modulemd/v2/packager/to_stream_v3",
+                   packager_test_map_to_stream_v3);
+
+  g_test_add_func ("/modulemd/v2/packager/index/read",
+                   packager_test_read_to_index);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-profile.c
+++ b/modulemd/tests/test-modulemd-profile.c
@@ -304,6 +304,38 @@ profile_test_copy (void)
   g_clear_pointer (&rpms, g_strfreev);
   g_clear_object (&p);
   g_clear_object (&p_copy);
+
+  /* Test copying profile with default set */
+  p = modulemd_profile_new ("testprofile");
+  modulemd_profile_set_default (p);
+  g_assert_nonnull (p);
+  g_assert_true (MODULEMD_IS_PROFILE (p));
+  g_assert_cmpstr (modulemd_profile_get_name (p), ==, "testprofile");
+  g_assert_true (modulemd_profile_is_default (p));
+
+  p_copy = modulemd_profile_copy (p);
+  g_assert_nonnull (p_copy);
+  g_assert_true (MODULEMD_IS_PROFILE (p_copy));
+  g_assert_cmpstr (modulemd_profile_get_name (p_copy), ==, "testprofile");
+  g_assert_true (modulemd_profile_is_default (p_copy));
+  g_clear_object (&p);
+  g_clear_object (&p_copy);
+
+  /* Test copying profile with default unset */
+  p = modulemd_profile_new ("testprofile");
+  modulemd_profile_unset_default (p);
+  g_assert_nonnull (p);
+  g_assert_true (MODULEMD_IS_PROFILE (p));
+  g_assert_cmpstr (modulemd_profile_get_name (p), ==, "testprofile");
+  g_assert_false (modulemd_profile_is_default (p));
+
+  p_copy = modulemd_profile_copy (p);
+  g_assert_nonnull (p_copy);
+  g_assert_true (MODULEMD_IS_PROFILE (p_copy));
+  g_assert_cmpstr (modulemd_profile_get_name (p_copy), ==, "testprofile");
+  g_assert_false (modulemd_profile_is_default (p_copy));
+  g_clear_object (&p);
+  g_clear_object (&p_copy);
 }
 
 
@@ -477,6 +509,7 @@ profile_test_emit_yaml (void)
   modulemd_profile_add_rpm (p, "test2");
   modulemd_profile_add_rpm (p, "test3");
   modulemd_profile_add_rpm (p, "test1");
+  modulemd_profile_set_default (p);
 
   g_assert_true (mmd_emitter_start_stream (&emitter, &error));
   g_assert_true (mmd_emitter_start_document (&emitter, &error));
@@ -495,6 +528,7 @@ profile_test_emit_yaml (void)
                    "  - test1\n"
                    "  - test2\n"
                    "  - test3\n"
+                   "  default: true\n"
                    "...\n");
 }
 

--- a/modulemd/tests/test_data/upgrades/packager_v3_to_stream_v2.yaml
+++ b/modulemd/tests/test_data/upgrades/packager_v3_to_stream_v2.yaml
@@ -1,102 +1,101 @@
 ---
-document: modulemd
-version: 2
-data:
-    name: testmodule
-    stream: teststream
-    summary: An example module
-    description: >-
-        A module for the demonstration of the metadata format. Also,
-        the obligatory lorem ipsum dolor sit amet goes right here.
-    license:
-        module:
-            - MIT
-    xmd:
-        some_key: some_data
-    dependencies:
-        - buildrequires:
-              platform: [f32]
-              appframework: [v1]
-          requires:
-              platform: [f32]
-              appframework: [v1]
-        - buildrequires:
-              platform: [f33]
-          requires:
-              platform: [f33]
-    references:
-        community: http://www.example.com/
-        documentation: http://www.example.com/
-        tracker: http://www.example.com/
-    profiles:
-        container:
-            rpms:
-                - bar
-                - bar-devel
-        minimal:
-            description: Minimal profile installing only the bar package.
-            rpms:
-                - bar
-        buildroot:
-            rpms:
-                - bar-devel
-        srpm-buildroot:
-            rpms:
-                - bar-extras
-    api:
-        rpms:
-            - bar
-            - bar-extras
-            - bar-devel
-            - baz
-            - xxx
-    filter:
-        rpms:
-            - baz-nonfoo
-    buildopts:
-        rpms:
-            macros: |
-                %demomacro 1
-                %demomacro2 %{demomacro}23
-            whitelist:
-                - fooscl-1-bar
-                - fooscl-1-baz
-                - xxx
-                - xyz
-        arches: [i686, x86_64]
-    components:
-        rpms:
-            bar:
-                name: bar-real
-                rationale: We need this to demonstrate stuff.
-                repository: https://pagure.io/bar.git
-                cache: https://example.com/cache
-                ref: 26ca0c0
-                buildonly: false
-            baz:
-                rationale: Demonstrate updating the buildroot contents.
-                buildroot: true
-                srpm-buildroot: true
-                buildorder: -1
-            xxx:
-                rationale: xxx demonstrates arches and multilib.
-                arches: [i686, x86_64]
-                multilib: [x86_64]
-            xyz:
-                rationale: xyz is a bundled dependency of xxx.
-                buildorder: 10
-        modules:
-            includedmodule:
-                rationale: Included in the stack, just because.
-                repository: https://pagure.io/includedmodule.git
-                ref: somecoolbranchname
-                buildorder: 100
-...
----
 document: modulemd-defaults
 version: 1
 data:
-  module: testmodule
+  module: foo
   profiles:
-    'teststream': [minimal]
+    latest: [minimal]
+...
+---
+document: modulemd
+version: 2
+data:
+  name: foo
+  stream: latest
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+  xmd:
+    some_key: some_data
+  dependencies:
+  - buildrequires:
+      appframework: [v1]
+      platform: [f32]
+    requires:
+      appframework: [v1]
+      platform: [f32]
+  - buildrequires:
+      platform: [f33]
+    requires:
+      platform: [f33]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+        buildafter:
+        - baz
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        buildafter:
+        - bar
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
 ...

--- a/modulemd/tests/test_data/upgrades/packager_v3_to_stream_v3.yaml
+++ b/modulemd/tests/test_data/upgrades/packager_v3_to_stream_v3.yaml
@@ -1,177 +1,170 @@
 ---
-document: modulemd-stream
-version: 3
-data:
-    name: testmodule
-    stream: teststream
-    version: 1
-    context: CTX1
-    arch: x86_64
-    summary: An example module
-    description: >-
-        A module for the demonstration of the metadata format. Also,
-        the obligatory lorem ipsum dolor sit amet goes right here.
-    license:
-        module:
-            - MIT
-    xmd:
-        some_key: some_data
-    dependencies:
-        platform: f32
-        buildrequires:
-            appframework: v1
-        requires:
-            appframework: v1
-    references:
-        community: http://www.example.com/
-        documentation: http://www.example.com/
-        tracker: http://www.example.com/
-    profiles:
-        container:
-            rpms:
-                - bar
-                - bar-devel
-        minimal:
-            description: Minimal profile installing only the bar package.
-            rpms:
-                - bar
-        buildroot:
-            rpms:
-                - bar-devel
-        srpm-buildroot:
-            rpms:
-                - bar-extras
-    api:
-        rpms:
-            - bar
-            - bar-extras
-            - bar-devel
-            - baz
-            - xxx
-    filter:
-        rpms:
-            - baz-nonfoo
-    buildopts:
-        rpms:
-            macros: |
-                %demomacro 1
-                %demomacro2 %{demomacro}23
-            whitelist:
-                - fooscl-1-bar
-                - fooscl-1-baz
-                - xxx
-                - xyz
-        arches: [i686, x86_64]
-    components:
-        rpms:
-            bar:
-                name: bar-real
-                rationale: We need this to demonstrate stuff.
-                repository: https://pagure.io/bar.git
-                cache: https://example.com/cache
-                ref: 26ca0c0
-                buildonly: false
-            baz:
-                rationale: Demonstrate updating the buildroot contents.
-                buildroot: true
-                srpm-buildroot: true
-                buildorder: -1
-            xxx:
-                rationale: xxx demonstrates arches and multilib.
-                arches: [i686, x86_64]
-                multilib: [x86_64]
-            xyz:
-                rationale: xyz is a bundled dependency of xxx.
-                buildorder: 10
-        modules:
-            includedmodule:
-                rationale: Included in the stack, just because.
-                repository: https://pagure.io/includedmodule.git
-                ref: somecoolbranchname
-                buildorder: 100
-...
----
-document: modulemd-stream
-version: 3
-data:
-    name: testmodule
-    stream: teststream
-    version: 1
-    context: CTX2
-    arch: x86_64
-    summary: An example module
-    description: >-
-        A module for the demonstration of the metadata format. Also,
-        the obligatory lorem ipsum dolor sit amet goes right here.
-    license:
-        module:
-            - MIT
-    xmd:
-        some_key: some_data
-    dependencies:
-        platform: f33
-    references:
-        community: http://www.example.com/
-        documentation: http://www.example.com/
-        tracker: http://www.example.com/
-    profiles:
-        container:
-            rpms:
-                - bar
-                - bar-devel
-        minimal:
-            description: Minimal profile installing only the bar package.
-            rpms:
-                - bar
-        buildroot:
-            rpms:
-                - bar-devel
-        srpm-buildroot:
-            rpms:
-                - bar-extras
-    api:
-        rpms:
-            - bar
-            - bar-extras
-            - bar-devel
-            - baz
-            - xxx
-    filter:
-        rpms:
-            - baz-nonfoo
-    components:
-        rpms:
-            bar:
-                name: bar-real
-                rationale: We need this to demonstrate stuff.
-                repository: https://pagure.io/bar.git
-                cache: https://example.com/cache
-                ref: 26ca0c0
-                buildonly: false
-            baz:
-                rationale: Demonstrate updating the buildroot contents.
-                buildroot: true
-                srpm-buildroot: true
-                buildorder: -1
-            xxx:
-                rationale: xxx demonstrates arches and multilib.
-                arches: [i686, x86_64]
-                multilib: [x86_64]
-            xyz:
-                rationale: xyz is a bundled dependency of xxx.
-                buildorder: 10
-        modules:
-            includedmodule:
-                rationale: Included in the stack, just because.
-                repository: https://pagure.io/includedmodule.git
-                ref: somecoolbranchname
-                buildorder: 100
-...
----
 document: modulemd-defaults
 version: 1
 data:
-  module: testmodule
+  module: foo
   profiles:
-    'teststream': [minimal]
+    latest: [minimal]
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: latest
+  context: CTX1
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: f32
+    buildrequires:
+      appframework: v1
+    requires:
+      appframework: v1
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+        buildafter:
+        - baz
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        buildafter:
+        - bar
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: latest
+  context: CTX2
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: f33
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+        buildafter:
+        - baz
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        buildafter:
+        - bar
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
 ...


### PR DESCRIPTION
This PR provides low level functionality to map PackagerV3 to StreamV2/StreamV3. Also a few corrections to the example YAML files for testing the mapping, as well as minor bug fixes for handling of the Profile 'default' attribute.

Basic tests are included. Of course more could be added later.

This PR should provide the functionality needed to adjust the higher level functions to accept a modulemd-packager v3 document and return it as if it were a modulemd-stream v2 object. However, those adjustments are not included in this PR.