### PR TITLE
Add wrapper script to simplify running valgrind tests

### DIFF
--- a/.travis/fedora/travis-tasks.sh
+++ b/.travis/fedora/travis-tasks.sh
@@ -16,15 +16,6 @@ pushd /builddir/
 # tests may fail if they are modified.
 ln -sf /builddir/bindings/python/gi/Modulemd.py $override_dir/
 
-valgrind_cmd='
-    valgrind --error-exitcode=1
-             --errors-for-leak-kinds=definite
-             --leak-check=full
-             --show-leak-kinds=definite
-             --suppressions=/usr/share/glib-2.0/valgrind/glib.supp
-             --suppressions=/builddir/contrib/valgrind/libmodulemd-python.supp
-'
-
 # Build the code under GCC and run standard tests
 meson --buildtype=debug \
       $MESON_DIRTY_REPO_ARGS \
@@ -43,7 +34,7 @@ meson test --suite ci \
            -t 5
 
 meson test --suite ci_valgrind \
-           --wrap="$valgrind_cmd" \
+           --wrap=/builddir/contrib/valgrind/valgrind_wrapper.sh \
            -C travis \
            --num-processes=$PROCESSORS \
            --print-errorlogs \

--- a/.travis/mageia/travis-tasks.sh
+++ b/.travis/mageia/travis-tasks.sh
@@ -10,15 +10,6 @@ COMMON_MESON_ARGS="-Dtest_dirty_git=${DIRTY_REPO_CHECK:-false} -Ddeveloper_build
 
 pushd /builddir/
 
-valgrind_cmd='
-    valgrind --error-exitcode=1
-             --errors-for-leak-kinds=definite
-             --leak-check=full
-             --show-leak-kinds=definite
-             --suppressions=/usr/share/glib-2.0/valgrind/glib.supp
-             --suppressions=/builddir/contrib/valgrind/libmodulemd-python.supp
-'
-
 # Build the code under GCC and run standard tests
 meson --buildtype=debug \
       $COMMON_MESON_ARGS \
@@ -31,7 +22,7 @@ meson test --suite ci \
            -t 5
 
 meson test --suite ci_valgrind \
-           --wrap="$valgrind_cmd" \
+           --wrap=/builddir/contrib/valgrind/valgrind_wrapper.sh \
            -C travis \
            --num-processes=$PROCESSORS \
            --print-errorlogs \

--- a/README.md
+++ b/README.md
@@ -347,14 +347,7 @@ and ignored at runtime.
 ### Running tests with valgrind
 Assuming your current working directory is `debugbuild` as described above:
 ```
-meson test --suite=ci_valgrind \
-  --wrap="valgrind
-            --error-exitcode=1
-            --errors-for-leak-kinds=definite
-            --leak-check=full
-            --show-leak-kinds=definite
-            --suppressions=/usr/share/glib-2.0/valgrind/glib.supp
-            --suppressions=/builddir/contrib/valgrind/libmodulemd-python.supp"
+meson test --suite=ci_valgrind --wrap=../contrib/valgrind/valgrind_wrapper.sh
 ```
 
 If not, you may need to adjust the path to libmodulemd-python.supp.

--- a/contrib/valgrind/valgrind_wrapper.sh
+++ b/contrib/valgrind/valgrind_wrapper.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+set -e
+set -x
+
+valgrind \
+    --error-exitcode=1 \
+    --errors-for-leak-kinds=definite \
+    --leak-check=full \
+    --show-leak-kinds=definite \
+    --suppressions=/usr/share/glib-2.0/valgrind/glib.supp \
+    --suppressions=$SCRIPT_DIR/libmodulemd-python.supp \
+    "$@"


### PR DESCRIPTION
The command line to manually run `valgrind` tests is getting unwieldy. This PR creates a wrapper script to simplify that and updates `README.md` accordingly.