### PR TITLE
tests: Do not use g_test_incomplete() broken in old glib

### DIFF
--- a/modulemd/tests/test-modulemd-context.c
+++ b/modulemd/tests/test-modulemd-context.c
@@ -159,15 +159,11 @@ test_modulemd_v2_context_overlong (void)
     "  context: a234567890_234\n"
     "...\n";
   type = modulemd_read_packager_string (yaml_string, &object, &error);
-  g_assert_true (type == G_TYPE_INVALID);
-  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
-  if (type != G_TYPE_INVALID)
-    {
-      g_test_incomplete ("Reading v2 document does not validate it");
-      /* Validating explicitly */
-      g_assert_false (modulemd_module_stream_validate (
-        MODULEMD_MODULE_STREAM (object), &error));
-    }
+  g_assert_true (type == MODULEMD_TYPE_MODULE_STREAM_V2);
+  g_assert_no_error (error);
+  /* Reading v2 document does not validate it; validating explictly */
+  g_assert_false (
+    modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (object), &error));
 }
 
 
@@ -195,15 +191,11 @@ test_modulemd_v2_context_bad_character (void)
     "  context: '-'\n"
     "...\n";
   type = modulemd_read_packager_string (yaml_string, &object, &error);
-  g_assert_true (type == G_TYPE_INVALID);
-  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
-  if (type != G_TYPE_INVALID)
-    {
-      g_test_incomplete ("Reading v2 document does not validate it");
-      /* Validating explicitly */
-      g_assert_false (modulemd_module_stream_validate (
-        MODULEMD_MODULE_STREAM (object), &error));
-    }
+  g_assert_true (type == MODULEMD_TYPE_MODULE_STREAM_V2);
+  g_assert_no_error (error);
+  /* Reading v2 document does not validate it; validating explictly */
+  g_assert_false (
+    modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (object), &error));
 }
 
 


### PR DESCRIPTION
The context validation tests dealt with v2 format not being valided
implicitly by marking the tests as expected to fail.

But g_test_incomplete() seems to be broken in glib2-2.56.4. It will
return a failure exit code if a test expected to fail indeed fails.
This is not how 2.68.1 behaves.

This patch accommodates to both behaviours by not using
the broken g_test_incomplete() at all.

Related to
<https://github.com/fedora-modularity/libmodulemd/issues/549>.

This fixes running the tests on RHEL 8.