### PR TITLE
Sort expanded dependencies for stream v2 to v3 upgrades

### DIFF
--- a/modulemd/include/private/modulemd-build-config.h
+++ b/modulemd/include/private/modulemd-build-config.h
@@ -347,6 +347,7 @@ modulemd_build_config_validate (ModulemdBuildConfig *buildconfig,
 ModulemdBuildConfig *
 modulemd_build_config_copy (ModulemdBuildConfig *self);
 
+
 /**
  * modulemd_build_config_equals:
  * @self_1: A pointer to a #ModulemdBuildConfig object.
@@ -361,5 +362,20 @@ modulemd_build_config_copy (ModulemdBuildConfig *self);
 gboolean
 modulemd_build_config_equals (ModulemdBuildConfig *self_1,
                               ModulemdBuildConfig *self_2);
+
+
+/**
+ * modulemd_build_config_compare:
+ * @self_1: (in): A pointer to a #ModulemdBuildConfig object.
+ * @self_2: (in): A pointer to a #ModulemdBuildConfig object.
+ *
+ * Returns: Less than zero if @self_1 sorts less than @self_2, zero for equal,
+ * greater than zero if @self_1 is greater than @self_2.
+ *
+ * Since: 2.10
+ */
+gint
+modulemd_build_config_compare (ModulemdBuildConfig *self_1,
+                               ModulemdBuildConfig *self_2);
 
 G_END_DECLS

--- a/modulemd/include/private/modulemd-buildopts-private.h
+++ b/modulemd/include/private/modulemd-buildopts-private.h
@@ -63,3 +63,18 @@ gboolean
 modulemd_buildopts_emit_yaml (ModulemdBuildopts *self,
                               yaml_emitter_t *emitter,
                               GError **error);
+
+
+/**
+ * modulemd_buildopts_compare:
+ * @self_1: (in): A #ModulemdBuildopts object.
+ * @self_2: (in): A #ModulemdBuildopts object.
+ *
+ * Returns: Less than zero if @self_1 sorts less than @self_2, zero for equal,
+ * greater than zero if @self_1 is greater than @self_2.
+ *
+ * Since: 2.10
+ */
+gint
+modulemd_buildopts_compare (ModulemdBuildopts *self_1,
+                            ModulemdBuildopts *self_2);

--- a/modulemd/include/private/modulemd-util.h
+++ b/modulemd/include/private/modulemd-util.h
@@ -205,6 +205,27 @@ modulemd_hash_table_equals (GHashTable *a,
                             GHashTable *b,
                             GEqualFunc compare_func);
 
+/*
+ * modulemd_hash_table_compare:
+ * @a: (in): A #GHashTable object.
+ * @b: (in): A #GHashTable object.
+ * @value_compare_func: (in): A #GCompareFunc function that is called to compare
+ * pairs of #GHashTable values for sorting. If NULL, only the #GHashTable keys
+ * are compared.
+ *
+ * Using guidance from
+ * https://docs.python.org/3/tutorial/datastructures.html#comparing-sequences-and-other-types
+ *
+ * Returns: Less than zero if @a sorts less than @b, zero for equal, greater than
+ * zero if @a is greater than @b.
+ *
+ * Since: 2.10
+ */
+gint
+modulemd_hash_table_compare (GHashTable *a,
+                             GHashTable *b,
+                             GCompareFunc value_compare_func);
+
 /**
  * modulemd_strcmp_sort:
  * @a: A #gconstpointer.
@@ -217,6 +238,19 @@ modulemd_hash_table_equals (GHashTable *a,
  */
 gint
 modulemd_strcmp_sort (gconstpointer a, gconstpointer b);
+
+/**
+ * modulemd_strcmp_wrapper:
+ * @a: (in): A #gconstpointer.
+ * @b: (in): A #gconstpointer.
+ *
+ * Returns: 0 if @a and @b are identical strings, a negative value if @a is less
+ * than @b, and a positive value if @a is greater than @b.
+ *
+ * Since: 2.10
+ */
+gint
+modulemd_strcmp_wrapper (gconstpointer a, gconstpointer b);
 
 /**
  * modulemd_ordered_str_keys:

--- a/modulemd/modulemd-build-config.c
+++ b/modulemd/modulemd-build-config.c
@@ -722,3 +722,67 @@ modulemd_build_config_equals (ModulemdBuildConfig *self_1,
 
   return TRUE;
 }
+
+
+/* return less than zero if first arg is less than second arg,
+ * zero for equal,
+ * greater than zero if first arg is greater than second arg.
+ */
+gint
+modulemd_build_config_compare (ModulemdBuildConfig *self_1,
+                               ModulemdBuildConfig *self_2)
+{
+  gint cmp;
+
+  if (!self_1 && !self_2)
+    {
+      return 0;
+    }
+
+  if (!self_1)
+    {
+      return -1;
+    }
+
+  if (!self_2)
+    {
+      return 1;
+    }
+
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self_1), 1);
+  g_return_val_if_fail (MODULEMD_IS_BUILD_CONFIG (self_2), -1);
+
+  cmp = g_strcmp0 (self_1->context, self_2->context);
+  if (cmp != 0)
+    {
+      return cmp;
+    }
+
+  cmp = g_strcmp0 (self_1->platform, self_2->platform);
+  if (cmp != 0)
+    {
+      return cmp;
+    }
+
+  cmp = modulemd_hash_table_compare (
+    self_1->buildrequires, self_2->buildrequires, modulemd_strcmp_wrapper);
+  if (cmp != 0)
+    {
+      return cmp;
+    }
+
+  cmp = modulemd_hash_table_compare (
+    self_1->requires, self_2->requires, modulemd_strcmp_wrapper);
+  if (cmp != 0)
+    {
+      return cmp;
+    }
+
+  cmp = modulemd_buildopts_compare (self_1->buildopts, self_2->buildopts);
+  if (cmp != 0)
+    {
+      return cmp;
+    }
+
+  return 0;
+}

