### PR TITLE
Modified Scripts to use env in shebang.

### DIFF
--- a/.travis/archlinux/travis-tasks.sh
+++ b/.travis/archlinux/travis-tasks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Exit on failures
 set -e

--- a/.travis/centos/travis-tasks.sh
+++ b/.travis/centos/travis-tasks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Exit on failures
 set -e

--- a/.travis/coverity/travis-tasks.sh
+++ b/.travis/coverity/travis-tasks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Exit on failures
 set -e

--- a/.travis/coverity_prep.sh
+++ b/.travis/coverity_prep.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -x
 

--- a/.travis/docs/travis-tasks.sh
+++ b/.travis/docs/travis-tasks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Exit on failures
 set -e

--- a/.travis/fedora/travis-tasks.sh
+++ b/.travis/fedora/travis-tasks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Exit on failures
 set -e

--- a/.travis/get_rawhide_version.py
+++ b/.travis/get_rawhide_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # This file is part of libmodulemd
 # Copyright (C) 2020 Stephen Gallagher

--- a/.travis/mageia/travis-tasks.sh
+++ b/.travis/mageia/travis-tasks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Exit on failures
 set -e

--- a/.travis/openmandriva/travis-tasks.sh
+++ b/.travis/openmandriva/travis-tasks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Exit on failures
 set -e

--- a/.travis/opensuse/travis-tasks.sh
+++ b/.travis/opensuse/travis-tasks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Exit on failures
 set -e

--- a/.travis/retry-command.sh
+++ b/.travis/retry-command.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function retry_command {
     local usage="Usage: ${FUNCNAME[0]} [-b backoff-factor] [-d delay] [-n numtries]"

--- a/.travis/scanbuild.sh
+++ b/.travis/scanbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This file is part of libmodulemd
 # Copyright (C) 2018 Stephen Gallagher
 #

--- a/.travis/travis-archlinux.sh
+++ b/.travis/travis-archlinux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd $SCRIPT_DIR

--- a/.travis/travis-centos.sh
+++ b/.travis/travis-centos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd $SCRIPT_DIR

--- a/.travis/travis-common.inc
+++ b/.travis/travis-common.inc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 

--- a/.travis/travis-coverity.sh
+++ b/.travis/travis-coverity.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd $SCRIPT_DIR

--- a/.travis/travis-docs.sh
+++ b/.travis/travis-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd $SCRIPT_DIR

--- a/.travis/travis-fedora.sh
+++ b/.travis/travis-fedora.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd $SCRIPT_DIR

--- a/.travis/travis-mageia.sh
+++ b/.travis/travis-mageia.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd $SCRIPT_DIR

--- a/.travis/travis-openmandriva.sh
+++ b/.travis/travis-openmandriva.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR

--- a/.travis/travis-opensuse.sh
+++ b/.travis/travis-opensuse.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd $SCRIPT_DIR

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/setup_dev_container.sh
+++ b/setup_dev_container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SCRIPT_DIR="$SOURCE_DIR/.travis"

--- a/spec_tmpl.sh
+++ b/spec_tmpl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function main {
     local template version release


### PR DESCRIPTION
The current shebang statements work fine on a Fedora host,
But while trying to setup a development environment on non-Fedora-like host,
It seems to cause an issue as bash doesn't always live on /bin/bash in some operating systems (e.g: NixOS, etc).

The usage /usr/bin/env bash makes sure, we're pointing towards the bash environment.

It improves our portability for the scripts for non-fedora-like hosts for developers to set up locally.

What do we think about it ?

Signed-off-by: nasirhm <nasirhussainm14@gmail.com>