### PR TITLE
modulemd_subdocument_info_debug_dump_failures: Prevent from possible NULL-pointer dereferences

### DIFF
--- a/modulemd/modulemd-subdocument-info.c
+++ b/modulemd/modulemd-subdocument-info.c
@@ -367,7 +367,8 @@ modulemd_subdocument_info_debug_dump_failures (GPtrArray *failures)
 
           if (yaml)
             {
-              g_debug ("Failed subdocument #%u (%s):\n%s", i + 1, message, yaml);
+              g_debug (
+                "Failed subdocument #%u (%s):\n%s", i + 1, message, yaml);
             }
           else
             {

--- a/modulemd/modulemd-subdocument-info.c
+++ b/modulemd/modulemd-subdocument-info.c
@@ -329,17 +329,50 @@ modulemd_subdocument_info_init (ModulemdSubdocumentInfo *self)
 void
 modulemd_subdocument_info_debug_dump_failures (GPtrArray *failures)
 {
-  ModulemdSubdocumentInfo *doc = NULL;
-
   if (failures && failures->len)
     {
-      g_debug ("%u YAML subdocuments were invalid", failures->len);
-      for (gsize i = 0; i < failures->len; i++)
+      if (failures->len == 1)
         {
+          g_debug ("%u YAML subdocument was invalid:", failures->len);
+        }
+      else
+        {
+          g_debug ("%u YAML subdocuments were invalid:", failures->len);
+        }
+      for (guint i = 0; i < failures->len; i++)
+        {
+          ModulemdSubdocumentInfo *doc = NULL;
+          const GError *error = NULL;
+          const gchar *message = NULL;
+          const gchar *yaml = NULL;
+
           doc = MODULEMD_SUBDOCUMENT_INFO (g_ptr_array_index (failures, i));
-          g_debug ("\nFailed subdocument (%s): \n%s\n",
-                   modulemd_subdocument_info_get_gerror (doc)->message,
-                   modulemd_subdocument_info_get_yaml (doc));
+          if (doc)
+            {
+              error = modulemd_subdocument_info_get_gerror (doc);
+              if (error && error->message)
+                {
+                  message = error->message;
+                }
+              else
+                {
+                  message = "unknown reason";
+                }
+              yaml = modulemd_subdocument_info_get_yaml (doc);
+            }
+          else
+            {
+              message = "undefined document";
+            }
+
+          if (yaml)
+            {
+              g_debug ("Failed subdocument #%u (%s):\n%s", i + 1, message, yaml);
+            }
+          else
+            {
+              g_debug ("Failed subdocument #%u (%s).", i + 1, message);
+            }
         }
     }
 }


### PR DESCRIPTION
A static analyzer reported that
modulemd_subdocument_info_get_gerror(doc) can return NULL leading to
a NULL-pointer derefence in a private
modulemd_subdocument_info_debug_dump_failures() function:

~~~
             doc = MODULEMD_SUBDOCUMENT_INFO (g_ptr_array_index (failures, i));
             g_debug ("\nFailed subdocument (%s): \n%s\n",
->                    modulemd_subdocument_info_get_gerror (doc)->message,
                      modulemd_subdocument_info_get_yaml (doc));
           }
~~~

That function is called mostly from tests and once from an in-library
private verify_load() which is called at two other places where the
array is computed by modulemd_module_index_update_from_*() calls and
the ramifications continue.

In general modulemd_subdocument_info_debug_dump_failures() accepts an
arbitrary array of ModulemdSubdocumentInfo objects. If not properly
constructed by other internal functions, the array could contain items
equaled to a NULL pointer or the attributes of the objects could be
NULL. That's because a private API for the object allows setting the
attributes to NULL. E.g. modulemd_yaml_parse_document_type() skips
setting error if no error was encountered.

I believe that the analyzer is unable to prove that that the error
attribute is never NULL.

Thus this patch take a defensive approach and prevents from the
possible NULL-pointer dereferences by handling all NULL values at
array and object level.

The patch also improves the debug messages (singular form, end of
lines). The non-NULL code path is already covered by module_index
test.