### PR TITLE
Demodularization

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@
 project(
   'modulemd',
   'c',
-version : '2.12.2',
+version : '2.13.0',
 default_options : ['buildtype=debugoptimized', 'c_std=c11', 'warning_level=1', 'b_asneeded=true'],
 license : 'MIT',
 meson_version : '>=0.47.0'

--- a/modulemd/include/modulemd-2.0/modulemd-module-stream-v2.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-stream-v2.h
@@ -764,6 +764,61 @@ modulemd_module_stream_v2_get_rpm_filters_as_strv (
 
 
 /**
+ * modulemd_module_stream_v2_add_demodularized_rpm:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @rpm: (in): A name of a binary RPM package to become non-modular.
+ *
+ * Add a binary package name to a list of demodularized packages.
+ *
+ * Since: 2.13
+ */
+void
+modulemd_module_stream_v2_add_demodularized_rpm (ModulemdModuleStreamV2 *self,
+                                                 const gchar *rpm);
+
+
+/**
+ * modulemd_module_stream_v2_remove_demodularized_rpm:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @rpm: (in): A binary RPM name to remove from a demodularized list.
+ *
+ * Remove a binary package name from a list of demodularized packages.
+ *
+ * Since: 2.13
+ */
+void
+modulemd_module_stream_v2_remove_demodularized_rpm (
+  ModulemdModuleStreamV2 *self, const gchar *rpm);
+
+
+/**
+ * modulemd_module_stream_v2_clear_demodularized_rpms:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Remove all RPM packages from a demodularized list of the object.
+ *
+ * Since: 2.13
+ */
+void
+modulemd_module_stream_v2_clear_demodularized_rpms (
+  ModulemdModuleStreamV2 *self);
+
+
+/**
+ * modulemd_module_stream_v2_get_demodularized_rpms:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Returns: (transfer full): An ordered #GStrv list of binary RPM package names
+ * that became non-modular.
+ *
+ * Since: 2.13
+ */
+GStrv
+modulemd_module_stream_v2_get_demodularized_rpms (
+  ModulemdModuleStreamV2 *self);
+
+
+/**
  * modulemd_module_stream_v2_add_servicelevel:
  * @self: (in): This #ModulemdModuleStreamV2 object.
  * @servicelevel: (in) (transfer none): A #ModulemdServiceLevel for this module stream.

--- a/modulemd/include/modulemd-2.0/modulemd-packager-v3.h
+++ b/modulemd/include/modulemd-2.0/modulemd-packager-v3.h
@@ -611,6 +611,74 @@ modulemd_packager_v3_replace_rpm_filters (ModulemdPackagerV3 *self,
 
 
 /**
+ * modulemd_packager_v3_add_demodularized_rpm:
+ * @self: (in): This #ModulemdPackagerV3 object.
+ * @rpm: (in): A name of a binary RPM package to become non-modular.
+ *
+ * Add a binary package name to a list of demodularized packages.
+ *
+ * Since: 2.13
+ */
+void
+modulemd_packager_v3_add_demodularized_rpm (ModulemdPackagerV3 *self,
+                                            const gchar *rpm);
+
+
+/**
+ * modulemd_packager_v3_remove_demodularized_rpm:
+ * @self: (in): This #ModulemdPackagerV3 object.
+ * @rpm: (in): A binary RPM package name to remove from a demodularized list.
+ *
+ * Remove a binary package name from a list of demodularized packages.
+ *
+ * Since: 2.13
+ */
+void
+modulemd_packager_v3_remove_demodularized_rpm (ModulemdPackagerV3 *self,
+                                               const gchar *rpm);
+
+
+/**
+ * modulemd_packager_v3_clear_demodularized_rpms:
+ * @self: (in): This #ModulemdPackagerV3 object.
+ *
+ * Remove all RPM packages from a demodularized list of the object.
+ *
+ * Since: 2.13
+ */
+void
+modulemd_packager_v3_clear_demodularized_rpms (ModulemdPackagerV3 *self);
+
+
+/**
+ * modulemd_packager_v3_get_demodularized_rpms:
+ * @self: (in): This #ModulemdPackagerV3 object.
+ *
+ * Returns: (transfer full): An ordered #GStrv list of binary RPM package names
+ * that became non-modular.
+ *
+ * Since: 2.13
+ */
+GStrv
+modulemd_packager_v3_get_demodularized_rpms (ModulemdPackagerV3 *self);
+
+
+/**
+ * modulemd_packager_v3_replace_demodularized_rpms:
+ * @self: (in): This #ModulemdPackagerV3 object.
+ * @set: (in): A #GHashTable set of names of binary RPM packages to demodularize.
+ *
+ * Any existing demodularized binary RPM package names associated with module
+ * stream @self are removed and replaced by @set.
+ *
+ * Since: 2.13
+ */
+void
+modulemd_packager_v3_replace_demodularized_rpms (ModulemdPackagerV3 *self,
+                                                 GHashTable *set);
+
+
+/**
  * modulemd_packager_v3_add_component:
  * @self: (in): This #ModulemdPackagerV3 object.
  * @component: (in) (transfer none): A #ModulemdComponent to be added to this

--- a/modulemd/include/private/modulemd-module-stream-v2-private.h
+++ b/modulemd/include/private/modulemd-module-stream-v2-private.h
@@ -73,6 +73,8 @@ struct _ModulemdModuleStreamV2
 
   GHashTable *rpm_filters; /* string set */
 
+  GHashTable *demodularized_rpms; /* string set */
+
   GHashTable *servicelevels; /* <string, Modulemd.ServiceLevel */
 
   GPtrArray *dependencies; /* <Modulemd.Dependencies> */
@@ -201,6 +203,20 @@ modulemd_module_stream_v2_replace_rpm_artifacts (ModulemdModuleStreamV2 *self,
 void
 modulemd_module_stream_v2_replace_rpm_filters (ModulemdModuleStreamV2 *self,
                                                GHashTable *set);
+
+/**
+ * modulemd_module_stream_v2_replace_demodularized_rpms:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ * @set: (in): A #GHashTable set of names of binary RPM packages to demodularize.
+ *
+ * Any existing demodularized binary RPM package names associated with module
+ * stream @self are removed and replaced by @set.
+ *
+ * Since: 2.13
+ */
+void
+modulemd_module_stream_v2_replace_demodularized_rpms (
+  ModulemdModuleStreamV2 *self, GHashTable *set);
 
 /**
  * modulemd_module_stream_v2_replace_dependencies:

--- a/modulemd/tests/ModulemdTests/modulestream.py
+++ b/modulemd/tests/ModulemdTests/modulestream.py
@@ -495,6 +495,25 @@ class TestModuleStream(TestBase):
             stream.clear_rpm_filters()
             assert len(stream.get_rpm_filters()) == 0
 
+    def test_demodularized_rpms(self):
+        for version in modulestream_versions:
+            stream = Modulemd.ModuleStream.new(version)
+            # demodularized_rpms are supported since v2
+            if version < Modulemd.ModuleStreamVersionEnum.TWO:
+                continue
+            stream.add_demodularized_rpm("foo")
+            stream.add_demodularized_rpm("bar")
+            assert "foo" in stream.get_demodularized_rpms()
+            assert "bar" in stream.get_demodularized_rpms()
+            assert len(stream.get_demodularized_rpms()) == 2
+
+            stream.remove_demodularized_rpm("bar")
+            assert "foo" in stream.get_demodularized_rpms()
+            assert len(stream.get_demodularized_rpms()) == 1
+
+            stream.clear_demodularized_rpms()
+            assert len(stream.get_demodularized_rpms()) == 0
+
     def test_servicelevels(self):
         for version in modulestream_versions:
             # servicelevels are not supported after v2
@@ -690,6 +709,10 @@ data:
   filter:
     rpms: rpm_c
 
+  demodularized:
+    rpms:
+      - rpm_d
+
   artifacts:
     rpms:
       - bar-0:1.23-1.module_deadbeef.x86_64
@@ -823,6 +846,8 @@ data:
         assert "rpm_b" in stream.get_rpm_api()
 
         assert "rpm_c" in stream.get_rpm_filters()
+
+        assert "rpm_d" in stream.get_demodularized_rpms()
 
         assert (
             "bar-0:1.23-1.module_deadbeef.x86_64" in stream.get_rpm_artifacts()

--- a/modulemd/tests/test-modulemd-packager-v3.c
+++ b/modulemd/tests/test-modulemd-packager-v3.c
@@ -76,6 +76,11 @@ packager_test_construct (void)
   g_assert_null (list[0]);
   g_clear_pointer (&list, g_strfreev);
 
+  list = modulemd_packager_v3_get_demodularized_rpms (packager);
+  g_assert_nonnull (list);
+  g_assert_null (list[0]);
+  g_clear_pointer (&list, g_strfreev);
+
 
   list = modulemd_packager_v3_get_rpm_component_names_as_strv (packager);
   g_assert_nonnull (list);
@@ -262,6 +267,13 @@ validate_spec (ModulemdPackagerV3 *packager)
   g_assert_null (strv[1]);
   g_clear_pointer (&strv, g_strfreev);
 
+  strv = modulemd_packager_v3_get_demodularized_rpms (packager);
+  g_assert_nonnull (strv);
+  g_assert_nonnull (strv[0]);
+  g_assert_cmpstr ("bar-old", ==, strv[0]);
+  g_assert_null (strv[1]);
+  g_clear_pointer (&strv, g_strfreev);
+
   strv = modulemd_packager_v3_get_rpm_component_names_as_strv (packager);
   g_assert_nonnull (strv);
   g_assert_nonnull (strv[0]);
@@ -369,6 +381,9 @@ validate_yaml (ModulemdPackagerV3 *packager)
     "  filter:\n"
     "    rpms:\n"
     "    - baz-nonfoo\n"
+    "  demodularized:\n"
+    "    rpms:\n"
+    "    - bar-old\n"
     "  components:\n"
     "    rpms:\n"
     "      bar:\n"

--- a/modulemd/tests/test_data/good-v2-extra-keys.yaml
+++ b/modulemd/tests/test_data/good-v2-extra-keys.yaml
@@ -178,6 +178,19 @@ data:
         unknown_sequence:
         - foo
         - bar
+    demodularized:
+        rpms:
+            - bar-old
+
+        unknown_key: foo
+        unknown_map:
+            stuff: [ a, b ]
+            junk: [ b, c ]
+            morestuff:
+                yay: [ d, e ]
+        unknown_sequence:
+        - foo
+        - bar
 
     buildopts:
         rpms:

--- a/modulemd/tests/test_data/upgrades/packager_v3_to_index.yaml
+++ b/modulemd/tests/test_data/upgrades/packager_v3_to_index.yaml
@@ -58,6 +58,9 @@ data:
   filter:
     rpms:
     - baz-nonfoo
+  demodularized:
+    rpms:
+    - bar-old
   buildopts:
     rpms:
       macros: >
@@ -144,6 +147,9 @@ data:
   filter:
     rpms:
     - baz-nonfoo
+  demodularized:
+    rpms:
+    - bar-old
   components:
     rpms:
       bar:

--- a/modulemd/tests/test_data/upgrades/packager_v3_to_stream_v2.yaml
+++ b/modulemd/tests/test_data/upgrades/packager_v3_to_stream_v2.yaml
@@ -61,6 +61,9 @@ data:
   filter:
     rpms:
     - baz-nonfoo
+  demodularized:
+    rpms:
+    - bar-old
   buildopts:
     rpms:
       macros: >

--- a/yaml_specs/modulemd_packager_v2.yaml
+++ b/yaml_specs/modulemd_packager_v2.yaml
@@ -275,6 +275,26 @@ data:
         rpms:
             - baz-nonfoo
 
+    # demodularized:
+    # Artifacts which became non-modular
+    # Defaults to no demodularization.
+    # Type: OPTIONAL
+    demodularized:
+        # rpms:
+        # A list of binary RPM package names which where removed from
+        # a module. This list explains to a package mananger that the packages
+        # are not part of the module anymore and up-to-now same-named masked
+        # non-modular packages should become available again. This enables
+        # moving a package from a module to a set of non-modular packages. The
+        # exact implementation of the demodularization (e.g. whether it
+        # applies to all modules or only to this stream) is defined by the
+        # package manager.
+        # Defaults to an empty list.
+        #
+        # Type: OPTIONAL
+        rpms:
+            - bar-old
+
     # components:
     # Functional components of the module
     #

--- a/yaml_specs/modulemd_packager_v3.yaml
+++ b/yaml_specs/modulemd_packager_v3.yaml
@@ -335,6 +335,26 @@ data:
         rpms:
             - baz-nonfoo
 
+    # demodularized:
+    # Artifacts which became non-modular
+    # Defaults to no demodularization.
+    # Type: OPTIONAL
+    demodularized:
+        # rpms:
+        # A list of binary RPM package names which where removed from
+        # a module. This list explains to a package mananger that the packages
+        # are not part of the module anymore and up-to-now same-named masked
+        # non-modular packages should become available again. This enables
+        # moving a package from a module to a set of non-modular packages. The
+        # exact implementation of the demodularization (e.g. whether it
+        # applies to all modules or only to this stream) is defined by the
+        # package manager.
+        # Defaults to an empty list.
+        #
+        # Type: OPTIONAL
+        rpms:
+            - bar-old
+
     # components:
     # Functional components of the module
     #

--- a/yaml_specs/modulemd_stream_v2.yaml
+++ b/yaml_specs/modulemd_stream_v2.yaml
@@ -385,6 +385,26 @@ data:
         rpms:
             - baz-nonfoo
 
+    # demodularized:
+    # Artifacts which became non-modular
+    # Defaults to no demodularization.
+    # Type: OPTIONAL
+    demodularized:
+        # rpms:
+        # A list of binary RPM package names which where removed from
+        # a module. This list explains to a package mananger that the packages
+        # are not part of the module anymore and up-to-now same-named masked
+        # non-modular packages should become available again. This enables
+        # moving a package from a module to a set of non-modular packages. The
+        # exact implementation of the demodularization (e.g. whether it
+        # applies to all modules or only to this stream) is defined by the
+        # package manager.
+        # Defaults to an empty list.
+        #
+        # Type: OPTIONAL
+        rpms:
+            - bar-old
+
     # buildopts:
     # Component build options
     # Additional per component type module-wide build options.


### PR DESCRIPTION
    A motivation is to enable a demodularization of the packages.
    
    Previously if a package was part of a module stream and later the
    package was removed, DNF still did not allow installing a same-named
    non-modular package.  The reason is that DNF considers all artifacts
    from all module version.  Hence simply removing the package from
    a newer module version did not exempt the package from a modular DNF
    filtering.
    
    There were two options: Either only consider artifacts of the latest
    module version, or have an explicit list of removed artifacts in the
    module metadata. DNF authors requested the explicit list.
    
    Hence this change amends v2 and v3 modulemd-packager formats and v2
    modulemd format with the explicit list. The list does not affect
    building a module in any way. It only affects a package manager
    whether to mask or not to mask non-modular packages ("modular
    filtering" in DNF language).
    
    The list consists of exact RPM package names. I.e. no NEVR strings.
    Just package names.
    
    Current DNF plans for interpeting the list:
    
    DNF will use the list for preventing the listed, non-modular packages
    from being masked. DNF will only use a list from the latest module
    version. This allows module maintainers to get a package back into
    a module by removing the package name from the list and rebuilding the
    module.
    
    DNF will apply the list to all available modules. Not only to packages
    of that stream which delivers the list. That means a module will be
    able to demodularize packages of other modules.
