### PR TITLE
Enable Modulemd.read_packager_file/string() to specify module and stream name overrides

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd.h
+++ b/modulemd/include/modulemd-2.0/modulemd.h
@@ -362,6 +362,33 @@ modulemd_read_packager_file (const gchar *yaml_path,
                              GError **error);
 
 /**
+ * modulemd_read_packager_file_ext:
+ * @yaml_path: (in): A path to a YAML file containing a packager document.
+ * @object: (out): (transfer full): A newly allocated #ModulemdModuleStreamV2 or
+ * #ModulemdPackagerV3 object initialized with the content from @yaml_path.
+ * @module_name: (in) (nullable): An optional module name to override the
+ * document on disk. Mostly useful in cases where the name is being
+ * auto-detected from git.
+ * @module_stream: (in) (nullable): An optional module stream name to override
+ * the document on disk. Mostly useful in cases where the name is being
+ * auto-detected from git.
+ * @error: (out): A #GError containing additional information if this function
+ * fails in a way that prevents program continuation.
+ *
+ * Returns: @MODULEMD_TYPE_MODULE_STREAM_V2, @MODULEMD_TYPE_PACKAGER_V3, or
+ * @G_TYPE_INVALID. Returns the matching GObject through the @object parameter.
+ * If the return value is @G_TYPE_INVALID, returns the reason as @error.
+ *
+ * Since: 2.11
+ */
+GType
+modulemd_read_packager_file_ext (const gchar *yaml_path,
+                                 GObject **object,
+                                 const gchar *module_name,
+                                 const gchar *module_stream,
+                                 GError **error);
+
+/**
  * modulemd_read_packager_string:
  * @yaml_string: (in): A YAML string containing a packager document.
  * @object: (out): (transfer full): A newly allocated #ModulemdModuleStreamV2 or
@@ -379,5 +406,32 @@ GType
 modulemd_read_packager_string (const gchar *yaml_string,
                                GObject **object,
                                GError **error);
+
+/**
+ * modulemd_read_packager_string_ext:
+ * @yaml_string: (in): A YAML string containing a packager document.
+ * @object: (out): (transfer full): A newly allocated #ModulemdModuleStreamV2 or
+ * #ModulemdPackagerV3 object initialized with the content from @yaml_string.
+ * @module_name: (in) (nullable): An optional module name to override the
+ * document on disk. Mostly useful in cases where the name is being
+ * auto-detected from git.
+ * @module_stream: (in) (nullable): An optional module stream name to override
+ * the document on disk. Mostly useful in cases where the name is being
+ * auto-detected from git.
+ * @error: (out): A #GError containing additional information if this function
+ * fails in a way that prevents program continuation.
+ *
+ * Returns: @MODULEMD_TYPE_MODULE_STREAM_V2, @MODULEMD_TYPE_PACKAGER_V3, or
+ * @G_TYPE_INVALID. Returns the matching GObject through the @object parameter.
+ * If the return value is @G_TYPE_INVALID, returns the reason as @error.
+ *
+ * Since: 2.11
+ */
+GType
+modulemd_read_packager_string_ext (const gchar *yaml_string,
+                                   GObject **object,
+                                   const gchar *module_name,
+                                   const gchar *module_stream,
+                                   GError **error);
 
 G_END_DECLS

