### PR TITLE
mmdv3 improvements

### DIFF
--- a/modulemd/include/private/modulemd-subdocument-info-private.h
+++ b/modulemd/include/private/modulemd-subdocument-info-private.h
@@ -139,3 +139,16 @@ modulemd_subdocument_info_get_data_parser (ModulemdSubdocumentInfo *self,
                                            yaml_parser_t *parser,
                                            gboolean strict,
                                            GError **error);
+
+
+/**
+ * modulemd_subdocument_info_debug_dump_failures:
+ * @failures: (in) (element-type ModulemdSubdocumentInfo): An array containing
+ * any subdocuments from the YAML file that failed to parse.
+ *
+ * Dumps human readable information about @failures to the debug log.
+ *
+ * Since: 2.10
+ */
+void
+modulemd_subdocument_info_debug_dump_failures (GPtrArray *failures);

--- a/modulemd/modulemd-module-stream.c
+++ b/modulemd/modulemd-module-stream.c
@@ -1320,6 +1320,15 @@ modulemd_module_stream_expand_v2_to_v3_deps (ModulemdModuleStreamV2 *v2_stream,
 
   g_debug ("Expansion: beginning v2 to v3 stream dependency expansion");
 
+  if (v2_stream->dependencies->len == 0)
+    {
+      g_set_error_literal (error,
+                           MODULEMD_ERROR,
+                           MMD_ERROR_UPGRADE,
+                           "Stream v2 has no dependencies.");
+      return NULL;
+    }
+
   /*
    * Create a #GPtrArray to capture the combined results of the stream
    * expansions for each set of dependencies.
@@ -1355,7 +1364,7 @@ modulemd_module_stream_expand_v2_to_v3_deps (ModulemdModuleStreamV2 *v2_stream,
           g_set_error_literal (error,
                                MODULEMD_ERROR,
                                MMD_ERROR_UPGRADE,
-                               "Stream v2 has no dependencies.");
+                               "Stream v2 has no module dependencies.");
           return NULL;
         }
 

--- a/modulemd/modulemd-subdocument-info.c
+++ b/modulemd/modulemd-subdocument-info.c
@@ -325,3 +325,21 @@ modulemd_subdocument_info_init (ModulemdSubdocumentInfo *self)
 {
   /* Nothing to init */
 }
+
+void
+modulemd_subdocument_info_debug_dump_failures (GPtrArray *failures)
+{
+  ModulemdSubdocumentInfo *doc = NULL;
+
+  if (failures && failures->len)
+    {
+      g_debug ("%u YAML subdocuments were invalid", failures->len);
+      for (gsize i = 0; i < failures->len; i++)
+        {
+          doc = MODULEMD_SUBDOCUMENT_INFO (g_ptr_array_index (failures, i));
+          g_debug ("\nFailed subdocument (%s): \n%s\n",
+                   modulemd_subdocument_info_get_gerror (doc)->message,
+                   modulemd_subdocument_info_get_yaml (doc));
+        }
+    }
+}

--- a/modulemd/modulemd.c
+++ b/modulemd/modulemd.c
@@ -14,6 +14,8 @@
 #include "modulemd.h"
 #include "config.h"
 