--- a/modulemd/modulemd-buildopts.c
+++ b/modulemd/modulemd-buildopts.c
@@ -82,6 +82,52 @@ modulemd_buildopts_equals (ModulemdBuildopts *self_1,
   return TRUE;
 }
 
+gint
+modulemd_buildopts_compare (ModulemdBuildopts *self_1,
+                            ModulemdBuildopts *self_2)
+{
+  gint cmp;
+
+  if (!self_1 && !self_2)
+    {
+      return 0;
+    }
+
+  if (!self_1)
+    {
+      return -1;
+    }
+
+  if (!self_2)
+    {
+      return 1;
+    }
+
+  g_return_val_if_fail (MODULEMD_IS_BUILDOPTS (self_1), 1);
+  g_return_val_if_fail (MODULEMD_IS_BUILDOPTS (self_2), -1);
+
+  cmp = g_strcmp0 (self_1->rpm_macros, self_2->rpm_macros);
+  if (cmp != 0)
+    {
+      return cmp;
+    }
+
+  cmp =
+    modulemd_hash_table_compare (self_1->whitelist, self_2->whitelist, NULL);
+  if (cmp != 0)
+    {
+      return cmp;
+    }
+
+  cmp = modulemd_hash_table_compare (self_1->arches, self_2->arches, NULL);
+  if (cmp != 0)
+    {
+      return cmp;
+    }
+
+  return 0;
+}
+
 
 ModulemdBuildopts *
 modulemd_buildopts_new (void)

--- a/modulemd/modulemd-obsoletes.c
+++ b/modulemd/modulemd-obsoletes.c
@@ -1166,8 +1166,7 @@ modulemd_obsoletes_emit_yaml (ModulemdObsoletes *self,
           g_set_error (error,
                        MODULEMD_ERROR,
                        MMD_ERROR_VALIDATE,
-                       "Cannot convert eol_date: %" PRIu64
-                       " to iso8601 date.",
+                       "Cannot convert eol_date: %" PRIu64 " to iso8601 date.",
                        eol_date);
           return FALSE;
         }

--- a/modulemd/modulemd-util.c
+++ b/modulemd/modulemd-util.c
@@ -233,10 +233,78 @@ modulemd_hash_table_equals (GHashTable *a,
   return TRUE;
 }
 