--- a/modulemd/include/modulemd-2.0/modulemd.h
+++ b/modulemd/include/modulemd-2.0/modulemd.h
@@ -343,7 +343,7 @@ ModulemdModuleIndex *
 modulemd_load_string (const gchar *yaml_string, GError **error);
 
 /**
- * modulemd_read_packager_file:
+ * modulemd_read_packager_file: (skip)
  * @yaml_path: (in): A path to a YAML file containing a packager document.
  * @object: (out): (transfer full): A newly allocated #ModulemdModuleStreamV2 or
  * #ModulemdPackagerV3 object initialized with the content from @yaml_path.
@@ -362,7 +362,7 @@ modulemd_read_packager_file (const gchar *yaml_path,
                              GError **error);
 
 /**
- * modulemd_read_packager_file_ext:
+ * modulemd_read_packager_file_ext: (rename-to modulemd_read_packager_file)
  * @yaml_path: (in): A path to a YAML file containing a packager document.
  * @object: (out): (transfer full): A newly allocated #ModulemdModuleStreamV2 or
  * #ModulemdPackagerV3 object initialized with the content from @yaml_path.
@@ -389,7 +389,7 @@ modulemd_read_packager_file_ext (const gchar *yaml_path,
                                  GError **error);
 
 /**
- * modulemd_read_packager_string:
+ * modulemd_read_packager_string: (skip)
  * @yaml_string: (in): A YAML string containing a packager document.
  * @object: (out): (transfer full): A newly allocated #ModulemdModuleStreamV2 or
  * #ModulemdPackagerV3 object initialized with the content from @yaml_string.
@@ -408,7 +408,7 @@ modulemd_read_packager_string (const gchar *yaml_string,
                                GError **error);
 
 /**
- * modulemd_read_packager_string_ext:
+ * modulemd_read_packager_string_ext: (rename-to modulemd_read_packager_string)
  * @yaml_string: (in): A YAML string containing a packager document.
  * @object: (out): (transfer full): A newly allocated #ModulemdModuleStreamV2 or
  * #ModulemdPackagerV3 object initialized with the content from @yaml_string.

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -352,6 +352,7 @@ endforeach
 
 python_tests = {
 'buildopts'        : 'tests/ModulemdTests/buildopts.py',
+'common'           : 'tests/ModulemdTests/common.py',
 'componentrpm'     : 'tests/ModulemdTests/componentrpm.py',
 'defaults'         : 'tests/ModulemdTests/defaults.py',
 'defaultsv1'       : 'tests/ModulemdTests/defaultsv1.py',

--- a/modulemd/modulemd.c
+++ b/modulemd/modulemd.c
@@ -111,12 +111,25 @@ verify_load (gboolean ret,
 static GType
 modulemd_read_packager_from_parser (yaml_parser_t *parser,
                                     GObject **object,
+                                    const gchar *module_name,
+                                    const gchar *module_stream,
                                     GError **error);
 
 GType
 modulemd_read_packager_file (const gchar *yaml_path,
                              GObject **object,
                              GError **error)
+{
+  return modulemd_read_packager_file_ext (
+    yaml_path, object, NULL, NULL, error);
+}
+
+GType
+modulemd_read_packager_file_ext (const gchar *yaml_path,
+                                 GObject **object,
+                                 const gchar *module_name,
+                                 const gchar *module_stream,
+                                 GError **error)
 {
   MMD_INIT_YAML_PARSER (parser);
   g_autoptr (FILE) yaml_stream = NULL;
@@ -142,13 +155,25 @@ modulemd_read_packager_file (const gchar *yaml_path,
 
   yaml_parser_set_input_file (&parser, yaml_stream);
 
-  return modulemd_read_packager_from_parser (&parser, object, error);
+  return modulemd_read_packager_from_parser (
+    &parser, object, module_name, module_stream, error);
 }
 
 GType
 modulemd_read_packager_string (const gchar *yaml_string,
                                GObject **object,
                                GError **error)
+{
+  return modulemd_read_packager_string_ext (
+    yaml_string, object, NULL, NULL, error);
+}
+
+GType
+modulemd_read_packager_string_ext (const gchar *yaml_string,
+                                   GObject **object,
+                                   const gchar *module_name,
+                                   const gchar *module_stream,
+                                   GError **error)
 {
   MMD_INIT_YAML_PARSER (parser);
 
@@ -159,12 +184,15 @@ modulemd_read_packager_string (const gchar *yaml_string,
   yaml_parser_set_input_string (
     &parser, (const unsigned char *)yaml_string, strlen (yaml_string));
 
-  return modulemd_read_packager_from_parser (&parser, object, error);
+  return modulemd_read_packager_from_parser (
+    &parser, object, module_name, module_stream, error);
 }
 
 static GType
 modulemd_read_packager_from_parser (yaml_parser_t *parser,
                                     GObject **object,
+                                    const gchar *module_name,
+                                    const gchar *module_stream,
                                     GError **error)
 {
   MMD_INIT_YAML_EVENT (event);
@@ -252,6 +280,17 @@ modulemd_read_packager_from_parser (yaml_parser_t *parser,
               return G_TYPE_INVALID;
             }
 
+          if (module_name)
+            {
+              modulemd_packager_v3_set_module_name (packager_v3, module_name);
+            }
+
+          if (module_stream)
+            {
+              modulemd_packager_v3_set_stream_name (packager_v3,
+                                                    module_stream);
+            }
+
           return_object = (GObject *)g_steal_pointer (&packager_v3);
           return_type = MODULEMD_TYPE_PACKAGER_V3;
           break;
@@ -285,6 +324,18 @@ modulemd_read_packager_from_parser (yaml_parser_t *parser,
               return G_TYPE_INVALID;
             }
 
+          if (module_name)
+            {
+              modulemd_module_stream_set_module_name (
+                MODULEMD_MODULE_STREAM (stream_v2), module_name);
+            }
+
+          if (module_stream)
+            {
+              modulemd_module_stream_set_stream_name (
+                MODULEMD_MODULE_STREAM (stream_v2), module_stream);
+            }
+
           return_object = (GObject *)g_steal_pointer (&stream_v2);
           return_type = MODULEMD_TYPE_MODULE_STREAM_V2;
           break;
@@ -295,6 +346,18 @@ modulemd_read_packager_from_parser (yaml_parser_t *parser,
           if (!stream_v2)
             {
               return G_TYPE_INVALID;
+            }
+
+          if (module_name)
+            {
+              modulemd_module_stream_set_module_name (
+                MODULEMD_MODULE_STREAM (stream_v2), module_name);
+            }
+
+          if (module_stream)
+            {
+              modulemd_module_stream_set_stream_name (
+                MODULEMD_MODULE_STREAM (stream_v2), module_stream);
             }
 
           return_object = (GObject *)g_steal_pointer (&stream_v2);

--- a/modulemd/tests/ModulemdTests/common.py
+++ b/modulemd/tests/ModulemdTests/common.py
@@ -1,0 +1,221 @@
+import json
+import logging
+import os
+import sys
+
+try:
+    import unittest
+    import gi
+
+    gi.require_version("Modulemd", "2.0")
+    from gi.repository import GLib
+    from gi.repository import Modulemd
+except ImportError:
+    # Return error 77 to skip this test on platforms without the necessary
+    # python modules
+    sys.exit(77)
+
+from base import TestBase
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+class TestCommon(TestBase):
+    def test_packager_read_file(self):
+        # We have a chicken-egg problem with overrides, since they can only
+        # be tested if they are already installed. This means they need to
+        # be run in the CI. In order to avoid changes to these tests or the
+        # overrides breaking things, we'll skip them if the appropriate
+        # override is not installed.
+        if not (
+            "_overrides_module" in dir(Modulemd)
+            and hasattr(gi.overrides.Modulemd, "read_packager_file")
+        ):
+            logging.debug(
+                "read_packager_file() override not installed, skipping tests"
+            )
+            return
+
+        # Validate that the PackagerV2 specification parses correctly
+        doc = Modulemd.read_packager_file(
+            os.path.join(
+                self.source_root, "yaml_specs/modulemd_packager_v2.yaml"
+            ),
+        )
+        self.assertIsNotNone(doc)
+        # Once read in, a modulemd-packager v2 document is a ModuleStream of the
+        # same version.
+        self.assertIs(type(doc), Modulemd.ModuleStreamV2)
+        # Confirm module and stream names are undefined
+        self.assertIsNone(doc.get_module_name())
+        self.assertIsNone(doc.get_stream_name())
+
+        # Read the PackagerV2 specification with module/stream name overrides
+        doc = Modulemd.read_packager_file(
+            os.path.join(
+                self.source_root, "yaml_specs/modulemd_packager_v2.yaml"
+            ),
+            "modulename-override",
+            "streamname-override",
+        )
+        self.assertIsNotNone(doc)
+        self.assertIs(type(doc), Modulemd.ModuleStreamV2)
+        # Confirm module and stream names were set
+        self.assertEqual(doc.get_module_name(), "modulename-override")
+        self.assertEqual(doc.get_stream_name(), "streamname-override")
+
+        # Valid PackagerV3 file
+        doc = Modulemd.read_packager_file(
+            os.path.join(
+                self.source_root, "yaml_specs/modulemd_packager_v3.yaml"
+            ),
+        )
+        self.assertIsNotNone(doc)
+        self.assertIs(type(doc), Modulemd.PackagerV3)
+
+        # Read PackagerV3 with module/stream name overrides
+        doc = Modulemd.read_packager_file(
+            os.path.join(
+                self.source_root, "yaml_specs/modulemd_packager_v3.yaml"
+            ),
+            "modulename-override",
+            "streamname-override",
+        )
+        self.assertIsNotNone(doc)
+        self.assertIs(type(doc), Modulemd.PackagerV3)
+        # Confirm module and stream names were set
+        self.assertEqual(doc.get_module_name(), "modulename-override")
+        self.assertEqual(doc.get_stream_name(), "streamname-override")
+
+        # Validate that the ModuleStreamV2 specification parses correctly
+        doc = Modulemd.read_packager_file(
+            os.path.join(
+                self.source_root, "yaml_specs/modulemd_stream_v2.yaml"
+            ),
+        )
+        self.assertIsNotNone(doc)
+        self.assertIs(type(doc), Modulemd.ModuleStreamV2)
+        # Confirm module and stream names are correct
+        self.assertEqual(doc.get_module_name(), "foo")
+        self.assertEqual(doc.get_stream_name(), "latest")
+
+        # Read the ModuleStreamV2 specification with module/stream name overrides
+        doc = Modulemd.read_packager_file(
+            os.path.join(
+                self.source_root, "yaml_specs/modulemd_stream_v2.yaml"
+            ),
+            "modulename-override",
+            "streamname-override",
+        )
+        self.assertIsNotNone(doc)
+        self.assertIs(type(doc), Modulemd.ModuleStreamV2)
+        # Confirm module and stream names were set
+        self.assertEqual(doc.get_module_name(), "modulename-override")
+        self.assertEqual(doc.get_stream_name(), "streamname-override")
+
+    def test_packager_read_string(self):
+        # We have a chicken-egg problem with overrides, since they can only
+        # be tested if they are already installed. This means they need to
+        # be run in the CI. In order to avoid changes to these tests or the
+        # overrides breaking things, we'll skip them if the appropriate
+        # override is not installed.
+        if not (
+            "_overrides_module" in dir(Modulemd)
+            and hasattr(gi.overrides.Modulemd, "read_packager_string")
+        ):
+            logging.debug(
+                "read_packager_string() override not installed, skipping tests"
+            )
+            return
+
+        # PackagerV2
+        minimal_valid = """---
+document: modulemd-packager
+version: 2
+data:
+  summary: A minimal valid module
+  description: A minimalistic module description
+  license:
+    module:
+      - MIT
+...
+"""
+        doc = Modulemd.read_packager_string(minimal_valid)
+        self.assertIsNotNone(doc)
+        # Once read in, a modulemd-packager document is a ModuleStream of the
+        # same version.
+        self.assertIs(type(doc), Modulemd.ModuleStreamV2)
+        # Confirm module and stream names are undefined
+        self.assertIsNone(doc.get_module_name())
+        self.assertIsNone(doc.get_stream_name())
+
+        # Read again with module/stream name overrides
+        doc = Modulemd.read_packager_string(
+            minimal_valid, "modulename-override", "streamname-override",
+        )
+        self.assertIsNotNone(doc)
+        self.assertIs(type(doc), Modulemd.ModuleStreamV2)
+        # Confirm module and stream names were set
+        self.assertEqual(doc.get_module_name(), "modulename-override")
+        self.assertEqual(doc.get_stream_name(), "streamname-override")
+
+        # PackagerV3
+        minimal_valid = """---
+document: modulemd-packager
+version: 3
+data:
+  summary: A minimal valid module
+  description: A minimalistic module description
+  license:
+    - MIT
+...
+"""
+        doc = Modulemd.read_packager_string(minimal_valid)
+        self.assertIsNotNone(doc)
+        self.assertIs(type(doc), Modulemd.PackagerV3)
+        # Confirm module and stream names are undefined
+        self.assertIsNone(doc.get_module_name())
+        self.assertIsNone(doc.get_stream_name())
+
+        # Read again with module/stream name overrides
+        doc = Modulemd.read_packager_string(
+            minimal_valid, "modulename-override", "streamname-override",
+        )
+        self.assertIsNotNone(doc)
+        self.assertIs(type(doc), Modulemd.PackagerV3)
+        # Confirm module and stream names were set
+        self.assertEqual(doc.get_module_name(), "modulename-override")
+        self.assertEqual(doc.get_stream_name(), "streamname-override")
+
+        # ModuleStreamV2
+        minimal_valid = """---
+document: modulemd-stream
+version: 2
+data:
+  summary: A minimal valid module
+  description: A minimalistic module description
+  license:
+    module:
+      - MIT
+...
+"""
+        doc = Modulemd.read_packager_string(minimal_valid)
+        self.assertIsNotNone(doc)
+        self.assertIs(type(doc), Modulemd.ModuleStreamV2)
+        # Confirm module and stream names are undefined
+        self.assertIsNone(doc.get_module_name())
+        self.assertIsNone(doc.get_stream_name())
+
+        # Read again with module/stream name overrides
+        doc = Modulemd.read_packager_string(
+            minimal_valid, "modulename-override", "streamname-override",
+        )
+        self.assertIsNotNone(doc)
+        self.assertIs(type(doc), Modulemd.ModuleStreamV2)
+        # Confirm module and stream names were set
+        self.assertEqual(doc.get_module_name(), "modulename-override")
+        self.assertEqual(doc.get_stream_name(), "streamname-override")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modulemd/tests/test-modulemd-common.c
+++ b/modulemd/tests/test-modulemd-common.c
@@ -176,6 +176,28 @@ test_packager_read_file (void)
   g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
 
 
+  /* Valid packager v2 file with module/stream name overrides */
+  g_clear_error (&error);
+  g_clear_object (&object);
+  g_clear_pointer (&yaml_file, g_free);
+  yaml_file = g_strdup_printf ("%s/yaml_specs/modulemd_packager_v2.yaml",
+                               g_getenv ("MESON_SOURCE_ROOT"));
+  otype = modulemd_read_packager_file_ext (
+    yaml_file, &object, "modulename-override", "streamname-override", &error);
+  g_assert_no_error (error);
+  g_assert_true (otype == MODULEMD_TYPE_MODULE_STREAM_V2);
+  g_assert_nonnull (object);
+  g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
+  g_assert_cmpstr (
+    modulemd_module_stream_get_module_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "modulename-override");
+  g_assert_cmpstr (
+    modulemd_module_stream_get_stream_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "streamname-override");
+
+
   /* Valid packager v3 file */
   g_clear_error (&error);
   g_clear_object (&object);