+#include "private/modulemd-subdocument-info-private.h"
+
 const gchar *
 modulemd_get_version (void)
 {
@@ -95,8 +97,6 @@ verify_load (gboolean ret,
              GError **error,
              GError **nested_error)
 {
-  ModulemdSubdocumentInfo *doc = NULL;
-
   if (!ret)
     {
       if (*nested_error)
@@ -106,16 +106,7 @@ verify_load (gboolean ret,
         }
       else if (failures && failures->len)
         {
-          g_debug ("%u YAML subdocuments were invalid", failures->len);
-          for (gsize i = 0; i < failures->len; i++)
-            {
-              doc =
-                MODULEMD_SUBDOCUMENT_INFO (g_ptr_array_index (failures, i));
-              g_debug ("\nFailed subdocument (%s): \n%s\n",
-                       modulemd_subdocument_info_get_gerror (doc)->message,
-                       modulemd_subdocument_info_get_yaml (doc));
-            }
-
+          modulemd_subdocument_info_debug_dump_failures (failures);
           g_set_error (error,
                        MODULEMD_ERROR,
                        MMD_ERROR_VALIDATE,

--- a/modulemd/tests/ModulemdTests/merger.py
+++ b/modulemd/tests/ModulemdTests/merger.py
@@ -102,8 +102,8 @@ class TestModuleIndexMerger(TestBase):
         self.assertEqual(
             httpd_defaults.get_default_stream("workstation"), "2.4"
         )
-        httpd_profile_streams = (
-            httpd_defaults.get_streams_with_default_profiles("workstation")
+        httpd_profile_streams = httpd_defaults.get_streams_with_default_profiles(
+            "workstation"
         )
         self.assertEqual(len(httpd_profile_streams), 2)
         self.assertTrue("2.4" in httpd_profile_streams)
@@ -203,8 +203,8 @@ class TestModuleIndexMerger(TestBase):
         self.assertEqual(
             httpd_defaults.get_default_stream("workstation"), "2.8"
         )
-        httpd_profile_streams = (
-            httpd_defaults.get_streams_with_default_profiles("workstation")
+        httpd_profile_streams = httpd_defaults.get_streams_with_default_profiles(
+            "workstation"
         )
         self.assertEqual(len(httpd_profile_streams), 3)
         self.assertTrue("2.4" in httpd_profile_streams)

--- a/modulemd/tests/ModulemdTests/moduleindex.py
+++ b/modulemd/tests/ModulemdTests/moduleindex.py
@@ -31,6 +31,18 @@ except ImportError:
 from base import TestBase
 
 
+def debug_dump_failures(failures):
+    if failures is None or len(failures) == 0:
+        return
+    print("{} YAML subdocuments were invalid".format(len(failures)))
+    for f in failures:
+        print(
+            "Failed subdocument ({}):\n{}\n".format(
+                str(f.get_gerror()), f.get_yaml()
+            )
+        )
+
+
 class TestModuleIndex(TestBase):
     def test_constructors(self):
         # Test that the new() function works
@@ -47,8 +59,9 @@ class TestModuleIndex(TestBase):
             "r",
         ) as v1:
             res, failures = idx.update_from_string(v1.read(), True)
-            self.assertTrue(res)
+            debug_dump_failures(failures)
             self.assertListEqual(failures, [])
+            self.assertTrue(res)
 
         for fname in [
             "yaml_specs/modulemd_stream_v2.yaml",
@@ -58,8 +71,9 @@ class TestModuleIndex(TestBase):
             res, failures = idx.update_from_file(
                 path.join(self.source_root, fname), True
             )
-            self.assertTrue(res)
+            debug_dump_failures(failures)
             self.assertListEqual(failures, [])
+            self.assertTrue(res)
 
         res, failures = idx.update_from_file(
             path.join(self.test_data_path, "te.yaml"), True
@@ -123,10 +137,10 @@ profiles:
         self.assertIsNotNone(default_streams)
 
         self.assertIn("dwm", default_streams.keys())
-        self.assertEquals("6.1", default_streams["dwm"])
+        self.assertEqual("6.1", default_streams["dwm"])
 
         self.assertIn("stratis", default_streams.keys())
-        self.assertEquals("1", default_streams["stratis"])
+        self.assertEqual("1", default_streams["stratis"])
 
         self.assertNotIn("nodejs", default_streams.keys())
 

--- a/modulemd/tests/test-modulemd-merger.c
+++ b/modulemd/tests/test-modulemd-merger.c
@@ -23,6 +23,7 @@
 
 #include "private/modulemd-module-private.h"
 #include "private/modulemd-obsoletes-private.h"
+#include "private/modulemd-subdocument-info-private.h"
 
 
 static void
@@ -45,6 +46,7 @@ merger_test_constructors (void)
 static void
 merger_test_deduplicate (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (ModulemdModuleIndex) index2 = NULL;
   g_autoptr (ModulemdModuleIndex) merged_index = NULL;
@@ -62,8 +64,11 @@ merger_test_deduplicate (void)
 
   g_assert_nonnull (yaml_path);
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&failures, g_ptr_array_unref);
 
@@ -77,8 +82,11 @@ merger_test_deduplicate (void)
 
   g_assert_nonnull (yaml_path);
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index2, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index2, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_assert_nonnull (index2);
   g_assert_null (error);
@@ -107,6 +115,7 @@ merger_test_deduplicate (void)
 static void
 merger_test_merger (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) base_index = NULL;
   g_autofree gchar *yaml_path = NULL;
   g_autofree gchar *module_name = NULL;
@@ -129,9 +138,11 @@ merger_test_merger (void)
   yaml_path =
     g_strdup_printf ("%s/merging-base.yaml", g_getenv ("TEST_DATA_PATH"));
   base_index = modulemd_module_index_new ();
-  g_assert_true (modulemd_module_index_update_from_file (
-    base_index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    base_index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&yaml_path, g_free);
 
   /* Baseline */
@@ -329,6 +340,7 @@ merger_test_merger (void)
 static void
 merger_test_add_only (void)
 {
+  gboolean ret;
   g_autoptr (GPtrArray) failures = NULL;
   g_autoptr (GError) error = NULL;
   g_autoptr (ModulemdModuleIndex) base_idx = modulemd_module_index_new ();
@@ -343,10 +355,16 @@ merger_test_add_only (void)
   g_autofree gchar *add_only_yaml =
     g_strdup_printf ("%s/merger/add_only.yaml", g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    base_idx, base_yaml, TRUE, &failures, &error));
-  g_assert_true (modulemd_module_index_update_from_file (
-    add_only_idx, add_only_yaml, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    base_idx, base_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
+  ret = modulemd_module_index_update_from_file (
+    add_only_idx, add_only_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
 
   modulemd_module_index_merger_associate_index (merger, base_idx, 0);
   modulemd_module_index_merger_associate_index (merger, add_only_idx, 0);
@@ -376,6 +394,7 @@ merger_test_add_only (void)
 static void
 merger_test_add_conflicting_stream (void)
 {
+  gboolean ret;
   g_autoptr (GPtrArray) failures = NULL;
   g_autoptr (GError) error = NULL;
   g_autoptr (ModulemdModuleIndex) base_idx = modulemd_module_index_new ();
@@ -391,10 +410,16 @@ merger_test_add_conflicting_stream (void)
   g_autofree gchar *add_conflicting_yaml = g_strdup_printf (
     "%s/merger/add_conflicting_stream.yaml", g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    base_idx, base_yaml, TRUE, &failures, &error));
-  g_assert_true (modulemd_module_index_update_from_file (
-    add_conflicting_idx, add_conflicting_yaml, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    base_idx, base_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
+  ret = modulemd_module_index_update_from_file (
+    add_conflicting_idx, add_conflicting_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
 
   modulemd_module_index_merger_associate_index (merger, base_idx, 0);
   modulemd_module_index_merger_associate_index (
@@ -419,6 +444,7 @@ merger_test_add_conflicting_stream (void)
 static void
 merger_test_add_conflicting_stream_and_profile_modified (void)
 {
+  gboolean ret;
   g_autoptr (GPtrArray) failures = NULL;
   g_autoptr (GError) error = NULL;
   g_autoptr (ModulemdModuleIndex) base_idx = modulemd_module_index_new ();
@@ -435,10 +461,16 @@ merger_test_add_conflicting_stream_and_profile_modified (void)
     "%s/merger/add_conflicting_stream_and_profile_modified.yaml",
     g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    base_idx, base_yaml, TRUE, &failures, &error));
-  g_assert_true (modulemd_module_index_update_from_file (
-    add_conflicting_idx, add_conflicting_yaml, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    base_idx, base_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
+  ret = modulemd_module_index_update_from_file (
+    add_conflicting_idx, add_conflicting_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
 
   modulemd_module_index_merger_associate_index (merger, base_idx, 0);
   modulemd_module_index_merger_associate_index (
@@ -464,6 +496,7 @@ merger_test_add_conflicting_stream_and_profile_modified (void)
 static void
 merger_test_with_real_world_data (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) f29 = NULL;
   g_autoptr (ModulemdModuleIndex) f29_updates = NULL;
   g_autoptr (ModulemdModuleIndex) index = NULL;
@@ -474,9 +507,11 @@ merger_test_with_real_world_data (void)
 
   f29 = modulemd_module_index_new ();
   yaml_path = g_strdup_printf ("%s/f29.yaml", g_getenv ("TEST_DATA_PATH"));
-  g_assert_true (modulemd_module_index_update_from_file (
-    f29, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    f29, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&yaml_path, g_free);
   g_clear_pointer (&failures, g_ptr_array_unref);
@@ -484,9 +519,11 @@ merger_test_with_real_world_data (void)
   f29_updates = modulemd_module_index_new ();
   yaml_path =
     g_strdup_printf ("%s/f29-updates.yaml", g_getenv ("TEST_DATA_PATH"));
-  g_assert_true (modulemd_module_index_update_from_file (
-    f29_updates, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    f29_updates, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&yaml_path, g_free);
   g_clear_pointer (&failures, g_ptr_array_unref);
@@ -504,6 +541,7 @@ merger_test_with_real_world_data (void)
 static void
 merger_test_obsoletes_add (void)
 {
+  gboolean ret;
   g_autoptr (GPtrArray) failures = NULL;
   g_autoptr (GError) error = NULL;
   g_autoptr (ModulemdModuleIndex) base_idx = modulemd_module_index_new ();
@@ -519,10 +557,16 @@ merger_test_obsoletes_add (void)
   g_autofree gchar *add_yaml = g_strdup_printf ("%s/merger/add_obsoletes.yaml",
                                                 g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    base_idx, base_yaml, TRUE, &failures, &error));
-  g_assert_true (modulemd_module_index_update_from_file (
-    add_idx, add_yaml, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    base_idx, base_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
+  ret = modulemd_module_index_update_from_file (
+    add_idx, add_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
 
   modulemd_module_index_merger_associate_index (merger, base_idx, 0);
   modulemd_module_index_merger_associate_index (merger, add_idx, 0);
@@ -563,6 +607,7 @@ merger_test_obsoletes_add (void)
 static void
 merger_test_obsoletes_newer (void)
 {
+  gboolean ret;
   g_autoptr (GPtrArray) failures = NULL;
   g_autoptr (GError) error = NULL;
   g_autoptr (ModulemdModuleIndex) base_idx = modulemd_module_index_new ();
@@ -578,10 +623,16 @@ merger_test_obsoletes_newer (void)
   g_autofree gchar *newer_yaml = g_strdup_printf (
     "%s/merger/newer_obsoletes.yaml", g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    base_idx, base_yaml, TRUE, &failures, &error));
-  g_assert_true (modulemd_module_index_update_from_file (
-    newer_idx, newer_yaml, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    base_idx, base_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
+  ret = modulemd_module_index_update_from_file (
+    newer_idx, newer_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
 
   modulemd_module_index_merger_associate_index (merger, base_idx, 0);
   modulemd_module_index_merger_associate_index (merger, newer_idx, 0);
@@ -619,6 +670,7 @@ static void
 merger_test_obsoletes_priority (void)
 {
   // When priority specified override existing obsolete
+  gboolean ret;
   g_autoptr (GPtrArray) failures = NULL;
   g_autoptr (GError) error = NULL;
   g_autoptr (ModulemdModuleIndex) base_idx = modulemd_module_index_new ();
@@ -635,10 +687,16 @@ merger_test_obsoletes_priority (void)
   g_autofree gchar *newer_yaml = g_strdup_printf (
     "%s/merger/conflict_obsoletes.yaml", g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    base_idx, base_yaml, TRUE, &failures, &error));
-  g_assert_true (modulemd_module_index_update_from_file (
-    conflicting_idx, newer_yaml, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    base_idx, base_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
+  ret = modulemd_module_index_update_from_file (
+    conflicting_idx, newer_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
 
   modulemd_module_index_merger_associate_index (merger, base_idx, 1);
   modulemd_module_index_merger_associate_index (merger, conflicting_idx, 0);
@@ -676,6 +734,7 @@ merger_test_obsoletes_incompatible (void)
    * undefined, so we will only validate that the merge completes and
    * it only contains a single obsoletes
    */
+  gboolean ret;
   g_autoptr (GPtrArray) failures = NULL;
   g_autoptr (GError) error = NULL;
   g_autoptr (ModulemdModuleIndex) base_idx = modulemd_module_index_new ();
@@ -691,10 +750,16 @@ merger_test_obsoletes_incompatible (void)
   g_autofree gchar *incompatible_yaml = g_strdup_printf (
     "%s/merger/conflict_obsoletes.yaml", g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    base_idx, base_yaml, TRUE, &failures, &error));
-  g_assert_true (modulemd_module_index_update_from_file (
-    incompatible_idx, incompatible_yaml, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    base_idx, base_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
+  ret = modulemd_module_index_update_from_file (
+    incompatible_idx, incompatible_yaml, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
 
   modulemd_module_index_merger_associate_index (merger, base_idx, 0);
   modulemd_module_index_merger_associate_index (merger, incompatible_idx, 0);

--- a/modulemd/tests/test-modulemd-module.c
+++ b/modulemd/tests/test-modulemd-module.c
@@ -27,6 +27,7 @@
 #include "private/modulemd-module-private.h"
 #include "private/modulemd-module-stream-private.h"
 #include "private/modulemd-obsoletes-private.h"
+#include "private/modulemd-subdocument-info-private.h"
 #include "private/modulemd-util.h"
 #include "private/modulemd-yaml.h"
 #include "private/test-utils.h"
@@ -457,15 +458,18 @@ modulemd_test_remove_streams (void)
   g_autoptr (GError) error = NULL;
   g_autoptr (GPtrArray) failures = NULL;
   g_autofree gchar *yaml_path = NULL;
+  gboolean ret;
 
   /* Get the f29 and f29-updates indexes. They have multiple streams and
    * versions for the 'dwm' module
    */
   f29 = modulemd_module_index_new ();
   yaml_path = g_strdup_printf ("%s/f29.yaml", g_getenv ("TEST_DATA_PATH"));
-  g_assert_true (modulemd_module_index_update_from_file (
-    f29, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    f29, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&yaml_path, g_free);
   g_clear_pointer (&failures, g_ptr_array_unref);
@@ -473,9 +477,10 @@ modulemd_test_remove_streams (void)
   f29_updates = modulemd_module_index_new ();
   yaml_path =
     g_strdup_printf ("%s/f29-updates.yaml", g_getenv ("TEST_DATA_PATH"));
-  g_assert_true (modulemd_module_index_update_from_file (
-    f29_updates, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    f29_updates, yaml_path, TRUE, &failures, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&yaml_path, g_free);
   g_clear_pointer (&failures, g_ptr_array_unref);
@@ -532,6 +537,7 @@ modulemd_test_remove_streams (void)
 static void
 module_test_search_streams_by_glob (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = modulemd_module_index_new ();
   g_autoptr (GError) error = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -542,9 +548,10 @@ module_test_search_streams_by_glob (void)
   yaml_path = g_strdup_printf ("%s/search_streams/search_streams.yaml",
                                g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
 
   module = modulemd_module_index_get_module (index, "nodejs");
   g_assert_nonnull (module);
@@ -608,6 +615,7 @@ module_test_search_streams_by_glob (void)
 static void
 module_test_search_streams_by_nsvca_glob (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = modulemd_module_index_new ();
   g_autoptr (GError) error = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -618,9 +626,10 @@ module_test_search_streams_by_nsvca_glob (void)
   yaml_path = g_strdup_printf ("%s/search_streams/search_streams.yaml",
                                g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
 
   module = modulemd_module_index_get_module (index, "nodejs");
   g_assert_nonnull (module);

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -28,6 +28,7 @@
 #include "modulemd-subdocument-info.h"
 #include "private/glib-extensions.h"
 #include "private/modulemd-module-private.h"
+#include "private/modulemd-subdocument-info-private.h"
 #include "private/modulemd-util.h"
 #include "private/modulemd-yaml.h"
 #include "private/test-utils.h"
@@ -40,6 +41,7 @@ typedef struct _ModuleIndexFixture
 static void
 module_index_test_dump (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (ModulemdTranslation) translation = NULL;
   g_autoptr (ModulemdObsoletes) obsoletes = NULL;
@@ -64,23 +66,24 @@ module_index_test_dump (void)
                                           "Een test omschrijving");
   modulemd_translation_set_translation_entry (translation, translation_entry);
   g_clear_pointer (&translation_entry, g_object_unref);
-  g_assert_true (
-    modulemd_module_index_add_translation (index, translation, &error));
+  ret = modulemd_module_index_add_translation (index, translation, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&translation, g_object_unref);
 
   /* Second: defaults */
   defaults = modulemd_defaults_new (1, "testmodule1");
-  g_assert_true (modulemd_module_index_add_defaults (index, defaults, &error));
+  ret = modulemd_module_index_add_defaults (index, defaults, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&defaults, g_object_unref);
 
   /* Third: some obsoletes */
   obsoletes = modulemd_obsoletes_new (
     1, 202001012020, "testmodule1", "teststream2", "testmessage");
-  g_assert_true (
-    modulemd_module_index_add_obsoletes (index, obsoletes, &error));
+  ret = modulemd_module_index_add_obsoletes (index, obsoletes, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&obsoletes, g_object_unref);
 
   /* Fourth: some streams */
@@ -94,9 +97,9 @@ module_index_test_dump (void)
     MODULEMD_MODULE_STREAM_V1 (stream), "A test stream's description");
   modulemd_module_stream_v1_add_module_license (
     MODULEMD_MODULE_STREAM_V1 (stream), "Beerware");
-  g_assert_true (
-    modulemd_module_index_add_module_stream (index, stream, &error));
+  ret = modulemd_module_index_add_module_stream (index, stream, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&stream, g_object_unref);
   stream = (ModulemdModuleStream *)modulemd_module_stream_v2_new (
     "testmodule1", "teststream2");
@@ -108,9 +111,9 @@ module_index_test_dump (void)
     MODULEMD_MODULE_STREAM_V2 (stream), "A second stream's description");
   modulemd_module_stream_v2_add_module_license (
     MODULEMD_MODULE_STREAM_V2 (stream), "Beerware");
-  g_assert_true (
-    modulemd_module_index_add_module_stream (index, stream, &error));
+  ret = modulemd_module_index_add_module_stream (index, stream, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&stream, g_object_unref);
 
   /* And now... emit */
@@ -200,18 +203,22 @@ module_index_test_read (void)
   /* The two stream definitions */
   yaml_path = g_strdup_printf ("%s/yaml_specs/modulemd_stream_v1.yaml",
                                g_getenv ("MESON_SOURCE_ROOT"));
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&yaml_path, g_free);
   g_clear_pointer (&failures, g_ptr_array_unref);
 
   yaml_path = g_strdup_printf ("%s/yaml_specs/modulemd_stream_v2.yaml",
                                g_getenv ("MESON_SOURCE_ROOT"));
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&yaml_path, g_free);
   g_clear_pointer (&failures, g_ptr_array_unref);
@@ -238,9 +245,11 @@ module_index_test_read (void)
   /* The translation definitions */
   yaml_path = g_strdup_printf ("%s/yaml_specs/modulemd_translations_v1.yaml",
                                g_getenv ("MESON_SOURCE_ROOT"));
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&yaml_path, g_free);
   g_clear_pointer (&failures, g_ptr_array_unref);
@@ -248,9 +257,11 @@ module_index_test_read (void)
   /* The obsoletes definitions */
   yaml_path = g_strdup_printf ("%s/yaml_specs/modulemd_obsoletes_v1.yaml",
                                g_getenv ("MESON_SOURCE_ROOT"));
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&yaml_path, g_free);
   g_clear_pointer (&failures, g_ptr_array_unref);
@@ -258,9 +269,11 @@ module_index_test_read (void)
   /* The defaults definitions */
   yaml_path = g_strdup_printf ("%s/yaml_specs/modulemd_defaults_v1.yaml",
                                g_getenv ("MESON_SOURCE_ROOT"));
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&yaml_path, g_free);
   g_clear_pointer (&failures, g_ptr_array_unref);
@@ -332,6 +345,7 @@ module_index_test_read (void)
 static void
 module_index_test_read_mixed (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autofree gchar *yaml_path = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -344,8 +358,11 @@ module_index_test_read_mixed (void)
     g_strdup_printf ("%s/long-valid.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&failures, g_ptr_array_unref);
 
@@ -359,6 +376,7 @@ module_index_test_read_mixed (void)
 static void
 module_index_test_read_unknown (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autofree gchar *yaml_path = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -375,8 +393,11 @@ module_index_test_read_unknown (void)
   g_assert_cmpint (failures->len, ==, 3);
   g_clear_pointer (&failures, g_ptr_array_unref);
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, FALSE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, FALSE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
+  g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&failures, g_ptr_array_unref);
 }
@@ -713,9 +734,9 @@ module_index_test_index_upgrade (void)
     MODULEMD_MODULE_STREAM_V1 (stream), "A test stream's description");
   modulemd_module_stream_v1_add_module_license (
     MODULEMD_MODULE_STREAM_V1 (stream), "Beerware");
-  g_assert_true (
-    modulemd_module_index_add_module_stream (index, stream, &error));
+  ret = modulemd_module_index_add_module_stream (index, stream, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&stream, g_object_unref);
 
   /* Verify that it was added as a StreamV1 object */
@@ -745,9 +766,9 @@ module_index_test_index_upgrade (void)
     MODULEMD_MODULE_STREAM_V1 (stream), "A test stream's description");
   modulemd_module_stream_v1_add_module_license (
     MODULEMD_MODULE_STREAM_V1 (stream), "Beerware");
-  g_assert_true (
-    modulemd_module_index_add_module_stream (index, stream, &error));
+  ret = modulemd_module_index_add_module_stream (index, stream, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&stream, g_object_unref);
 
   /* Verify that it was added as a StreamV1 object */
@@ -767,8 +788,9 @@ module_index_test_index_upgrade (void)
 
   /* Add some defaults */
   defaults = modulemd_defaults_new (1, "testmodule1");
-  g_assert_true (modulemd_module_index_add_defaults (index, defaults, &error));
+  ret = modulemd_module_index_add_defaults (index, defaults, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&defaults, g_object_unref);
 
   /* Verify that the index is at stream and defaults v1 */
@@ -869,9 +891,9 @@ module_index_test_index_upgrade (void)
     MODULEMD_MODULE_STREAM_V2 (stream), "A test stream's description");
   modulemd_module_stream_v2_add_module_license (
     MODULEMD_MODULE_STREAM_V2 (stream), "Beerware");
-  g_assert_true (
-    modulemd_module_index_add_module_stream (index, stream, &error));
+  ret = modulemd_module_index_add_module_stream (index, stream, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&stream, g_object_unref);
 
   /* Verify that it was added as a StreamV2 object */
@@ -901,9 +923,9 @@ module_index_test_index_upgrade (void)
     MODULEMD_MODULE_STREAM_V2 (stream), "A test stream's description");
   modulemd_module_stream_v2_add_module_license (
     MODULEMD_MODULE_STREAM_V2 (stream), "Beerware");
-  g_assert_true (
-    modulemd_module_index_add_module_stream (index, stream, &error));
+  ret = modulemd_module_index_add_module_stream (index, stream, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&stream, g_object_unref);
 
   /* Verify that it was added as a StreamV2 object */
@@ -923,8 +945,9 @@ module_index_test_index_upgrade (void)
 
   /* Add some defaults */
   defaults = modulemd_defaults_new (1, "testmodule1");
-  g_assert_true (modulemd_module_index_add_defaults (index, defaults, &error));
+  ret = modulemd_module_index_add_defaults (index, defaults, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&defaults, g_object_unref);
 
   /* Verify that the index is at stream v2 and defaults v1 */
@@ -1025,9 +1048,9 @@ module_index_test_index_upgrade (void)
     MODULEMD_MODULE_STREAM_V3 (stream), "A test stream's description");
   modulemd_module_stream_v3_add_module_license (
     MODULEMD_MODULE_STREAM_V3 (stream), "Beerware");
-  g_assert_true (
-    modulemd_module_index_add_module_stream (index, stream, &error));
+  ret = modulemd_module_index_add_module_stream (index, stream, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&stream, g_object_unref);
 
   /* Verify that it was added as a StreamV3 object */
@@ -1057,9 +1080,9 @@ module_index_test_index_upgrade (void)
     MODULEMD_MODULE_STREAM_V3 (stream), "A test stream's description");
   modulemd_module_stream_v3_add_module_license (
     MODULEMD_MODULE_STREAM_V3 (stream), "Beerware");
-  g_assert_true (
-    modulemd_module_index_add_module_stream (index, stream, &error));
+  ret = modulemd_module_index_add_module_stream (index, stream, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&stream, g_object_unref);
 
   /* Verify that it was added as a StreamV3 object */
@@ -1079,8 +1102,9 @@ module_index_test_index_upgrade (void)
 
   /* Add some defaults */
   defaults = modulemd_defaults_new (1, "testmodule1");
-  g_assert_true (modulemd_module_index_add_defaults (index, defaults, &error));
+  ret = modulemd_module_index_add_defaults (index, defaults, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_clear_pointer (&defaults, g_object_unref);
 
   /* Verify that the index is at stream v3 and defaults v1 */
@@ -1194,6 +1218,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 static void
 module_index_test_remove_module (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autofree gchar *yaml_path = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -1205,10 +1230,12 @@ module_index_test_remove_module (void)
     g_strdup_printf ("%s/long-valid.yaml", g_getenv ("TEST_DATA_PATH"));
   g_assert_nonnull (yaml_path);
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
-  g_assert_cmpint (failures->len, ==, 0);
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
+  g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&failures, g_ptr_array_unref);
 
   /* Verify that the 'reviewboard' module exists in the index */
@@ -1263,6 +1290,7 @@ custom_string_read_handler (void *data,
 static void
 module_index_test_custom_read (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (GPtrArray) failures = NULL;
   g_autoptr (GError) error = NULL;
@@ -1360,10 +1388,12 @@ module_index_test_custom_read (void)
 
   index = modulemd_module_index_new ();
 
-  g_assert_true (modulemd_module_index_update_from_custom (
-    index, custom_string_read_handler, &custom, TRUE, &failures, &error));
-  g_assert_cmpint (failures->len, ==, 0);
+  ret = modulemd_module_index_update_from_custom (
+    index, custom_string_read_handler, &custom, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
+  g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&failures, g_ptr_array_unref);
 
   /* Verify we did indeed get the module we expected */
@@ -1374,6 +1404,7 @@ module_index_test_custom_read (void)
 static void
 module_index_test_custom_write (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (GPtrArray) failures = NULL;
   g_autoptr (GError) error = NULL;
@@ -1470,10 +1501,12 @@ module_index_test_custom_write (void)
 
   index = modulemd_module_index_new ();
 
-  g_assert_true (modulemd_module_index_update_from_string (
-    index, str, TRUE, &failures, &error));
-  g_assert_cmpint (failures->len, ==, 0);
+  ret = modulemd_module_index_update_from_string (
+    index, str, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
+  g_assert_cmpint (failures->len, ==, 0);
   g_clear_pointer (&failures, g_ptr_array_unref);
 
   /* Verify we did indeed get the module we expected */
@@ -1489,10 +1522,11 @@ module_index_test_custom_write (void)
 
 
   /* Write it out to a string using a custom emitter */
-  g_assert_true (modulemd_module_index_dump_to_custom (
-    index, write_yaml_string, yaml_string, &error));
-  g_assert_nonnull (yaml_string->str);
+  ret = modulemd_module_index_dump_to_custom (
+    index, write_yaml_string, yaml_string, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
+  g_assert_nonnull (yaml_string->str);
   g_assert_cmpstr (yaml_string->str, ==, output_string);
 }
 
@@ -1500,6 +1534,7 @@ module_index_test_custom_write (void)
 static void
 module_index_test_get_default_streams (void)
 {
+  gboolean ret;
   g_autofree gchar *yaml_path = NULL;
   g_autoptr (ModulemdModuleIndex) index = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -1513,9 +1548,11 @@ module_index_test_get_default_streams (void)
   index = modulemd_module_index_new ();
   g_assert_nonnull (index);
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
   g_assert_cmpint (failures->len, ==, 0);
 
   default_streams =
@@ -1657,8 +1694,9 @@ test_module_index_read_compressed (void)
 
   bret = modulemd_module_index_update_from_file (
     baseline_idx, file_path, TRUE, &failures, &error);
-  g_assert_true (bret);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (bret);
   g_assert_cmpint (failures->len, ==, 0);
 
   baseline_text = modulemd_module_index_dump_to_string (baseline_idx, &error);
@@ -1683,6 +1721,8 @@ test_module_index_read_compressed (void)
       bret = modulemd_module_index_update_from_file (
         compressed_idx, file_path, TRUE, &failures, &error);
 
+      modulemd_subdocument_info_debug_dump_failures (failures);
+
       if (error)
         {
           g_debug ("Error: %s", error->message);
@@ -1690,8 +1730,8 @@ test_module_index_read_compressed (void)
 
       if (expected[i].succeeds)
         {
-          g_assert_true (bret);
           g_assert_no_error (error);
+          g_assert_true (bret);
         }
       else
         {
@@ -1723,7 +1763,9 @@ test_module_index_read_compressed (void)
 static void
 test_module_index_read_def_dir (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) idx = modulemd_module_index_new ();
+  g_autoptr (GPtrArray) failures = NULL;
   g_autoptr (GError) error = NULL;
   g_autofree gchar *path =
     g_build_path ("/", g_getenv ("TEST_DATA_PATH"), "defaults", NULL);
@@ -1737,9 +1779,10 @@ test_module_index_read_def_dir (void)
   g_assert_nonnull (idx);
 
   /* First verify that it works without overrides */
-  g_assert_true (modulemd_module_index_update_from_defaults_directory (
-    idx, path, TRUE, NULL, &error));
+  ret = modulemd_module_index_update_from_defaults_directory (
+    idx, path, TRUE, NULL, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
 
   /* There should be three modules in the index now:
    * - meson
@@ -1771,9 +1814,10 @@ test_module_index_read_def_dir (void)
 
 
   /* Verify with overrides */
-  g_assert_true (modulemd_module_index_update_from_defaults_directory (
-    idx, path, TRUE, overrides_path, &error));
+  ret = modulemd_module_index_update_from_defaults_directory (
+    idx, path, TRUE, overrides_path, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
 
   /* There should be four modules in the index now:
    * - meson
@@ -1846,9 +1890,10 @@ test_module_index_read_def_dir (void)
   /* Base directory contains two defaults with conflicting streams for the
    * same module in separate files. Non-strict mode.
    */
-  g_assert_true (modulemd_module_index_update_from_defaults_directory (
-    idx, bad_path, FALSE, NULL, &error));
+  ret = modulemd_module_index_update_from_defaults_directory (
+    idx, bad_path, FALSE, NULL, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
 
 
   /* There should be three modules in the index now:
@@ -1885,6 +1930,7 @@ test_module_index_read_def_dir (void)
 static void
 test_modulemd_index_search_streams (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = modulemd_module_index_new ();
   g_autoptr (GError) error = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -1894,9 +1940,13 @@ test_modulemd_index_search_streams (void)
   yaml_path = g_strdup_printf ("%s/search_streams/search_streams.yaml",
                                g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
+  g_assert_cmpint (failures->len, ==, 0);
+  g_clear_pointer (&failures, g_ptr_array_unref);
 
   streams = modulemd_module_index_search_streams (
     index, "nodejs", NULL, NULL, NULL, NULL);
@@ -2005,6 +2055,7 @@ test_modulemd_index_search_streams (void)
 static void
 test_module_index_search_streams_by_nsvca_glob (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = modulemd_module_index_new ();
   g_autoptr (GError) error = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -2014,9 +2065,13 @@ test_module_index_search_streams_by_nsvca_glob (void)
   yaml_path = g_strdup_printf ("%s/search_streams/search_streams.yaml",
                                g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
+  g_assert_cmpint (failures->len, ==, 0);
+  g_clear_pointer (&failures, g_ptr_array_unref);
 
   streams = modulemd_module_index_search_streams_by_nsvca_glob (index, "*");
   g_assert_nonnull (streams);
@@ -2056,6 +2111,7 @@ test_module_index_search_streams_by_nsvca_glob (void)
 static void
 test_module_index_search_rpms (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleIndex) index = modulemd_module_index_new ();
   g_autoptr (GError) error = NULL;
   g_autoptr (GPtrArray) failures = NULL;
@@ -2065,9 +2121,13 @@ test_module_index_search_rpms (void)
   yaml_path = g_strdup_printf ("%s/search_streams/search_streams.yaml",
                                g_getenv ("TEST_DATA_PATH"));
 
-  g_assert_true (modulemd_module_index_update_from_file (
-    index, yaml_path, TRUE, &failures, &error));
+  ret = modulemd_module_index_update_from_file (
+    index, yaml_path, TRUE, &failures, &error);
+  modulemd_subdocument_info_debug_dump_failures (failures);
   g_assert_no_error (error);
+  g_assert_true (ret);
+  g_assert_cmpint (failures->len, ==, 0);
+  g_clear_pointer (&failures, g_ptr_array_unref);
 
 
   /* Searching for "python*" should give us ReviewBoard and Django */

--- a/modulemd/tests/test-modulemd-modulestream.c
+++ b/modulemd/tests/test-modulemd-modulestream.c
@@ -4983,6 +4983,7 @@ module_stream_v1_test_xmd_issue_274 (void)
 static void
 module_stream_v2_test_xmd_issue_290 (void)
 {
+  gboolean ret;
   g_auto (GVariantBuilder) builder;
   g_autoptr (GVariant) xmd = NULL;
   GVariant *xmd_array = NULL;
@@ -5014,9 +5015,10 @@ module_stream_v2_test_xmd_issue_290 (void)
 
   modulemd_module_stream_v2_set_xmd (stream, xmd);
 
-  g_assert_true (modulemd_module_index_add_module_stream (
-    index, MODULEMD_MODULE_STREAM (stream), &error));
+  ret = modulemd_module_index_add_module_stream (
+    index, MODULEMD_MODULE_STREAM (stream), &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
 
   yaml_str = modulemd_module_index_dump_to_string (index, &error);
 
@@ -5048,6 +5050,7 @@ module_stream_v2_test_xmd_issue_290 (void)
 static void
 module_stream_v2_test_xmd_issue_290_with_example (void)
 {
+  gboolean ret;
   g_autoptr (ModulemdModuleStream) stream = NULL;
   g_autofree gchar *path = NULL;
   g_autoptr (GError) error = NULL;
@@ -5065,13 +5068,13 @@ module_stream_v2_test_xmd_issue_290_with_example (void)
     modulemd_module_stream_v1_get_xmd (MODULEMD_MODULE_STREAM_V1 (stream)));
   modulemd_module_stream_v1_set_xmd (MODULEMD_MODULE_STREAM_V1 (stream), xmd);
 
-  g_assert_true (
-    modulemd_module_index_add_module_stream (index, stream, &error));
+  ret = modulemd_module_index_add_module_stream (index, stream, &error);
   g_assert_no_error (error);
+  g_assert_true (ret);
 
   output_yaml = modulemd_module_index_dump_to_string (index, &error);
-  g_assert_nonnull (output_yaml);
   g_assert_no_error (error);
+  g_assert_nonnull (output_yaml);
 }
 
 


### PR DESCRIPTION
Background: When setting the default stream_mdversion to 3, a lot of tests are going to need major updating because a lot of the current StreamV2 test data will not upgrade to StreamV3. Either due to lack of any dependencies, or failed stream expansion for modules that specify `[]` or excluded streams. Even with the steam expansion helper addition, tests will still need a lot of work to incorporate that.

With this PR, I have revised many of the tests to make them easier to debug when making future changes for the stream_mdversion 3 default tests. For example, getting a test failure that simply says a function call didn't return TRUE isn't very helpful. Asserting that there is no gerror returned is better to do first, since the test will at least display what the error was.

I also added a function to dump sub-document failures, and called it in many existing tests, so the causes of StreamV2 to StreamV3 conversion failures can be viewed.

I did make one change to non-test code, and that is to detect and report when StreamV2 is being upgraded to StreamV3 and has no dependencies. That was previously being caught later with a difficult to comprehend "Unable to deduplicate expanded dependencies" message. 