### PR TITLE
modulemd v2: Relax context up to 13 characters including underscore

### DIFF
--- a/modulemd/include/private/modulemd-module-stream-v2-private.h
+++ b/modulemd/include/private/modulemd-module-stream-v2-private.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "modulemd-module-stream.h"
 #include "modulemd-module-stream-v2.h"
 #include "modulemd-subdocument-info.h"
 #include <glib-object.h>
@@ -20,6 +21,17 @@
 
 
 G_BEGIN_DECLS
+
+
+/**
+ * MODULEMD_MODULE_STREAM_V2_MAXCONTEXTLEN:
+ *
+ * The ModuleStream v3 specification defines the maximum lenth of the context
+ * field. Just before building, the v3 format is converted to v2 format.  But
+ * if a scratch build was requested, an underscore with a decimal number (e.g.
+ * "_1") is appended to the v2 context. Allow up to 99 scratch builds here.
+ */
+#define MODULEMD_MODULE_STREAM_V2_MAXCONTEXTLEN (MMD_MAXCONTEXTLEN + 3)
 
 
 /**

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -271,6 +271,7 @@ c_tests = {
 'component_module'    : [ 'tests/test-modulemd-component-module.c' ],
 'component_rpm'       : [ 'tests/test-modulemd-component-rpm.c' ],
 'compression'         : [ 'tests/test-modulemd-compression.c' ],
+'context'             : [ 'tests/test-modulemd-context.c' ],
 'defaults'            : [ 'tests/test-modulemd-defaults.c' ],
 'defaultsv1'          : [ 'tests/test-modulemd-defaults-v1.c' ],
 'dependencies'        : [ 'tests/test-modulemd-dependencies.c' ],

--- a/modulemd/modulemd-module-stream-v2.c
+++ b/modulemd/modulemd-module-stream-v2.c
@@ -1237,7 +1237,7 @@ static gboolean
 modulemd_module_stream_v2_validate_context (const gchar *context,
                                             GError **error)
 {
-  /* must be string of up to MMD_MAXCONTEXTLEN [a-zA-Z0-9] */
+  /* must be string of up to MODULEMD_MODULE_STREAM_V2_MAXCONTEXTLEN [a-zA-Z0-9_] */
 
   if (context == NULL || *context == '\0')
     {
@@ -1246,25 +1246,25 @@ modulemd_module_stream_v2_validate_context (const gchar *context,
       return FALSE;
     }
 
-  if (strlen (context) > MMD_MAXCONTEXTLEN)
+  if (strlen (context) > MODULEMD_MODULE_STREAM_V2_MAXCONTEXTLEN)
     {
       g_set_error (error,
                    MODULEMD_ERROR,
                    MMD_ERROR_VALIDATE,
                    "Stream context '%s' exceeds maximum length (%d)",
                    context,
-                   MMD_MAXCONTEXTLEN);
+                   MODULEMD_MODULE_STREAM_V2_MAXCONTEXTLEN);
       return FALSE;
     }
 
   for (const gchar *i = context; *i != '\0'; i++)
     {
-      if (!g_ascii_isalnum (*i))
+      if (!g_ascii_isalnum (*i) && *i != '_')
         {
           g_set_error (error,
                        MODULEMD_ERROR,
                        MMD_ERROR_VALIDATE,
-                       "Non-alphanumeric character in stream context '%s'",
+                       "Stream context '%s' can only contain [a-zA-Z0-9_] characters",
                        context);
           return FALSE;
         }

--- a/modulemd/tests/test-modulemd-context.c
+++ b/modulemd/tests/test-modulemd-context.c
@@ -1,0 +1,225 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#include <locale.h>
+#include <glib.h>
+#include "modulemd.h"
+#include "config.h"
+
+static void
+test_modulemd_v3_context_valid (void)
+{
+  const gchar *yaml_string = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GObject) object = NULL;
+  GType type = G_TYPE_INVALID;
+
+  yaml_string =
+    "---\n"
+    "document: modulemd-packager\n"
+    "version: 3\n"
+    "data:\n"
+    "  name: trivialname\n"
+    "  stream: trivialstream\n"
+    "  summary: Trivial Summary\n"
+    "  description: >-\n"
+    "    Trivial Description\n"
+    "  license: [MIT]\n"
+    "  configurations:\n"
+    "    - context: a234567890\n"
+    "      platform: foo\n"
+    "...\n";
+  type = modulemd_read_packager_string (yaml_string, &object, &error);
+  g_assert_true (type == MODULEMD_TYPE_PACKAGER_V3);
+  g_assert_no_error (error);
+}
+
+
+static void
+test_modulemd_v3_context_overlong (void)
+{
+  const gchar *yaml_string = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GObject) object = NULL;
+  GType type = G_TYPE_INVALID;
+
+  yaml_string =
+    "---\n"
+    "document: modulemd-packager\n"
+    "version: 3\n"
+    "data:\n"
+    "  name: trivialname\n"
+    "  stream: trivialstream\n"
+    "  summary: Trivial Summary\n"
+    "  description: >-\n"
+    "    Trivial Description\n"
+    "  license: [MIT]\n"
+    "  configurations:\n"
+    "    - context: a2345678901\n"
+    "      platform: foo\n"
+    "...\n";
+  type = modulemd_read_packager_string (yaml_string, &object, &error);
+  g_assert_true (type == G_TYPE_INVALID);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
+}
+
+
+static void
+test_modulemd_v3_context_bad_underscore (void)
+{
+  const gchar *yaml_string = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GObject) object = NULL;
+  GType type = G_TYPE_INVALID;
+
+  yaml_string =
+    "---\n"
+    "document: modulemd-packager\n"
+    "version: 3\n"
+    "data:\n"
+    "  name: trivialname\n"
+    "  stream: trivialstream\n"
+    "  summary: Trivial Summary\n"
+    "  description: >-\n"
+    "    Trivial Description\n"
+    "  license: [MIT]\n"
+    "  configurations:\n"
+    "    - context: _\n"
+    "      platform: foo\n"
+    "...\n";
+  type = modulemd_read_packager_string (yaml_string, &object, &error);
+  g_assert_true (type == G_TYPE_INVALID);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
+}
+
+
+static void
+test_modulemd_v2_context_valid (void)
+{
+  const gchar *yaml_string = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GObject) object = NULL;
+  GType type = G_TYPE_INVALID;
+
+  yaml_string =
+    "---\n"
+    "document: modulemd\n"
+    "version: 2\n"
+    "data:\n"
+    "  name: trivialname\n"
+    "  stream: trivialstream\n"
+    "  summary: Trivial Summary\n"
+    "  description: >-\n"
+    "    Trivial Description\n"
+    "  license:\n"
+    "    module: [MIT]\n"
+    "  static_context: true\n"
+    "  context: a234567890_23\n"
+    "...\n";
+  type = modulemd_read_packager_string (yaml_string, &object, &error);
+  g_assert_true (type == MODULEMD_TYPE_MODULE_STREAM_V2);
+  g_assert_no_error (error);
+  /* Reading v2 document does not validate it; validating explictly */
+  g_assert_true (modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (object), &error));
+}
+
+
+static void
+test_modulemd_v2_context_overlong (void)
+{
+  const gchar *yaml_string = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GObject) object = NULL;
+  GType type = G_TYPE_INVALID;
+
+  yaml_string =
+    "---\n"
+    "document: modulemd\n"
+    "version: 2\n"
+    "data:\n"
+    "  name: trivialname\n"
+    "  stream: trivialstream\n"
+    "  summary: Trivial Summary\n"
+    "  description: >-\n"
+    "    Trivial Description\n"
+    "  license:\n"
+    "    module: [MIT]\n"
+    "  static_context: true\n"
+    "  context: a234567890_234\n"
+    "...\n";
+  type = modulemd_read_packager_string (yaml_string, &object, &error);
+  g_assert_true (type == G_TYPE_INVALID);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
+  if (type != G_TYPE_INVALID)
+    {
+      g_test_incomplete ("Reading v2 document does not validate it");
+      /* Validating explicitly */
+      g_assert_false (modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (object), &error));
+    }
+}
+
+
+static void
+test_modulemd_v2_context_bad_character (void)
+{
+  const gchar *yaml_string = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GObject) object = NULL;
+  GType type = G_TYPE_INVALID;
+
+  yaml_string =
+    "---\n"
+    "document: modulemd\n"
+    "version: 2\n"
+    "data:\n"
+    "  name: trivialname\n"
+    "  stream: trivialstream\n"
+    "  summary: Trivial Summary\n"
+    "  description: >-\n"
+    "    Trivial Description\n"
+    "  license:\n"
+    "    module: [MIT]\n"
+    "  static_context: true\n"
+    "  context: '-'\n"
+    "...\n";
+  type = modulemd_read_packager_string (yaml_string, &object, &error);
+  g_assert_true (type == G_TYPE_INVALID);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
+  if (type != G_TYPE_INVALID)
+    {
+      g_test_incomplete ("Reading v2 document does not validate it");
+      /* Validating explicitly */
+      g_assert_false (modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (object), &error));
+    }
+}
+
+
+int
+main (int argc, char *argv[])
+{
+  setlocale (LC_ALL, "");
+  g_test_init (&argc, &argv, NULL);
+  g_test_set_nonfatal_assertions ();
+  g_test_bug_base ("https://github.com/fedora-modularity/libmodulemd/issues/");
+  g_test_bug ("549");
+
+  g_test_add_func ("/modulemd/v3/context/valid", test_modulemd_v3_context_valid);
+  g_test_add_func ("/modulemd/v3/context/overlong", test_modulemd_v3_context_overlong);
+  g_test_add_func ("/modulemd/v3/context/bad_underscore", test_modulemd_v3_context_bad_underscore);
+
+  g_test_add_func ("/modulemd/v2/context/valid", test_modulemd_v2_context_valid);
+  g_test_add_func ("/modulemd/v2/context/overlong", test_modulemd_v2_context_overlong);
+  g_test_add_func ("/modulemd/v2/context/bad_character", test_modulemd_v2_context_bad_character);
+
+  return g_test_run ();
+}

