### PR TITLE
mmdv3 enhancements

### DIFF
--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -177,7 +177,7 @@ main (int argc, char *argv[])
                   for (gsize j = 0; j < failures->len; j++)
                     {
                       doc = MODULEMD_SUBDOCUMENT_INFO (
-                        g_ptr_array_index (failures, i));
+                        g_ptr_array_index (failures, j));
                       g_printf (
                         "\nFailed subdocument (%s): \n%s\n",
                         modulemd_subdocument_info_get_gerror (doc)->message,

--- a/modulemd/modulemd.c
+++ b/modulemd/modulemd.c
@@ -44,7 +44,7 @@ modulemd_get_default_stream_mdversion (void)
 static ModulemdModuleIndex *
 verify_load (int ret,
              ModulemdModuleIndex *idx,
-             guint num_failures,
+             GPtrArray *failures,
              GError **error,
              GError **nested_error);
 
@@ -64,7 +64,7 @@ modulemd_load_file (const gchar *yaml_file, GError **error)
 
   ret = modulemd_module_index_update_from_file (
     idx, yaml_file, FALSE, &failures, &nested_error);
-  return verify_load (ret, idx, failures->len, error, &nested_error);
+  return verify_load (ret, idx, failures, error, &nested_error);
 }
 
 
@@ -84,17 +84,19 @@ modulemd_load_string (const gchar *yaml_string, GError **error)
 
   ret = modulemd_module_index_update_from_string (
     idx, yaml_string, FALSE, &failures, &nested_error);
-  return verify_load (ret, idx, failures->len, error, &nested_error);
+  return verify_load (ret, idx, failures, error, &nested_error);
 }
 
 
 static ModulemdModuleIndex *
 verify_load (gboolean ret,
              ModulemdModuleIndex *idx,
-             guint num_failures,
+             GPtrArray *failures,
              GError **error,
              GError **nested_error)
 {
+  ModulemdSubdocumentInfo *doc = NULL;
+
   if (!ret)
     {
       if (*nested_error)
@@ -102,8 +104,18 @@ verify_load (gboolean ret,
           g_propagate_error (error, g_steal_pointer (nested_error));
           return NULL;
         }
-      else if (num_failures)
+      else if (failures && failures->len)
         {
+          g_debug ("%u YAML subdocuments were invalid", failures->len);
+          for (gsize i = 0; i < failures->len; i++)
+            {
+              doc =
+                MODULEMD_SUBDOCUMENT_INFO (g_ptr_array_index (failures, i));
+              g_debug ("\nFailed subdocument (%s): \n%s\n",
+                       modulemd_subdocument_info_get_gerror (doc)->message,
+                       modulemd_subdocument_info_get_yaml (doc));
+            }
+
           g_set_error (error,
                        MODULEMD_ERROR,
                        MMD_ERROR_VALIDATE,


### PR DESCRIPTION
A small improvement to enable diagnosing which sub-document(s) in a failed batch load are at fault.

Also fix for a bug in `modulemd-validator` that I ran across while borrowing some of its code.