+
+gint
+modulemd_hash_table_compare (GHashTable *a,
+                             GHashTable *b,
+                             GCompareFunc value_compare_func)
+{
+  g_autoptr (GPtrArray) set_a = NULL;
+  g_autoptr (GPtrArray) set_b = NULL;
+  int i = 0;
+  gchar *key = NULL;
+  gchar *value_a = NULL;
+  gchar *value_b = NULL;
+  gint cmp;
+
+  /* Get the ordered list of keys from each hashtable. */
+  set_a = modulemd_ordered_str_keys (a, modulemd_strcmp_sort);
+  set_b = modulemd_ordered_str_keys (b, modulemd_strcmp_sort);
+
+  for (i = 0; i < set_a->len; i++)
+    {
+      /* If we ran out of elements in the second set, it is shorter and thus the
+       * lesser one.
+       */
+      if (i >= set_b->len)
+        {
+          return 1;
+        }
+
+      /* Compare the keys. */
+      cmp =
+        g_strcmp0 (g_ptr_array_index (set_a, i), g_ptr_array_index (set_b, i));
+      if (cmp != 0)
+        {
+          return cmp;
+        }
+
+      /* If the keys match, compare the values if needed. */
+      if (value_compare_func)
+        {
+          key = g_ptr_array_index (set_a, i);
+          value_a = g_hash_table_lookup (a, key);
+          value_b = g_hash_table_lookup (b, key);
+          cmp = value_compare_func (value_a, value_b);
+          if (cmp != 0)
+            {
+              return cmp;
+            }
+        }
+    }
+
+  /* If everything has been the same so far but there are more elements in the
+   * second set, it is longer and thus the greater one.
+   */
+  if (set_a->len < set_b->len)
+    {
+      return -1;
+    }
+
+  /* If we made it this far, they are equal. */
+  return 0;
+}
+
 gint
 modulemd_strcmp_sort (gconstpointer a, gconstpointer b)
 {
   return g_strcmp0 (*(const gchar **)a, *(const gchar **)b);
+}
+
+gint
+modulemd_strcmp_wrapper (gconstpointer a, gconstpointer b)
+{
+  return g_strcmp0 ((gchar *)a, (gchar *)b);
 }
 
 GPtrArray *

--- a/modulemd/tests/test-modulemd-build-config.c
+++ b/modulemd/tests/test-modulemd-build-config.c
@@ -758,9 +758,8 @@ buildconfig_test_emit_yaml (void)
                    "...\n");
 }
 
-
 static void
-buildconfig_test_equals (void)
+buildconfig_test_comparison (void)
 {
   g_autoptr (ModulemdBuildConfig) bc_1 = NULL;
   g_autoptr (ModulemdBuildConfig) bc_2 = NULL;
@@ -776,6 +775,17 @@ buildconfig_test_equals (void)
   g_assert_true (MODULEMD_IS_BUILD_CONFIG (bc_2));
 
   g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), ==, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), ==, 0);
+
+  /* checks when NULL is involved */
+  g_assert_true (modulemd_build_config_equals (NULL, NULL));
+  g_assert_false (modulemd_build_config_equals (NULL, bc_2));
+  g_assert_false (modulemd_build_config_equals (bc_1, NULL));
+  g_assert_cmpint (modulemd_build_config_compare (NULL, NULL), ==, 0);
+  g_assert_cmpint (modulemd_build_config_compare (NULL, bc_2), <, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, NULL), >, 0);
+
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -791,6 +801,8 @@ buildconfig_test_equals (void)
   modulemd_build_config_set_context (bc_2, "CTX1");
 
   g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), ==, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), ==, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -806,6 +818,8 @@ buildconfig_test_equals (void)
   modulemd_build_config_set_context (bc_2, "CTX2");
 
   g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), <, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), >, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -821,6 +835,8 @@ buildconfig_test_equals (void)
   modulemd_build_config_set_platform (bc_2, "f33");
 
   g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), ==, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), ==, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -836,6 +852,8 @@ buildconfig_test_equals (void)
   modulemd_build_config_set_platform (bc_2, "f32");
 
   g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), >, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), <, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -857,6 +875,8 @@ buildconfig_test_equals (void)
     bc_2, "buildmod2", "stream2");
 
   g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), ==, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), ==, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -880,6 +900,8 @@ buildconfig_test_equals (void)
     bc_2, "buildmod3", "stream3");
 
   g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), <, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), >, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -897,6 +919,8 @@ buildconfig_test_equals (void)
   modulemd_build_config_add_runtime_requirement (bc_2, "runmod2", "stream4");
 
   g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), ==, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), ==, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -915,6 +939,8 @@ buildconfig_test_equals (void)
   modulemd_build_config_add_runtime_requirement (bc_2, "runmod3", "stream5");
 
   g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), <, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), >, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -940,6 +966,8 @@ buildconfig_test_equals (void)
   modulemd_build_config_add_runtime_requirement (bc_2, "runmod2", "stream4");
 
   g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), ==, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), ==, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -967,6 +995,8 @@ buildconfig_test_equals (void)
   modulemd_build_config_add_runtime_requirement (bc_2, "runmod2", "stream4");
 
   g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), >, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), <, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
 