--- a/yaml_specs/modulemd_stream_v2.yaml
+++ b/yaml_specs/modulemd_stream_v2.yaml
@@ -88,7 +88,7 @@ data:
     #   Mandatory for module metadata in a yum/dnf repository.
     #
     # If 'static_context' is set to True:
-    #   The context flag is a string of up to ten [a-zA-Z0-9] characters
+    #   The context flag is a string of up to thirteen [a-zA-Z0-9_] characters
     #   representing a build and runtime configuration for this stream. This
     #   string is arbitrary but must be unique in this module stream.
     #


### PR DESCRIPTION
cb507415b158b79df44d9b11ca69642c2c546f0b (Add BuildConfig object)
commit broke scratch builds:

$ rhpkg module-scratch-build --file perl-YAML.yaml --buildrequires platform:el8.5.0
Submitting the module build...
Could not execute module_scratch_build: The build failed with:
modulemd-error-quark: Could not validate stream to emit: Non-alphanumeric character in stream context 'a6d43775_1' (1)

The reason is that a scratch build automatically adds an underscore
suffix (e.g.  "_1)" to the context value.

This patch fixes it by allowing the underscore character and
prolonging a limit of 10 characters with 3 additional characters (i.e.
up to 99 scratch builds). We keep v3 context strict as it was (no
underscore, 10 characters) to prevent packagers from specifying
a context in v3 which could not be scratch-built later.
A specification was amended accordingly.

This dichotomy is dictated by the fact that v3 is an input-only
format, while v2 is both input and output format for MBS.

The implemented tests discovered that reading v2 document with
a static context does not perform a validation in contrast to reading
a v3 document. This patch does not change it. It instead marks the
affected tests as TODO and test an explicit validation in addition.

<https://github.com/fedora-modularity/libmodulemd/issues/549>