@@ -187,6 +209,28 @@ test_packager_read_file (void)
   g_assert_true (otype == MODULEMD_TYPE_PACKAGER_V3);
   g_assert_nonnull (object);
   g_assert_true (MODULEMD_IS_PACKAGER_V3 (object));
+
+
+  /* Valid packager v3 file with module/stream name overrides */
+  g_clear_error (&error);
+  g_clear_object (&object);
+  g_clear_pointer (&yaml_file, g_free);
+  yaml_file = g_strdup_printf ("%s/yaml_specs/modulemd_packager_v3.yaml",
+                               g_getenv ("MESON_SOURCE_ROOT"));
+  otype = modulemd_read_packager_file_ext (
+    yaml_file, &object, "modulename-override", "streamname-override", &error);
+  g_assert_no_error (error);
+  g_assert_true (otype == MODULEMD_TYPE_PACKAGER_V3);
+  g_assert_nonnull (object);
+  g_assert_true (MODULEMD_IS_PACKAGER_V3 (object));
+  g_assert_cmpstr (
+    modulemd_packager_v3_get_module_name (MODULEMD_PACKAGER_V3 (object)),
+    ==,
+    "modulename-override");
+  g_assert_cmpstr (
+    modulemd_packager_v3_get_stream_name (MODULEMD_PACKAGER_V3 (object)),
+    ==,
+    "streamname-override");
 
 
   /* Valid stream v2 file */
