### PR TITLE
validator: Handle a failed g_setenv()

### DIFF
--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -76,7 +76,14 @@ set_verbosity (const gchar *option_name,
             {
               debugging_env = g_strdup (G_LOG_DOMAIN);
             }
-          g_setenv ("G_MESSAGES_DEBUG", debugging_env, TRUE);
+          if (!g_setenv ("G_MESSAGES_DEBUG", debugging_env, TRUE))
+            {
+              g_set_error (error,
+                           G_OPTION_ERROR,
+                           G_OPTION_ERROR_FAILED,
+                           "Could not set G_MESSAGES_DEBUG environment variable");
+              return FALSE;
+            }
         }
     }
   else if (g_strcmp0 ("-q", option_name) == 0 ||


### PR DESCRIPTION
g_setenv() can fail and then --debug option would lost its effect.
This patch raises an error in that case.

CID 370512