### PR TITLE
Change the specification of `ref`

### DIFF
--- a/yaml_specs/modulemd_packager_v3.yaml
+++ b/yaml_specs/modulemd_packager_v3.yaml
@@ -380,8 +380,10 @@ data:
                 # ref:
                 # Use this specific commit hash, branch name or tag for
                 # the build.  If ref is a branch name, the branch HEAD
-                # will be used.  If no ref is given, the master branch
-                # is assumed.
+                # will be used.  If no ref is given, the build system is
+                # permitted to make reasonable assumptions about the correct
+                # default value. Otherwise, the fall-back is the default branch
+                # for the git repository (commonly 'master').
                 #
                 # Type: AUTOMATIC
                 ref: 26ca0c0


### PR DESCRIPTION
Loosen the restriction on how the build system must treat an
unspecified `ref` in a component. It must always fall back to the
repo's default branch (which may not be 'master' these days), but
if build-system rules exist to pick a different branch, that is
up to the build-system to decide.

Fixes https://pagure.io/modularity/issue/142

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

CC @voxik