@@ -202,6 +246,28 @@ test_packager_read_file (void)
   g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
 
 
+  /* Valid stream v2 file with module/stream name overrides */
+  g_clear_error (&error);
+  g_clear_object (&object);
+  g_clear_pointer (&yaml_file, g_free);
+  yaml_file = g_strdup_printf ("%s/yaml_specs/modulemd_stream_v2.yaml",
+                               g_getenv ("MESON_SOURCE_ROOT"));
+  otype = modulemd_read_packager_file_ext (
+    yaml_file, &object, "modulename-override", "streamname-override", &error);
+  g_assert_no_error (error);
+  g_assert_true (otype == MODULEMD_TYPE_MODULE_STREAM_V2);
+  g_assert_nonnull (object);
+  g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
+  g_assert_cmpstr (
+    modulemd_module_stream_get_module_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "modulename-override");
+  g_assert_cmpstr (
+    modulemd_module_stream_get_stream_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "streamname-override");
+
+
   /* Valid stream v1 file, should get upgraded to v2 */
   g_clear_error (&error);
   g_clear_object (&object);
@@ -213,6 +279,30 @@ test_packager_read_file (void)
   g_assert_true (otype == MODULEMD_TYPE_MODULE_STREAM_V2);
   g_assert_nonnull (object);
   g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
