### PR TITLE
Handle XMD for ModuleStreamV3 in python

### DIFF
--- a/.travis/fedora/travis-tasks.sh
+++ b/.travis/fedora/travis-tasks.sh
@@ -8,7 +8,13 @@ PROCESSORS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
 MESON_DIRTY_REPO_ARGS="-Dtest_dirty_git=${DIRTY_REPO_CHECK:-false}"
 RETRY_CMD=/builddir/.travis/retry-command.sh
 
+override_dir=`python3 -c 'import gi; print(gi._overridesdir)'`
+
 pushd /builddir/
+
+# Ensure that the python 3 overrides are always in place or else some of those
+# tests may fail if they are modified.
+ln -sf /builddir/bindings/python/gi/Modulemd.py $override_dir/
 
 valgrind_cmd='
     valgrind --error-exitcode=1
@@ -81,7 +87,7 @@ $RETRY_CMD dnf -y install --nogpgcheck \
 
 # Also install the python2-libmodulemd if it was built for this release
 # the ||: at the end instructs bash to consider this a pass either way.
-$RETRY_CMD dnf -y install --nogpgcheck \
+dnf -y install --nogpgcheck \
                --allowerasing \
                --repofrompath libmodulemd-travis,$arch \
                $arch/python2-libmodulemd*.rpm ||:

--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -98,6 +98,21 @@ class ModulemdUtil(object):
 
 if float(Modulemd._version) >= 2:
 
+    class ModuleStreamV3(Modulemd.ModuleStreamV3):
+        def set_xmd(self, xmd):
+            super(ModuleStreamV3, self).set_xmd(
+                ModulemdUtil.python_to_variant(xmd)
+            )
+
+        def get_xmd(self):
+            variant_xmd = super(ModuleStreamV3, self).get_xmd()
+            if variant_xmd is None:
+                return {}
+            return variant_xmd.unpack()
+
+    ModuleStreamV3 = override(ModuleStreamV3)
+    __all__.append(ModuleStreamV3)
+
     class ModuleStreamV2(Modulemd.ModuleStreamV2):
         def set_xmd(self, xmd):
             super(ModuleStreamV2, self).set_xmd(

--- a/modulemd/tests/ModulemdTests/modulestream.py
+++ b/modulemd/tests/ModulemdTests/modulestream.py
@@ -587,39 +587,45 @@ class TestModuleStream(TestBase):
 
     def test_xmd(self):
         if "_overrides_module" in dir(Modulemd):
-            # The XMD python tests can only be run against the installed lib
-            # because the overrides that translate between python and GVariant
-            # must be installed in /usr/lib/python*/site-packages/gi/overrides
-            # or they are not included when importing Modulemd
-            stream = Modulemd.ModuleStreamV2.new("foo", "bar")
-            # An empty dictionary should be returned if no xmd value is set
-            assert stream.get_xmd() == {}
+            for version in modulestream_versions:
+                # The XMD python tests can only be run against the installed lib
+                # because the overrides that translate between python and GVariant
+                # must be installed in /usr/lib/python*/site-packages/gi/overrides
+                # or they are not included when importing Modulemd
+                stream = Modulemd.ModuleStream.new(version, "foo", "bar")
+                # An empty dictionary should be returned if no xmd value is set
+                self.assertEqual(stream.get_xmd(), dict())
 
-            xmd = {"outer_key": {"inner_key": ["scalar", "another_scalar"]}}
+                xmd = {
+                    "outer_key": {"inner_key": ["scalar", "another_scalar"]}
+                }
 
-            stream.set_xmd(xmd)
+                stream.set_xmd(xmd)
 
-            xmd_copy = stream.get_xmd()
-            assert xmd_copy
-            assert "outer_key" in xmd_copy
-            assert "inner_key" in xmd_copy["outer_key"]
-            assert "scalar" in xmd_copy["outer_key"]["inner_key"]
-            assert "another_scalar" in xmd_copy["outer_key"]["inner_key"]
+                xmd_copy = stream.get_xmd()
+                assert xmd_copy
+                assert "outer_key" in xmd_copy
+                assert "inner_key" in xmd_copy["outer_key"]
+                assert "scalar" in xmd_copy["outer_key"]["inner_key"]
+                assert "another_scalar" in xmd_copy["outer_key"]["inner_key"]
 
-            # Verify that we can add content and save it back
-            xmd["something"] = ["foo", "bar"]
-            stream.set_xmd(xmd)
+                # Verify that we can add content and save it back
+                xmd["something"] = ["foo", "bar"]
+                stream.set_xmd(xmd)
 
-            stream.set_summary("foo")
-            stream.set_description("bar")
-            stream.add_module_license("MIT")
+                stream.set_summary("foo")
+                stream.set_description("bar")
+                stream.add_module_license("MIT")
+                if hasattr(stream, 'set_platform'):
+                    stream.set_platform('f33')
 
-            # Verify that we can output the XMD successfully
-            index = Modulemd.ModuleIndex()
-            index.add_module_stream(stream)
-            out_yaml = index.dump_to_string()
+                # Verify that we can output the XMD successfully
+                index = Modulemd.ModuleIndex()
+                index.add_module_stream(stream)
 
-            self.assertIsNotNone(out_yaml)
+                out_yaml = index.dump_to_string()
+
+                self.assertIsNotNone(out_yaml)
 
     def test_upgrade_v1_to_v2(self):
         v1_stream = Modulemd.ModuleStreamV1.new("SuperModule", "latest")


### PR DESCRIPTION
I missed when reviewing ModuleStreamV3 that it didn't support the python override to make dealing with XMD more sane. This corrects that and also makes some minor changes to the test runner to ensure that we are always testing the correct version of the override.

I modified the `test_xmd()` routine from the python tests so it will now test XMD on all available stream versions.

I also dropped the `$RETRY_CMD` from the attempt to install `python2-libmodulemd` for performance reasons. (No need to retry repeatedly when we expect to fail most of the time.)