### PR TITLE
Work around libseccomp issue in CI

### DIFF
--- a/.ci/fedora/ci-tasks.sh
+++ b/.ci/fedora/ci-tasks.sh
@@ -12,6 +12,9 @@ override_dir=`python3 -c 'import gi; print(gi._overridesdir)'`
 
 pushd /builddir/
 
+# Work-around ldd bug in rawhide CIs
+sed -i -e 's/test -r/test -f/g' -e 's/test -x/test -f/g' /bin/ldd
+
 # Build the code under GCC and run standard tests
 meson --buildtype=debugoptimized \
       -Dverbose_tests=false \


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1906575 for more
details.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>


Fedora Rawhide CI runs were failing (but for unrelated reasons the error was being caught and the CI task was reporting "green"). This works around an issue with Rawhide/F34 and CI hosts running with `libseccomp < 2.4.4`.