### PR TITLE
When adding obsoletes ensure index has stream mdversion at least 2

### DIFF
--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -1290,11 +1290,24 @@ modulemd_module_index_add_obsoletes (ModulemdModuleIndex *self,
   g_autoptr (GError) nested_error = NULL;
 
   g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
+  g_return_val_if_fail (MODULEMD_IS_OBSOLETES (obsoletes), FALSE);
 
   modulemd_module_add_obsoletes (
     get_or_create_module (self,
                           modulemd_obsoletes_get_module_name (obsoletes)),
     obsoletes);
+
+  /* Obsoletes need at least MD_MODULESTREAM_VERSION_TWO */
+  if (self->stream_mdversion < MD_MODULESTREAM_VERSION_TWO)
+    {
+      if (!modulemd_module_index_upgrade_streams (
+            self, MD_MODULESTREAM_VERSION_TWO, &nested_error))
+        {
+          g_propagate_error (error, g_steal_pointer (&nested_error));
+          return FALSE;
+        }
+    }
+
   return TRUE;
 }
 


### PR DESCRIPTION
Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

@kontura @j-mracek


This modifies #540 so that the check occurs when the Obsoletes data is added to the ModuleIndex, rather than waiting until a merge is attempted. I left your test unmodified to demonstrate that it still works to solve the same problem.