### PR TITLE
Upgrade helper

### DIFF
--- a/.travis/archlinux/Dockerfile.deps.tmpl
+++ b/.travis/archlinux/Dockerfile.deps.tmpl
@@ -16,3 +16,5 @@ RUN pacman -Syu --needed --noconfirm \
 	python-gobject \
 	python2-six \
 && pacman -Scc --noconfirm
+
+RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py

--- a/.travis/centos/Dockerfile.deps.tmpl
+++ b/.travis/centos/Dockerfile.deps.tmpl
@@ -41,3 +41,5 @@ ifelse(eval(__RELEASE__ < 8), 1, `dnl
 	rpmdevtools \
 	sudo \
     && yum -y clean all
+
+RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py

--- a/.travis/fedora/Dockerfile.deps.tmpl
+++ b/.travis/fedora/Dockerfile.deps.tmpl
@@ -36,6 +36,7 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' \
 	python3-devel \
 	python3-GitPython \
 	python3-gobject-base \
+	python3-koji \
 	python3-pycodestyle \
 	python3-rpm-macros \
 	redhat-rpm-config \
@@ -50,4 +51,4 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' \
 	wget \
     && dnf -y clean all
 
-__EXTRACOMMANDS__
+RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py

--- a/.travis/fedora/travis-tasks.sh
+++ b/.travis/fedora/travis-tasks.sh
@@ -12,10 +12,6 @@ override_dir=`python3 -c 'import gi; print(gi._overridesdir)'`
 
 pushd /builddir/
 
-# Ensure that the python 3 overrides are always in place or else some of those
-# tests may fail if they are modified.
-ln -sf /builddir/bindings/python/gi/Modulemd.py $override_dir/
-
 # Build the code under GCC and run standard tests
 meson --buildtype=debug \
       $MESON_DIRTY_REPO_ARGS \

--- a/.travis/mageia/Dockerfile.deps.tmpl
+++ b/.travis/mageia/Dockerfile.deps.tmpl
@@ -42,3 +42,5 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	valgrind \
 	wget \
     && dnf -y clean all
+
+RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py

--- a/.travis/openmandriva/Dockerfile.deps.tmpl
+++ b/.travis/openmandriva/Dockerfile.deps.tmpl
@@ -25,3 +25,5 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	git-core \
 	elinks \
     && dnf -y clean all
+
+RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py

--- a/.travis/opensuse/Dockerfile.deps.tmpl
+++ b/.travis/opensuse/Dockerfile.deps.tmpl
@@ -35,3 +35,5 @@ RUN zypper install --no-confirm --no-recommends --capability \
 	sudo \
 	valgrind \
 && zypper clean --all
+
+RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py

--- a/.travis/travis-common.inc
+++ b/.travis/travis-common.inc
@@ -54,7 +54,6 @@ trap common_finalize EXIT
 function mmd_setup_container {
     local os release repository image
     local deps_template deps_image
-    local oci_extra_commands
     local "${@}"
 
     if [ -z $SCRIPT_DIR ]; then
@@ -76,7 +75,6 @@ function mmd_setup_container {
     m4  -D__IMAGE__="$repository/$image" \
         -D__OS__=$os \
         -D__RELEASE__=$release \
-        -D__EXTRACOMMANDS__="$oci_extra_commands" \
         $SCRIPT_DIR/${deps_template} \
         > $SCRIPT_DIR/$MMD_OS/Dockerfile.deps.$MMD_RELEASE
 

--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -98,6 +98,19 @@ class ModulemdUtil(object):
 
 if float(Modulemd._version) >= 2:
 
+    if hasattr(Modulemd, "UpgradeHelper"):
+
+        class UpgradeHelper(Modulemd.UpgradeHelper):
+            def set_known_streams(self, known_streams):
+                for module, streams in known_streams.items():
+                    for stream in streams:
+                        super(UpgradeHelper, self).add_known_stream(
+                            module, stream
+                        )
+
+        UpgradeHelper = override(UpgradeHelper)
+        __all__.append(UpgradeHelper)
+
     if hasattr(Modulemd, "ModuleStreamV3"):
 
         class ModuleStreamV3(Modulemd.ModuleStreamV3):

--- a/modulemd/include/modulemd-2.0/modulemd-upgrade-helper.h
+++ b/modulemd/include/modulemd-2.0/modulemd-upgrade-helper.h
@@ -1,0 +1,104 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/**
+ * SECTION: modulemd-upgrade-helper
+ * @title: Modulemd.UpgradeHelper
+ * @stability: stable
+ * @short_description: Helpers to provide cues to #ModulemdModuleStream
+ * upgrades.
+ */
+
+#define MODULEMD_TYPE_UPGRADE_HELPER (modulemd_upgrade_helper_get_type ())
+
+G_DECLARE_FINAL_TYPE (ModulemdUpgradeHelper,
+                      modulemd_upgrade_helper,
+                      MODULEMD,
+                      UPGRADE_HELPER,
+                      GObject)
+
+
+/**
+ * modulemd_upgrade_helper_new:
+ *
+ * Returns: (transfer full): A newly-allocated #ModulemdUpgradeHelper object.
+ * This object must be freed with g_object_unref().
+ *
+ * Since: 2.10
+ */
+ModulemdUpgradeHelper *
+modulemd_upgrade_helper_new (void);
+
+
+/**
+ * modulemd_upgrade_helper_add_known_stream:
+ * @self: (in): This #ModulemdUpgradeHelper object.
+ * @module_name: (in): The name of the known module being added.
+ * @stream_name: (in): The name of the known module stream being added.
+ *
+ * This function adds a `module:stream` entry to the #ModulemdUpgradeHelper.
+ * It will be used if and when libmodulemd needs to upgrade a
+ * #ModulemdModuleStreamV2 object to a #ModulemdModuleStreamV3 object if it
+ * encounters a module dependency that is specified as either `[ ]`
+ * (all streams) or `[ -streamname ]` (all but some exclusions).
+ *
+ * When using the python bindings, a simpler way to set these values is to call
+ * ```
+ * helper = Modulemd.UpgradeHelper.new()
+ * helper.set_known_streams({"module_name": ["stream1", "stream2"]}
+ * ```
+ *
+ * Since: 2.10
+ */
+void
+modulemd_upgrade_helper_add_known_stream (ModulemdUpgradeHelper *self,
+                                          const gchar *module_name,
+                                          const gchar *stream_name);
+
+
+/**
+ * modulemd_upgrade_helper_get_known_modules_as_strv: (rename-to modulemd_upgrade_helper_get_known_modules)
+ * @self: (in): This #ModulemdUpgradeHelper
+ *
+ * Returns: (transfer full): A list of known modules to provide clues to the
+ * stream upgrade process.
+ *
+ * Since: 2.10
+ */
+GStrv
+modulemd_upgrade_helper_get_known_modules_as_strv (
+  ModulemdUpgradeHelper *self);
+
+
+/**
+ * modulemd_upgrade_helper_get_known_streams_as_strv: (rename-to modulemd_upgrade_helper_get_known_streams)
+ * @self: (in): This #ModulemdUpgradeHelper
+ * @module_name: (in): The name of the module to return a list of known streams
+ * for.
+ *
+ * Returns: (transfer full): A list of known streams to provide clues to the
+ * stream upgrade process.
+ *
+ * Since: 2.10
+ */
+GStrv
+modulemd_upgrade_helper_get_known_streams_as_strv (ModulemdUpgradeHelper *self,
+                                                   const gchar *module_name);
+
+G_END_DECLS

--- a/modulemd/include/private/gi-binding-renames.h
+++ b/modulemd/include/private/gi-binding-renames.h
@@ -360,4 +360,17 @@ modulemd_module_index_get_default_streams (ModulemdModuleIndex *self,
 gchar *
 modulemd_rpm_map_entry_get_nevra (ModulemdRpmMapEntry *self);
 
+/**
+ * modulemd_upgrade_helper_get_known_modules: (skip)
+ */
+GStrv
+modulemd_upgrade_helper_get_known_modules (ModulemdUpgradeHelper *self);
+
+/**
+ * modulemd_upgrade_helper_get_known_streams: (skip)
+ */
+GStrv
+modulemd_upgrade_helper_get_known_streams (ModulemdUpgradeHelper *self,
+                                           const gchar *module_name);
+
 G_END_DECLS

--- a/modulemd/include/private/modulemd-util.h
+++ b/modulemd/include/private/modulemd-util.h
@@ -489,3 +489,14 @@ modulemd_guint64_to_iso8601date (guint64 date);
   ObjName, obj_name, OBJ_NAME, attr, ATTR)                                    \
   MODULEMD_SETTER_GETTER_STRING_EXT (                                         \
     static, ObjName, obj_name, OBJ_NAME, attr, ATTR)
+
+/**
+ * modulemd_str_set_new:
+ *
+ * A convenience macro to simplify the common operation of setting up a hash
+ * table in libmodulemd for containing a set() of unique strings.
+ *
+ * Since: 2.10
+ */
+#define modulemd_str_set_new()                                                \
+  g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL)

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -83,6 +83,7 @@ modulemd_srcs = files(
     'modulemd-subdocument-info.c',
     'modulemd-translation.c',
     'modulemd-translation-entry.c',
+    'modulemd-upgrade-helper.c',
     'modulemd-util.c',
     'modulemd-yaml-util.c',
     'modulemd-obsoletes.c',
@@ -117,6 +118,7 @@ modulemd_hdrs = files(
     'include/modulemd-2.0/modulemd-subdocument-info.h',
     'include/modulemd-2.0/modulemd-translation.h',
     'include/modulemd-2.0/modulemd-translation-entry.h',
+    'include/modulemd-2.0/modulemd-upgrade-helper.h',
     'include/modulemd-2.0/modulemd-obsoletes.h',
 )
 
@@ -322,6 +324,7 @@ c_tests = {
 'service_level'       : [ 'tests/test-modulemd-service-level.c' ],
 'translation'         : [ 'tests/test-modulemd-translation.c' ],
 'translation_entry'   : [ 'tests/test-modulemd-translation-entry.c' ],
+'upgrade_helper'      : [ 'tests/test-modulemd-upgrade-helper.c' ],
 'obsoletes'           : [ 'tests/test-modulemd-obsoletes.c' ],
 }
 
@@ -365,6 +368,7 @@ python_tests = {
 'servicelevel'     : 'tests/ModulemdTests/servicelevel.py',
 'translation'      : 'tests/ModulemdTests/translation.py',
 'translationentry' : 'tests/ModulemdTests/translationentry.py',
+'upgradehelper'    : 'tests/ModulemdTests/upgradehelper.py',
 }
 
 foreach name, script : python_tests

--- a/modulemd/modulemd-profile.c
+++ b/modulemd/modulemd-profile.c
@@ -353,8 +353,7 @@ modulemd_profile_parse_yaml (yaml_parser_t *parser,
   YAML_PARSER_PARSE_WITH_EXIT (parser, &event, error);
   if (event.type != YAML_MAPPING_START_EVENT)
     {
-      MMD_YAML_ERROR_EVENT_EXIT (
-        error, event, "No map in profile: %s", nested_error->message);
+      MMD_YAML_ERROR_EVENT_EXIT (error, event, "No map in profile");
     }
 
   p = modulemd_profile_new (name);

--- a/modulemd/modulemd-upgrade-helper.c
+++ b/modulemd/modulemd-upgrade-helper.c
@@ -1,0 +1,105 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+
+#include "modulemd-upgrade-helper.h"
+#include "private/modulemd-util.h"
+
+struct _ModulemdUpgradeHelper
+{
+  GObject parent_instance;
+
+  GHashTable *known_streams; /* <string, set<string>> */
+};
+
+G_DEFINE_TYPE (ModulemdUpgradeHelper, modulemd_upgrade_helper, G_TYPE_OBJECT)
+
+
+ModulemdUpgradeHelper *
+modulemd_upgrade_helper_new (void)
+{
+  return g_object_new (MODULEMD_TYPE_UPGRADE_HELPER, NULL);
+}
+
+
+static void
+modulemd_upgrade_helper_finalize (GObject *object)
+{
+  ModulemdUpgradeHelper *self = (ModulemdUpgradeHelper *)object;
+
+  g_clear_pointer (&self->known_streams, g_hash_table_unref);
+
+  G_OBJECT_CLASS (modulemd_upgrade_helper_parent_class)->finalize (object);
+}
+
+
+static void
+modulemd_upgrade_helper_class_init (ModulemdUpgradeHelperClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = modulemd_upgrade_helper_finalize;
+}
+
+
+static void
+modulemd_upgrade_helper_init (ModulemdUpgradeHelper *self)
+{
+  self->known_streams = g_hash_table_new_full (
+    g_str_hash, g_str_equal, g_free, modulemd_hash_table_unref);
+}
+
+
+void
+modulemd_upgrade_helper_add_known_stream (ModulemdUpgradeHelper *self,
+                                          const gchar *module_name,
+                                          const gchar *stream_name)
+{
+  g_return_if_fail (MODULEMD_IS_UPGRADE_HELPER (self));
+
+  GHashTable *known_module =
+    g_hash_table_lookup (self->known_streams, module_name);
+  if (NULL == known_module)
+    {
+      known_module = modulemd_str_set_new ();
+      g_hash_table_insert (
+        self->known_streams, g_strdup (module_name), known_module);
+    }
+
+  g_hash_table_add (known_module, g_strdup (stream_name));
+}
+
+
+GStrv
+modulemd_upgrade_helper_get_known_modules_as_strv (ModulemdUpgradeHelper *self)
+{
+  g_return_val_if_fail (MODULEMD_IS_UPGRADE_HELPER (self), NULL);
+
+  return modulemd_ordered_str_keys_as_strv (self->known_streams);
+}
+
+
+GStrv
+modulemd_upgrade_helper_get_known_streams_as_strv (ModulemdUpgradeHelper *self,
+                                                   const gchar *module_name)
+{
+  g_return_val_if_fail (MODULEMD_IS_UPGRADE_HELPER (self), NULL);
+
+  GHashTable *known_module =
+    g_hash_table_lookup (self->known_streams, module_name);
+
+  if (NULL == known_module)
+    return (GStrv)g_malloc0 (sizeof (gchar *));
+
+  return modulemd_ordered_str_keys_as_strv (known_module);
+}

--- a/modulemd/tests/ModulemdTests/modulestream.py
+++ b/modulemd/tests/ModulemdTests/modulestream.py
@@ -20,6 +20,10 @@ try:
     import unittest
     import gi
 
+    gi._overridesdir = os.path.join(
+        os.getenv("MESON_SOURCE_ROOT"), "bindings", "python", "gi", "overrides"
+    )
+
     gi.require_version("Modulemd", "2.0")
     from gi.repository import GLib
     from gi.repository import Modulemd

--- a/modulemd/tests/ModulemdTests/upgradehelper.py
+++ b/modulemd/tests/ModulemdTests/upgradehelper.py
@@ -1,0 +1,84 @@
+#!/usr/bin/python3
+
+# This file is part of libmodulemd
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# Fedora-License-Identifier: MIT
+# SPDX-2.0-License-Identifier: MIT
+# SPDX-3.0-License-Identifier: MIT
+#
+# This program is free software.
+# For more information on the license, see COPYING.
+# For more information on free software, see
+# <https://www.gnu.org/philosophy/free-sw.en.html>.
+
+import sys
+
+try:
+    import unittest
+    import gi
+
+    gi.require_version("Modulemd", "2.0")
+    from gi.repository import Modulemd
+except ImportError:
+    # Return error 77 to skip this test on platforms without the necessary
+    # python modules
+    sys.exit(77)
+
+from base import TestBase
+
+
+class TestUpgradeHelper(TestBase):
+    def test_constructor(self):
+        # Test that the new() function works
+        helper = Modulemd.UpgradeHelper.new()
+        self.assertIsNotNone(helper)
+
+        modules = helper.get_known_modules()
+        self.assertIsNotNone(modules)
+        self.assertEqual(0, len(modules))
+
+    def test_known_streams(self):
+        helper = Modulemd.UpgradeHelper.new()
+        self.assertIsNotNone(helper)
+
+        if hasattr(helper, "set_known_streams"):
+            helper.set_known_streams(
+                {"platform": ["f33", "f34", "eln"], "django": ["3.0"]}
+            )
+        else:
+            helper.add_known_stream("platform", "f33")
+            helper.add_known_stream("platform", "f34")
+            helper.add_known_stream("platform", "eln")
+            helper.add_known_stream("django", "3.0")
+
+        modules = helper.get_known_modules()
+        self.assertEqual(2, len(modules))
+        self.assertIn("platform", modules)
+        self.assertIn("django", modules)
+
+        self.assertIn("f33", helper.get_known_streams("platform"))
+        self.assertIn("f34", helper.get_known_streams("platform"))
+        self.assertIn("eln", helper.get_known_streams("platform"))
+
+        self.assertIn("3.0", helper.get_known_streams("django"))
+
+        # Add a duplicate to verify deduplication
+        helper.add_known_stream("platform", "f33")
+
+        modules = helper.get_known_modules()
+        self.assertEqual(2, len(modules))
+        self.assertIn("platform", modules)
+        self.assertIn("django", modules)
+
+        self.assertIn("f33", helper.get_known_streams("platform"))
+        self.assertIn("f34", helper.get_known_streams("platform"))
+        self.assertIn("eln", helper.get_known_streams("platform"))
+
+        self.assertIn("3.0", helper.get_known_streams("django"))
+
+        self.assertEqual(0, len(helper.get_known_streams("unknownmodule")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modulemd/tests/test-modulemd-upgrade-helper.c
+++ b/modulemd/tests/test-modulemd-upgrade-helper.c
@@ -1,0 +1,121 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#include "modulemd-upgrade-helper.h"
+#include "private/test-utils.h"
+
+
+static void
+upgrade_helper_construct (void)
+{
+  g_autoptr (ModulemdUpgradeHelper) helper = modulemd_upgrade_helper_new ();
+  g_assert_nonnull (helper);
+  g_assert_true (MODULEMD_IS_UPGRADE_HELPER (helper));
+
+  g_auto (GStrv) modules =
+    modulemd_upgrade_helper_get_known_modules_as_strv (helper);
+  g_assert_nonnull (modules);
+  g_assert_null (modules[0]);
+}
+
+
+static void
+upgrade_helper_known_streams (void)
+{
+  g_autoptr (ModulemdUpgradeHelper) helper = NULL;
+  g_auto (GStrv) modules = NULL;
+  g_auto (GStrv) streams = NULL;
+
+  helper = modulemd_upgrade_helper_new ();
+  g_assert_nonnull (helper);
+
+  modulemd_upgrade_helper_add_known_stream (helper, "platform", "f33");
+  modulemd_upgrade_helper_add_known_stream (helper, "platform", "f34");
+  modulemd_upgrade_helper_add_known_stream (helper, "platform", "eln");
+  modulemd_upgrade_helper_add_known_stream (helper, "django", "3.0");
+
+  modules = modulemd_upgrade_helper_get_known_modules_as_strv (helper);
+  g_assert_nonnull (modules);
+  g_assert_cmpstr ("django", ==, modules[0]);
+  g_assert_cmpstr ("platform", ==, modules[1]);
+  g_assert_null (modules[2]);
+  g_clear_pointer (&modules, g_strfreev);
+
+  streams =
+    modulemd_upgrade_helper_get_known_streams_as_strv (helper, "platform");
+  g_assert_nonnull (streams);
+  g_assert_cmpstr ("eln", ==, streams[0]);
+  g_assert_cmpstr ("f33", ==, streams[1]);
+  g_assert_cmpstr ("f34", ==, streams[2]);
+  g_assert_null (streams[3]);
+  g_clear_pointer (&streams, g_strfreev);
+
+  streams =
+    modulemd_upgrade_helper_get_known_streams_as_strv (helper, "django");
+  g_assert_nonnull (streams);
+  g_assert_cmpstr ("3.0", ==, streams[0]);
+  g_assert_null (streams[1]);
+  g_clear_pointer (&streams, g_strfreev);
+
+
+  /* Add a duplicate to verify that we are deduplicating */
+  modulemd_upgrade_helper_add_known_stream (helper, "platform", "f33");
+
+  modules = modulemd_upgrade_helper_get_known_modules_as_strv (helper);
+  g_assert_nonnull (modules);
+  g_assert_cmpstr ("django", ==, modules[0]);
+  g_assert_cmpstr ("platform", ==, modules[1]);
+  g_assert_null (modules[2]);
+  g_clear_pointer (&modules, g_strfreev);
+
+  streams =
+    modulemd_upgrade_helper_get_known_streams_as_strv (helper, "platform");
+  g_assert_nonnull (streams);
+  g_assert_cmpstr ("eln", ==, streams[0]);
+  g_assert_cmpstr ("f33", ==, streams[1]);
+  g_assert_cmpstr ("f34", ==, streams[2]);
+  g_assert_null (streams[3]);
+  g_clear_pointer (&streams, g_strfreev);
+
+  streams =
+    modulemd_upgrade_helper_get_known_streams_as_strv (helper, "django");
+  g_assert_nonnull (streams);
+  g_assert_cmpstr ("3.0", ==, streams[0]);
+  g_assert_null (streams[1]);
+  g_clear_pointer (&streams, g_strfreev);
+
+  /* Verify that we get an empty list back if we look up streams for an unknown
+   * module
+   */
+  streams =
+    modulemd_upgrade_helper_get_known_streams_as_strv (helper, "unknown");
+  g_assert_nonnull (streams);
+  g_assert_null (streams[0]);
+}
+
+
+int
+main (int argc, char *argv[])
+{
+  setlocale (LC_ALL, "");
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_bug_base ("https://bugzilla.redhat.com/show_bug.cgi?id=");
+
+  g_test_add_func ("/modulemd/v2/upgradehelper/construct",
+                   upgrade_helper_construct);
+  g_test_add_func ("/modulemd/v2/upgradehelper/known",
+                   upgrade_helper_known_streams);
+
+  return g_test_run ();
+}

--- a/setup_dev_container.sh
+++ b/setup_dev_container.sh
@@ -20,7 +20,6 @@ mmd_setup_container \
     release=$release \
     repository=quay.io \
     image=$image \
-    oci_extra_commands='RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py' \
     deps_image=libmodulemd-dev-$release
 
 


### PR DESCRIPTION
Add Modulemd.UpgradeHelper object
    
This is the implementation of an object that will hold known
module:stream values to provide a way to resolve ambiguous
upgrades from ModuleStreamV2 dependencies.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>
