### PR TITLE
Build documentation with Github Actions

### DIFF
--- a/.ci/ci-docs.sh
+++ b/.ci/ci-docs.sh
@@ -8,6 +8,7 @@ source $SCRIPT_DIR/ci-common.inc
 set -e
 set -x
 
+modulemd_version=${1:-latest}
 os=fedora
 release=32
 repository=quay.io
@@ -22,8 +23,8 @@ mmd_run_docker_tests \
     test_template="docs/Dockerfile.tmpl" \
     test_image="libmodulemd-docs-$os:$release" \
     oci_extra_args="
-        -e GITHUB_SHA=$GITHUB_SHA
-        -e DOC_TOKEN='$DOC_TOKEN'
+        --env MODULEMD_VERSION=$modulemd_version
+        --volume=$GITHUB_WORKSPACE:/builddir
     "
 
-popd # $SCRIPT_DIR
+popd # $SCRIPT_DIR 

--- a/.ci/docs/ci-tasks.sh
+++ b/.ci/docs/ci-tasks.sh
@@ -26,26 +26,11 @@ pushd doc-generation/modulemd/html
 /builddir/contrib/doc-tools/fix-xref.sh
 popd
 
-$RETRY_CMD git clone https://sgallagher:$DOC_TOKEN@github.com/fedora-modularity/fedora-modularity.github.io
-rsync -avh --delete-before --no-perms --omit-dir-times /builddir/doc-generation/modulemd/html/* fedora-modularity.github.io/libmodulemd/latest
+MODULEMD_VERSION=${MODULEMD_VERSION:-latest}
 
-pushd fedora-modularity.github.io
-
-git add libmodulemd/latest
-
-# Check to see if there are any changes
-set +e
-git commit -m "Updating libmodulemd docs for $GITHUB_SHA" --dry-run
-err=$?
-if [ $err = 0 ]; then
-    set -e
-    git config user.name "Libmodulemd CI"
-    git config user.email "sgallagh@redhat.com"
-    git commit -m "Updating libmodulemd docs for $GITHUB_SHA"
-    $RETRY_CMD git push origin master
-fi
-set -e
-
-popd #fedora-modularity.github.io
+mkdir -p /builddir/fedora-modularity.github.io/libmodulemd/$MODULEMD_VERSION
+rsync -avh --delete-before --no-perms --omit-dir-times \
+    /builddir/doc-generation/modulemd/html/* \
+    /builddir/fedora-modularity.github.io/libmodulemd/$MODULEMD_VERSION
 
 popd #builddir

--- a/.github/workflows/upstreamed.yaml
+++ b/.github/workflows/upstreamed.yaml
@@ -7,6 +7,7 @@ jobs:
   static_analysis:
     name: Static Analysis
     runs-on: ubuntu-20.04
+    if: github.repository == 'fedora-modularity/libmodulemd'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -20,12 +21,34 @@ jobs:
   docs:
     name: Publish Documentation
     runs-on: ubuntu-20.04
+    continue-on-error: false
+    if: github.repository == 'fedora-modularity/libmodulemd'
     steps:
-      - name: Checkout code
+      - name: Checkout code repo
         uses: actions/checkout@v2
 
-      - name: Publish
-        env:
-          DOC_TOKEN: ${{ secrets.DOC_TOKEN }}
+      - name: Checkout documentation repo
+        uses: actions/checkout@v2
+        with:
+          repository: fedora-modularity/fedora-modularity.github.io
+          ref: main
+          path: fedora-modularity.github.io
+          token: ${{ secrets.DOC_TOKEN }}
+
+
+      - name: Generate documentation
         run: |
           ./.ci/ci-docs.sh
+
+      - name: Commit documentation
+        uses: EndBug/add-and-commit@v6
+        with:
+          branch: main
+          token: ${{ secrets.DOC_TOKEN }}
+          cwd: fedora-modularity.github.io
+          author_name: Libmodulemd CI
+          author_email: github-actions@github.com
+          message: Updating libmodulemd docs for ${{ github.sha }}
+          add: libmodulemd/latest
+          signoff: true
+          push: true


### PR DESCRIPTION
Also ensures that static analysis and documentation generation will
occur only on the main branch of the upstream repository.

I also modified the doc generation script so that in the future we can
add an "on-release" Action that will generate a snapshot of the API
docs automatically.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>