+
+
+  /* Valid stream v1 file, should get upgraded to v2,
+   * with module/stream name overrides
+   */
+  g_clear_error (&error);
+  g_clear_object (&object);
+  g_clear_pointer (&yaml_file, g_free);
+  yaml_file = g_strdup_printf ("%s/yaml_specs/modulemd_stream_v1.yaml",
+                               g_getenv ("MESON_SOURCE_ROOT"));
+  otype = modulemd_read_packager_file_ext (
+    yaml_file, &object, "modulename-override", "streamname-override", &error);
+  g_assert_no_error (error);
+  g_assert_true (otype == MODULEMD_TYPE_MODULE_STREAM_V2);
+  g_assert_nonnull (object);
+  g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
+  g_assert_cmpstr (
+    modulemd_module_stream_get_module_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "modulename-override");
+  g_assert_cmpstr (
+    modulemd_module_stream_get_stream_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "streamname-override");
 
 
   /* Nonexistent file */
@@ -295,7 +385,26 @@ test_packager_read_string (void)
   g_assert_true (otype == MODULEMD_TYPE_MODULE_STREAM_V2);
   g_assert_nonnull (object);
   g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
-
+  /* with module/stream name overrides */
+  g_clear_error (&error);
+  g_clear_object (&object);
+  otype = modulemd_read_packager_string_ext (yaml_string,
+                                             &object,
+                                             "modulename-override",
+                                             "streamname-override",
+                                             &error);
+  g_assert_no_error (error);
+  g_assert_true (otype == MODULEMD_TYPE_MODULE_STREAM_V2);
+  g_assert_nonnull (object);
+  g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
+  g_assert_cmpstr (
+    modulemd_module_stream_get_module_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "modulename-override");
+  g_assert_cmpstr (
+    modulemd_module_stream_get_stream_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "streamname-override");
 
   /* Trivial modulemd packager v3 */
   g_clear_error (&error);
