### PR TITLE
Allow disabling Python 3

### DIFF
--- a/bindings/python/meson.build
+++ b/bindings/python/meson.build
@@ -2,17 +2,19 @@ gobject_overrides_dir_py3 = get_option('gobject_overrides_dir_py3')
 gobject_overrides_dir_py2 = get_option('gobject_overrides_dir_py2')
 
 # Python 3
-if gobject_overrides_dir_py3 == ''
-  ret = run_command([python3, '-c', 'import gi; print(gi._overridesdir)'])
+if with_py3
+  if gobject_overrides_dir_py3 == ''
+    ret = run_command([python3, '-c', 'import gi; print(gi._overridesdir)'])
 
-  if ret.returncode() != 0
-    error('Failed to determine Python 3 pygobject overridedir')
-  else
-    gobject_overrides_dir_py3 = ret.stdout().strip()
+    if ret.returncode() != 0
+      error('Failed to determine Python 3 pygobject overridedir')
+    else
+      gobject_overrides_dir_py3 = ret.stdout().strip()
+    endif
   endif
-endif
 
-install_data('gi/overrides/Modulemd.py', install_dir: gobject_overrides_dir_py3)
+  install_data('gi/overrides/Modulemd.py', install_dir: gobject_overrides_dir_py3)
+endif
 
 # Python 2
 if with_py2

--- a/meson.build
+++ b/meson.build
@@ -105,14 +105,19 @@ has_extend_and_steal = cc.has_function(
     'g_ptr_array_extend_and_steal',
     dependencies : [ glib ])
 
-python_name = get_option('python_name')
+with_py3 = get_option('with_py3')
+if with_py3
+    python_name = get_option('python_name')
 
-if python_name != ''
-    # If we've been instructed to use a specific python version
-    python3 = pymod.find_installation(python_name)
+    if python_name != ''
+        # If we've been instructed to use a specific python version
+        python3 = pymod.find_installation(python_name)
+    else
+        # Use the python installation that is running meson
+        python3 = pymod.find_installation()
+    endif
 else
-    # Use the python installation that is running meson
-    python3 = pymod.find_installation()
+    python3 = disabler()
 endif
 
 with_py2 = get_option('with_py2')
@@ -193,7 +198,7 @@ if meson.version().version_compare('>=0.53')
              'libdir': get_option('libdir'),
              'datadir': get_option('datadir'),
              'Python 2 GObject Overrides': gobject_overrides_dir_py2,
-             'Python 3 GObject Overrides': gobject_overrides_dir_py3
+             'Python 3 GObject Overrides': gobject_overrides_dir_py3,
             }, section: 'Directories')
 
     summary({'libmagic Support': magic_status,
@@ -202,6 +207,7 @@ if meson.version().version_compare('>=0.53')
              'Generate Manpages': manpages_status,
              'Generate HTML Documentation': get_option('with_docs'),
              'Python 2 Support': get_option('with_py2'),
+             'Python 3 Support': get_option('with_py3'),
              'Skip Introspection': get_option('skip_introspection'),
              'Test Installed Library': get_option('test_installed_lib'),
             }, section: 'Build Configuration')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -38,6 +38,9 @@ option('with_manpages', type : 'feature', value : 'auto',
 option('with_py2', type : 'boolean', value : false,
        description : 'Build Python 2 language bindings and run Python 2 tests.')
 
+option('with_py3', type : 'boolean', value : true,
+       description : 'Build Python 3 language bindings and run Python 3 tests.')
+
 option('gobject_overrides_dir_py2', type : 'string',
        description : 'Path to Python 2 PyGObject overrides directory. Leave empty to determine it automatically.')
 


### PR DESCRIPTION
RHEL 7 does not have a Python3 binding for GObject. It's only in EPEL.