### PR TITLE
tests: Correct Arch Linux image address

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,7 +244,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: docker.io/archlinux/base
+      image: docker.io/library/archlinux:base
 
     steps:
       - name: Install dependencies

--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -78,10 +78,11 @@ set_verbosity (const gchar *option_name,
             }
           if (!g_setenv ("G_MESSAGES_DEBUG", debugging_env, TRUE))
             {
-              g_set_error (error,
-                           G_OPTION_ERROR,
-                           G_OPTION_ERROR_FAILED,
-                           "Could not set G_MESSAGES_DEBUG environment variable");
+              g_set_error (
+                error,
+                G_OPTION_ERROR,
+                G_OPTION_ERROR_FAILED,
+                "Could not set G_MESSAGES_DEBUG environment variable");
               return FALSE;
             }
         }


### PR DESCRIPTION
The old one failed with:

    Error response from daemon: pull access denied for archlinux/base,
    repository does not exist or may require 'docker login': denied:
    requested access to the resource is denied

<https://wiki.archlinux.org/title/Install_Arch_Linux_via_Docker>
refers to <https://hub.docker.com/_/archlinux?tab=tags> which
recommends "docker pull archlinux:base" command.

According to <https://docs.docker.com/registry/introduction/>,
unqualified name translates to docker.io/library.