### PR TITLE
Container-based build setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ __pycache__/
 /fedora/modulemd-*
 /fedora/libmodulemd-*
 *.rpm
+.travis/.home*
+.travis/*/Dockerfile.deps.*

--- a/.travis/fedora/Dockerfile.deps.tmpl
+++ b/.travis/fedora/Dockerfile.deps.tmpl
@@ -49,3 +49,5 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' \
 	valgrind \
 	wget \
     && dnf -y clean all
+
+__EXTRACOMMANDS__

--- a/.travis/travis-common.inc
+++ b/.travis/travis-common.inc
@@ -51,17 +51,47 @@ function common_finalize {
 trap common_finalize EXIT
 
 
-function mmd_run_docker_tests {
+function mmd_setup_container {
     local os release repository image
     local deps_template deps_image
-    local test_template test_image
-    local oci_extra_args
+    local oci_extra_commands
     local "${@}"
 
     if [ -z $SCRIPT_DIR ]; then
         >&2 echo "Programming error: \$SCRIPT_DIR must be set"
         exit 1
     fi
+
+    os=${os-fedora}
+    release=${release-rawhide}
+    repository=${repository-registry.fedoraproject.org}
+
+    # Lower-case the os and release for the container registry
+    MMD_OS=${os,,}
+    MMD_RELEASE=${release,,}
+
+    deps_template=${deps_template-$MMD_OS/Dockerfile.deps.tmpl}
+    deps_image=${deps_image-libmodulemd-deps-$MMD_OS:$MMD_RELEASE}
+
+    m4  -D__IMAGE__="$repository/$image" \
+        -D__OS__=$os \
+        -D__RELEASE__=$release \
+        -D__EXTRACOMMANDS__="$oci_extra_commands" \
+        $SCRIPT_DIR/${deps_template} \
+        > $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE
+
+    $MMD_BUILDAH $MMD_LAYERS_TRUE \
+        -f $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE \
+        -t fedora-modularity/${deps_image} .
+}
+
+
+function mmd_run_docker_tests {
+    local os release repository image
+    local deps_template deps_image
+    local test_template test_image
+    local oci_extra_args
+    local "${@}"
 
     os=${os-fedora}
     release=${release-rawhide}
@@ -85,21 +115,19 @@ function mmd_run_docker_tests {
     git ls-files |xargs tar cfj $MMD_TARBALL_PATH .git
     popd
 
-    m4  -D__IMAGE__="$repository/$image" \
-        -D__OS__=$os \
-        -D__RELEASE__=$release \
-        $SCRIPT_DIR/${deps_template} \
-        > $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE
+    mmd_setup_container \
+        os=$os \
+        release=$release \
+        repository=$repository \
+        image=$image \
+        deps_template=$deps_template \
+        deps_image=$deps_image
 
     m4  -D__DEPS_IMAGE__="fedora-modularity/${deps_image}" \
         -D__OS__=$os \
         -D__RELEASE__=$release \
         $SCRIPT_DIR/${test_template} \
         > $SCRIPT_DIR/$MMD_OS/Dockerfile.test.$MMD_RELEASE
-
-    $MMD_BUILDAH $MMD_LAYERS_TRUE \
-        -f $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE \
-        -t fedora-modularity/${deps_image} .
 
     $MMD_BUILDAH $MMD_LAYERS_FALSE \
         -f $SCRIPT_DIR/$MMD_OS/Dockerfile.test.$MMD_RELEASE \

--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -98,70 +98,75 @@ class ModulemdUtil(object):
 
 if float(Modulemd._version) >= 2:
 
-    class ModuleStreamV3(Modulemd.ModuleStreamV3):
-        def set_xmd(self, xmd):
-            super(ModuleStreamV3, self).set_xmd(
-                ModulemdUtil.python_to_variant(xmd)
-            )
-
-        def get_xmd(self):
-            variant_xmd = super(ModuleStreamV3, self).get_xmd()
-            if variant_xmd is None:
-                return {}
-            return variant_xmd.unpack()
-
-    ModuleStreamV3 = override(ModuleStreamV3)
-    __all__.append(ModuleStreamV3)
-
-    class ModuleStreamV2(Modulemd.ModuleStreamV2):
-        def set_xmd(self, xmd):
-            super(ModuleStreamV2, self).set_xmd(
-                ModulemdUtil.python_to_variant(xmd)
-            )
-
-        def get_xmd(self):
-            variant_xmd = super(ModuleStreamV2, self).get_xmd()
-            if variant_xmd is None:
-                return {}
-            return variant_xmd.unpack()
-
-    ModuleStreamV2 = override(ModuleStreamV2)
-    __all__.append(ModuleStreamV2)
-
-    class ModuleStreamV1(Modulemd.ModuleStreamV1):
-        def set_xmd(self, xmd):
-            super(ModuleStreamV1, self).set_xmd(
-                ModulemdUtil.python_to_variant(xmd)
-            )
-
-        def get_xmd(self):
-            variant_xmd = super(ModuleStreamV1, self).get_xmd()
-            if variant_xmd is None:
-                return {}
-            return variant_xmd.unpack()
-
-    ModuleStreamV1 = override(ModuleStreamV1)
-    __all__.append(ModuleStreamV1)
-
-    class ServiceLevel(Modulemd.ServiceLevel):
-        def set_eol(self, eol):
-            if isinstance(eol, datetime.date):
-                return super(ServiceLevel, self).set_eol_ymd(
-                    eol.year, eol.month, eol.day
+    if hasattr(Modulemd, 'ModuleStreamV3'):
+        class ModuleStreamV3(Modulemd.ModuleStreamV3):
+            def set_xmd(self, xmd):
+                super(ModuleStreamV3, self).set_xmd(
+                    ModulemdUtil.python_to_variant(xmd)
                 )
 
-            raise TypeError(
-                "Expected datetime.date, but got %s." % (type(eol).__name__)
-            )
+            def get_xmd(self):
+                variant_xmd = super(ModuleStreamV3, self).get_xmd()
+                if variant_xmd is None:
+                    return {}
+                return variant_xmd.unpack()
 
-        def get_eol(self):
-            eol = super(ServiceLevel, self).get_eol()
-            if eol is None:
-                return None
+        ModuleStreamV3 = override(ModuleStreamV3)
+        __all__.append(ModuleStreamV3)
 
-            return datetime.date(
-                eol.get_year(), eol.get_month(), eol.get_day()
-            )
+    if hasattr(Modulemd, 'ModuleStreamV2'):
+        class ModuleStreamV2(Modulemd.ModuleStreamV2):
+            def set_xmd(self, xmd):
+                super(ModuleStreamV2, self).set_xmd(
+                    ModulemdUtil.python_to_variant(xmd)
+                )
 
-    ServiceLevel = override(ServiceLevel)
-    __all__.append(ServiceLevel)
+            def get_xmd(self):
+                variant_xmd = super(ModuleStreamV2, self).get_xmd()
+                if variant_xmd is None:
+                    return {}
+                return variant_xmd.unpack()
+
+        ModuleStreamV2 = override(ModuleStreamV2)
+        __all__.append(ModuleStreamV2)
+
+    if hasattr(Modulemd, 'ModuleStreamV1'):
+        class ModuleStreamV1(Modulemd.ModuleStreamV1):
+            def set_xmd(self, xmd):
+                super(ModuleStreamV1, self).set_xmd(
+                    ModulemdUtil.python_to_variant(xmd)
+                )
+
+            def get_xmd(self):
+                variant_xmd = super(ModuleStreamV1, self).get_xmd()
+                if variant_xmd is None:
+                    return {}
+                return variant_xmd.unpack()
+
+        ModuleStreamV1 = override(ModuleStreamV1)
+        __all__.append(ModuleStreamV1)
+
+    if hasattr(Modulemd, 'ServiceLevel'):
+        class ServiceLevel(Modulemd.ServiceLevel):
+            def set_eol(self, eol):
+                if isinstance(eol, datetime.date):
+                    return super(ServiceLevel, self).set_eol_ymd(
+                        eol.year, eol.month, eol.day
+                    )
+
+                raise TypeError(
+                    "Expected datetime.date, but got %s." % (type(eol).__name__)
+                )
+
+            def get_eol(self):
+                eol = super(ServiceLevel, self).get_eol()
+                if eol is None:
+                    return None
+
+                return datetime.date(
+                    eol.get_year(), eol.get_month(), eol.get_day()
+                )
+
+        ServiceLevel = override(ServiceLevel)
+        __all__.append(ServiceLevel)
+

--- a/setup_dev_container.sh
+++ b/setup_dev_container.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$SOURCE_DIR/.travis"
+pushd $SCRIPT_DIR
+
+source $SCRIPT_DIR/travis-common.inc
+
+set -e
+set -x
+
+HOME=${HOME-/}
+
+release=${1:-$($SCRIPT_DIR/get_rawhide_version.py)}
+image=fedora/fedora:$release-$(uname -m)
+
+
+mmd_setup_container \
+    os=fedora \
+    release=$release \
+    repository=quay.io \
+    image=$image \
+    oci_extra_commands='RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py' \
+    deps_image=libmodulemd-dev-$release
+
+
+# Create a home directory to log into
+homedir=$SCRIPT_DIR/.home_fedora
+if [ ! -d $homedir ]; then
+    cp -a /etc/skel $homedir
+fi
+
+eval $MMD_OCI run \
+     --rm \
+     --tty \
+     --interactive \
+     --name libmodulemd-dev-$release \
+     --hostname libmodulemd-dev-$release \
+     --userns keep-id \
+     --volume=$homedir:$HOME:Z \
+     --volume=$SOURCE_DIR:/builddir:Z \
+     --workdir=/builddir \
+     --env HOME=$HOME \
+     fedora-modularity/libmodulemd-dev-$release \
+     /usr/bin/bash
+
+set +x


### PR DESCRIPTION
Create a script in the root to produce a container that can build libmodulemd (and test against the GObject overrides without impacting the host system). Run it with `./setup_dev_container.sh`

TODO: Update documentation to explain how to use it.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>