### PR TITLE
When adding obsoletes ensure index has stream mdversion at least 2

### DIFF
--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -1602,6 +1602,17 @@ modulemd_module_index_merge (ModulemdModuleIndex *from,
             }
         }
 
+      if (obsoletes_array->len > 0)
+        {
+          /* Obsoletes need at least MD_MODULESTREAM_VERSION_TWO */
+          if (!modulemd_module_index_upgrade_streams (
+                into, MD_MODULESTREAM_VERSION_TWO, &nested_error))
+            {
+              g_propagate_error (error, g_steal_pointer (&nested_error));
+              return FALSE;
+            }
+        }
+
       g_debug ("Prioritizer: all documents merged for %s", module_name);
       g_clear_pointer (&translations, g_ptr_array_unref);
     }


### PR DESCRIPTION
We were getting ready to finally merge the obsoletes part in libdnf and dnf but running the tests I have created before showed this issue with the new libmodulemd version.

When there is an index with just obsoletes it doesn't have a `stream_mdversion` and its not possible to add streams due to: https://github.com/fedora-modularity/libmodulemd/blob/main/modulemd/modulemd-module.c#L381

This is currently blocking us and if I understand correctly there is no workaround.