@@ -317,6 +426,26 @@ test_packager_read_string (void)
   g_assert_true (otype == MODULEMD_TYPE_PACKAGER_V3);
   g_assert_nonnull (object);
   g_assert_true (MODULEMD_IS_PACKAGER_V3 (object));
+  /* with module/stream name overrides */
+  g_clear_error (&error);
+  g_clear_object (&object);
+  otype = modulemd_read_packager_string_ext (yaml_string,
+                                             &object,
+                                             "modulename-override",
+                                             "streamname-override",
+                                             &error);
+  g_assert_no_error (error);
+  g_assert_true (otype == MODULEMD_TYPE_PACKAGER_V3);
+  g_assert_nonnull (object);
+  g_assert_true (MODULEMD_IS_PACKAGER_V3 (object));
+  g_assert_cmpstr (
+    modulemd_packager_v3_get_module_name (MODULEMD_PACKAGER_V3 (object)),
+    ==,
+    "modulename-override");
+  g_assert_cmpstr (
+    modulemd_packager_v3_get_stream_name (MODULEMD_PACKAGER_V3 (object)),
+    ==,
+    "streamname-override");
 
   /* Trivial modulemd stream v2 */
   g_clear_error (&error);
@@ -339,6 +468,26 @@ test_packager_read_string (void)
   g_assert_true (otype == MODULEMD_TYPE_MODULE_STREAM_V2);
   g_assert_nonnull (object);
   g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