@@ -985,6 +1015,8 @@ buildconfig_test_equals (void)
   modulemd_build_config_set_buildopts (bc_2, opts);
 
   g_assert_true (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), ==, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), ==, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
   g_clear_object (&opts);
@@ -1008,6 +1040,8 @@ buildconfig_test_equals (void)
   modulemd_build_config_set_buildopts (bc_2, opts);
 
   g_assert_false (modulemd_build_config_equals (bc_1, bc_2));
+  g_assert_cmpint (modulemd_build_config_compare (bc_1, bc_2), <, 0);
+  g_assert_cmpint (modulemd_build_config_compare (bc_2, bc_1), >, 0);
   g_clear_object (&bc_1);
   g_clear_object (&bc_2);
   g_clear_object (&opts);
@@ -1065,7 +1099,8 @@ main (int argc, char *argv[])
   g_test_add_func ("/modulemd/v2/buildconfig/yaml/emit",
                    buildconfig_test_emit_yaml);
 
-  g_test_add_func ("/modulemd/v2/buildconfig/equals", buildconfig_test_equals);
+  g_test_add_func ("/modulemd/v2/buildconfig/comparison",
+                   buildconfig_test_comparison);
 
   return g_test_run ();
 }

--- a/modulemd/tests/test-modulemd-buildopts.c
+++ b/modulemd/tests/test-modulemd-buildopts.c
@@ -60,7 +60,7 @@ buildopts_test_construct (void)
 
 
 static void
-buildopts_test_equals (void)
+buildopts_test_comparison (void)
 {
   g_autoptr (ModulemdBuildopts) b_1 = NULL;
   g_autoptr (ModulemdBuildopts) b_2 = NULL;
@@ -75,6 +75,8 @@ buildopts_test_equals (void)
   g_assert_true (MODULEMD_IS_BUILDOPTS (b_2));
 
   g_assert_true (modulemd_buildopts_equals (b_1, b_2));
+  g_assert_cmpint (modulemd_buildopts_compare (b_1, b_2), ==, 0);
+  g_assert_cmpint (modulemd_buildopts_compare (b_2, b_1), ==, 0);
   g_clear_object (&b_1);
   g_clear_object (&b_2);
 
@@ -90,6 +92,8 @@ buildopts_test_equals (void)
   g_assert_true (MODULEMD_IS_BUILDOPTS (b_2));
 
   g_assert_true (modulemd_buildopts_equals (b_1, b_2));
+  g_assert_cmpint (modulemd_buildopts_compare (b_1, b_2), ==, 0);
+  g_assert_cmpint (modulemd_buildopts_compare (b_2, b_1), ==, 0);
   g_clear_object (&b_1);
   g_clear_object (&b_2);
 
@@ -105,6 +109,8 @@ buildopts_test_equals (void)
   g_assert_true (MODULEMD_IS_BUILDOPTS (b_2));
 
   g_assert_false (modulemd_buildopts_equals (b_1, b_2));
+  g_assert_cmpint (modulemd_buildopts_compare (b_1, b_2), <, 0);
+  g_assert_cmpint (modulemd_buildopts_compare (b_2, b_1), >, 0);
   g_clear_object (&b_1);
   g_clear_object (&b_2);
 
@@ -124,6 +130,8 @@ buildopts_test_equals (void)
   g_assert_true (MODULEMD_IS_BUILDOPTS (b_2));
 
   g_assert_true (modulemd_buildopts_equals (b_1, b_2));
+  g_assert_cmpint (modulemd_buildopts_compare (b_1, b_2), ==, 0);
+  g_assert_cmpint (modulemd_buildopts_compare (b_2, b_1), ==, 0);
   g_clear_object (&b_1);
   g_clear_object (&b_2);
 
@@ -141,6 +149,8 @@ buildopts_test_equals (void)
   g_assert_true (MODULEMD_IS_BUILDOPTS (b_2));
 
   g_assert_false (modulemd_buildopts_equals (b_1, b_2));
+  g_assert_cmpint (modulemd_buildopts_compare (b_1, b_2), >, 0);
+  g_assert_cmpint (modulemd_buildopts_compare (b_2, b_1), <, 0);
   g_clear_object (&b_1);
   g_clear_object (&b_2);
 
@@ -161,6 +171,8 @@ buildopts_test_equals (void)
   g_assert_true (MODULEMD_IS_BUILDOPTS (b_2));
 
   g_assert_false (modulemd_buildopts_equals (b_1, b_2));
+  g_assert_cmpint (modulemd_buildopts_compare (b_1, b_2), <, 0);
+  g_assert_cmpint (modulemd_buildopts_compare (b_2, b_1), >, 0);
   g_clear_object (&b_1);
   g_clear_object (&b_2);
 
@@ -181,6 +193,8 @@ buildopts_test_equals (void)
   g_assert_true (MODULEMD_IS_BUILDOPTS (b_2));
 
   g_assert_false (modulemd_buildopts_equals (b_1, b_2));
+  g_assert_cmpint (modulemd_buildopts_compare (b_1, b_2), >, 0);
+  g_assert_cmpint (modulemd_buildopts_compare (b_2, b_1), <, 0);
   g_clear_object (&b_1);
   g_clear_object (&b_2);
 
@@ -204,6 +218,8 @@ buildopts_test_equals (void)
   g_assert_true (MODULEMD_IS_BUILDOPTS (b_2));
 
   g_assert_false (modulemd_buildopts_equals (b_1, b_2));
+  g_assert_cmpint (modulemd_buildopts_compare (b_1, b_2), >, 0);
+  g_assert_cmpint (modulemd_buildopts_compare (b_2, b_1), <, 0);
   g_clear_object (&b_1);
   g_clear_object (&b_2);
 }
