### PR TITLE
CI: Add Github Actions for aarch64, ppc64le and s390x

### DIFF
--- a/.ci/fedora/Dockerfile.deps.tmpl
+++ b/.ci/fedora/Dockerfile.deps.tmpl
@@ -2,53 +2,7 @@ FROM __IMAGE__
 
 MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
-RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' \
-           --nogpgcheck --skip-broken install \
-	python3-black \
-	clang \
-	clang-analyzer \
-	clang-tools-extra \
-	createrepo_c \
-	"libmodulemd >= 2.3" \
-	curl \
-	elinks \
-	file-devel \
-	gcc \
-	gcc-c++ \
-	git-core \
-	glib2-devel \
-	glib2-doc \
-	gobject-introspection-devel \
-	gtk-doc \
-	help2man \
-	jq \
-	libyaml-devel \
-	meson \
-	ninja-build \
-	openssl \
-	packit \
-	pkgconf \
-	popt-devel \
-	python2-devel \
-	python2-six \
-	python2-gobject-base \
-	python3-autopep8 \
-	python3-devel \
-	python3-GitPython \
-	python3-gobject-base \
-	python3-koji \
-	python3-pycodestyle \
-	python3-rpm-macros \
-	redhat-rpm-config \
-	rpm-build \
-	rpm-devel \
-	rpmdevtools \
-	ruby \
-	"rubygem(json)" \
-	rubygems \
-	sudo \
-	valgrind \
-	wget \
-    && dnf -y clean all
+COPY ./fedora/get_fedora_deps.sh /root
 
-RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py
+RUN /root/get_fedora_deps.sh
+

--- a/.ci/fedora/ci-tasks.sh
+++ b/.ci/fedora/ci-tasks.sh
@@ -7,6 +7,7 @@ set -x
 PROCESSORS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
 MESON_DIRTY_REPO_ARGS="-Dtest_dirty_git=${DIRTY_REPO_CHECK:-false}"
 RETRY_CMD=/builddir/.ci/retry-command.sh
+WITH_RPM_TESTS=${WITH_RPM_TESTS:-true}
 
 override_dir=`python3 -c 'import gi; print(gi._overridesdir)'`
 
@@ -58,6 +59,10 @@ else
     pushd ci_scanbuild
     /builddir/.ci/scanbuild.sh
     popd #ci_scanbuild
+fi
+
+if [ $WITH_RPM_TESTS != true ]; then
+    exit 0
 fi
 
 

--- a/.ci/fedora/get_fedora_deps.sh
+++ b/.ci/fedora/get_fedora_deps.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $SCRIPT_DIR
+
+dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' \
+       --nogpgcheck --skip-broken --quiet install \
+    python3-black \
+    clang \
+    clang-analyzer \
+    clang-tools-extra \
+    createrepo_c \
+    "libmodulemd >= 2.3" \
+    curl \
+    elinks \
+    file-devel \
+    gcc \
+    gcc-c++ \
+    git-core \
+    glib2-devel \
+    glib2-doc \
+    gobject-introspection-devel \
+    gtk-doc \
+    help2man \
+    jq \
+    libyaml-devel \
+    meson \
+    ninja-build \
+    openssl \
+    packit \
+    pkgconf \
+    popt-devel \
+    python2-devel \
+    python2-six \
+    python2-gobject-base \
+    python3-autopep8 \
+    python3-devel \
+    python3-GitPython \
+    python3-gobject-base \
+    python3-koji \
+    python3-pycodestyle \
+    python3-rpm-macros \
+    redhat-rpm-config \
+    rpm-build \
+    rpm-devel \
+    rpmdevtools \
+    ruby \
+    "rubygem(json)" \
+    rubygems \
+    sudo \
+    valgrind \
+    wget
+
+dnf -y clean all
+
+ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py
+
+popd

--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -1,0 +1,40 @@
+name: Other Architectures
+on: [push, pull_request]
+
+jobs:
+  multiarch:
+    runs-on: ubuntu-20.04
+    name: ${{ matrix.distro }} on ${{ matrix.arch }}
+    continue-on-error: true
+
+    # Run steps on a matrix of 3 arch/distro combinations
+    strategy:
+      matrix:
+        include:
+          - arch: ppc64le
+            distro: fedora_latest
+          - arch: s390x
+            distro: fedora_latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: uraimo/run-on-arch-action@v2.0.7
+        name: Perform upstream tests
+
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Work-around ldd bug in rawhide CIs
+          run: |
+            $GITHUB_WORKSPACE/.ci/fedora/get_fedora_deps.sh
+            sed -i -e 's/test -r/test -f/g' -e 's/test -x/test -f/g' /bin/ldd
+            meson setup --buildtype=debugoptimized -Dverbose_tests=false /tmp/ci $GITHUB_WORKSPACE
+            meson test --suite formatters -C /tmp/ci --print-errorlogs -t 5
+            meson test --suite ci -C /tmp/ci --print-errorlogs -t 5
+


### PR DESCRIPTION
We cannot run valgrind on these because it is incompatible with
the qemu-static virtualization, but this will allow us to at
least run all of the standard CI tests on those architectures.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>