### PR TITLE
Add missing @staticmethod for python2

### DIFF
--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -28,6 +28,7 @@ __all__ = []
 
 
 class ModulemdUtil(object):
+    @staticmethod
     def strip_gtype(method):
         @functools.wraps(method)
         def wrapped(*args, **kwargs):


### PR DESCRIPTION
Fixes: https://github.com/fedora-modularity/libmodulemd/issues/537

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>