@@ -559,7 +575,8 @@ main (int argc, char *argv[])
   g_test_add_func ("/modulemd/v2/buildopts/construct",
                    buildopts_test_construct);
 
-  g_test_add_func ("/modulemd/v2/buildopts/equals", buildopts_test_equals);
+  g_test_add_func ("/modulemd/v2/buildopts/comparison",
+                   buildopts_test_comparison);
 
   g_test_add_func ("/modulemd/v2/buildopts/copy", buildopts_test_copy);
 

--- a/modulemd/tests/test_data/upgrades/stream_v1_to_stream_v3.yaml
+++ b/modulemd/tests/test_data/upgrades/stream_v1_to_stream_v3.yaml
@@ -1,0 +1,98 @@
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "stream-name"
+  version: 20160927144203
+  context: c0ffee43
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: and-its-stream-name
+    buildrequires:
+      extra-build-env: [and-its-stream-name-too]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    default:
+      rpms:
+      - bar
+      - bar-extras
+      - baz
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: This one is here to demonstrate other stuff.
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...

--- a/modulemd/tests/test_data/upgrades/stream_v2_to_stream_v3.yaml
+++ b/modulemd/tests/test_data/upgrades/stream_v2_to_stream_v3.yaml
@@ -1,0 +1,2645 @@
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0001
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [baz]
+      moreextras: [bar]
+    requires:
+      extras: [baz]
+      moreextras: [bar]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0002
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [baz]
+      moreextras: [bar]
+    requires:
+      extras: [baz]
+      moreextras: [foo]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0003
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [baz]
+      moreextras: [bar]
+    requires:
+      extras: [qux]
+      moreextras: [bar]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0004
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [baz]
+      moreextras: [bar]
+    requires:
+      extras: [qux]
+      moreextras: [foo]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0005
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [baz]
+      moreextras: [foo]
+    requires:
+      extras: [baz]
+      moreextras: [bar]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0006
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [baz]
+      moreextras: [foo]
+    requires:
+      extras: [baz]
+      moreextras: [foo]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0007
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [baz]
+      moreextras: [foo]
+    requires:
+      extras: [qux]
+      moreextras: [bar]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0008
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [baz]
+      moreextras: [foo]
+    requires:
+      extras: [qux]
+      moreextras: [foo]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0009
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [qux]
+      moreextras: [bar]
+    requires:
+      extras: [baz]
+      moreextras: [bar]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0010
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [qux]
+      moreextras: [bar]
+    requires:
+      extras: [baz]
+      moreextras: [foo]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0011
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [qux]
+      moreextras: [bar]
+    requires:
+      extras: [qux]
+      moreextras: [bar]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0012
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [qux]
+      moreextras: [bar]
+    requires:
+      extras: [qux]
+      moreextras: [foo]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0013
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [qux]
+      moreextras: [foo]
+    requires:
+      extras: [baz]
+      moreextras: [bar]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0014
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [qux]
+      moreextras: [foo]
+    requires:
+      extras: [baz]
+      moreextras: [foo]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0015
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [qux]
+      moreextras: [foo]
+    requires:
+      extras: [qux]
+      moreextras: [bar]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0016
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel7
+    buildrequires:
+      extras: [qux]
+      moreextras: [foo]
+    requires:
+      extras: [qux]
+      moreextras: [foo]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0017
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: epel8
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0018
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: f27
+    buildrequires:
+      buildtools: [v1]
+      compatible: [v3]
+    requires:
+      compatible: [v3]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0019
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: f27
+    buildrequires:
+      buildtools: [v1]
+      compatible: [v3]
+    requires:
+      compatible: [v4]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0020
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: f27
+    buildrequires:
+      buildtools: [v2]
+      compatible: [v3]
+    requires:
+      compatible: [v3]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0021
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: f27
+    buildrequires:
+      buildtools: [v2]
+      compatible: [v3]
+    requires:
+      compatible: [v4]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0022
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: f28
+    requires:
+      runtime: [a]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0023
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: f28
+    requires:
+      runtime: [b]
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0024
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: f29
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...
+---
+document: modulemd-stream
+version: 3
+data:
+  name: foo
+  stream: "latest"
+  version: 20160927144203
+  context: AUTO0025
+  arch: x86_64
+  summary: An example module
+  description: >-
+    A module for the demonstration of the metadata format. Also, the obligatory lorem
+    ipsum dolor sit amet goes right here.
+  license:
+    module:
+    - MIT
+    content:
+    - Beerware
+    - GPLv2+
+    - zlib
+  xmd:
+    some_key: some_data
+  dependencies:
+    platform: f30
+  references:
+    community: http://www.example.com/
+    documentation: http://www.example.com/
+    tracker: http://www.example.com/
+  profiles:
+    buildroot:
+      rpms:
+      - bar-devel
+    container:
+      rpms:
+      - bar
+      - bar-devel
+    minimal:
+      description: Minimal profile installing only the bar package.
+      rpms:
+      - bar
+    srpm-buildroot:
+      rpms:
+      - bar-extras
+  api:
+    rpms:
+    - bar
+    - bar-devel
+    - bar-extras
+    - baz
+    - xxx
+  filter:
+    rpms:
+    - baz-nonfoo
+  buildopts:
+    rpms:
+      macros: >
+        %demomacro 1
+
+        %demomacro2 %{demomacro}23
+      whitelist:
+      - fooscl-1-bar
+      - fooscl-1-baz
+      - xxx
+      - xyz
+    arches: [i686, x86_64]
+  components:
+    rpms:
+      bar:
+        rationale: We need this to demonstrate stuff.
+        name: bar-real
+        repository: https://pagure.io/bar.git
+        cache: https://example.com/cache
+        ref: 26ca0c0
+      baz:
+        rationale: Demonstrate updating the buildroot contents.
+        buildroot: true
+        srpm-buildroot: true
+        buildorder: -1
+      xxx:
+        rationale: xxx demonstrates arches and multilib.
+        arches: [i686, x86_64]
+        multilib: [x86_64]
+      xyz:
+        rationale: xyz is a bundled dependency of xxx.
+        buildorder: 10
+    modules:
+      includedmodule:
+        rationale: Included in the stack, just because.
+        repository: https://pagure.io/includedmodule.git
+        ref: somecoolbranchname
+        buildorder: 100
+  artifacts:
+    rpms:
+    - bar-0:1.23-1.module_deadbeef.x86_64
+    - bar-devel-0:1.23-1.module_deadbeef.x86_64
+    - bar-extras-0:1.23-1.module_deadbeef.x86_64
+    - baz-0:42-42.module_deadbeef.x86_64
+    - xxx-0:1-1.module_deadbeef.i686
+    - xxx-0:1-1.module_deadbeef.x86_64
+    - xyz-0:1-1.module_deadbeef.x86_64
+...


### PR DESCRIPTION
When modulemd-stream v2 documents are upgraded to modulemd-stream v3, they may undergo stream expansion of the buildtime and runtime dependencies. This PR implements strict sorting of stream expanded dependencies so they are in a sensible, predictable, and reliable order before contexts are auto-generated.

Having this ordering in place also facilitates the implementation of meaningful stream expansion and upgrade tests--which are also provided by this PR.