+  /* with module/stream name overrides */
+  g_clear_error (&error);
+  g_clear_object (&object);
+  otype = modulemd_read_packager_string_ext (yaml_string,
+                                             &object,
+                                             "modulename-override",
+                                             "streamname-override",
+                                             &error);
+  g_assert_no_error (error);
+  g_assert_true (otype == MODULEMD_TYPE_MODULE_STREAM_V2);
+  g_assert_nonnull (object);
+  g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
+  g_assert_cmpstr (
+    modulemd_module_stream_get_module_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "modulename-override");
+  g_assert_cmpstr (
+    modulemd_module_stream_get_stream_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "streamname-override");
 
   /* Trivial modulemd stream v1, should get upgraded to v2 */
   g_clear_error (&error);
@@ -361,6 +510,26 @@ test_packager_read_string (void)
   g_assert_true (otype == MODULEMD_TYPE_MODULE_STREAM_V2);
   g_assert_nonnull (object);
   g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
+  /* with module/stream name overrides */
+  g_clear_error (&error);
+  g_clear_object (&object);
+  otype = modulemd_read_packager_string_ext (yaml_string,
+                                             &object,
+                                             "modulename-override",
+                                             "streamname-override",
+                                             &error);
+  g_assert_no_error (error);
+  g_assert_true (otype == MODULEMD_TYPE_MODULE_STREAM_V2);
+  g_assert_nonnull (object);
+  g_assert_true (MODULEMD_IS_MODULE_STREAM_V2 (object));
+  g_assert_cmpstr (
+    modulemd_module_stream_get_module_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "modulename-override");
+  g_assert_cmpstr (
+    modulemd_module_stream_get_stream_name (MODULEMD_MODULE_STREAM (object)),
+    ==,
+    "streamname-override");
 
   /* NULL string should raise an exception */
   g_clear_error (&error);


### PR DESCRIPTION
This is the C implementation to address RFE #535 that adds new `modulemd_read_packager_file_ext()` and `modulemd_read_packager_string_ext()` API calls.

However, the Python implementation is still missing. I am sure it is possible to integrate this with the Python API so the current `Modulemd.read_packager_file()` and `Modulemd.read_packager_string()` methods automatically do the correct thing if extra module and stream name parameters are provided, but I have no idea how to get GObject to do that.