### PR TITLE
Python support requires GIR support

### DIFF
--- a/.ci/fedora/ci-tasks.sh
+++ b/.ci/fedora/ci-tasks.sh
@@ -55,6 +55,7 @@ else
     set -e
     meson --buildtype=debug \
           -Dskip_introspection=true \
+          -Dwith_py3=false \
           ci_scanbuild
 
     pushd ci_scanbuild

--- a/.ci/mageia/ci-tasks.sh
+++ b/.ci/mageia/ci-tasks.sh
@@ -41,6 +41,7 @@ else
     set -e
     meson --buildtype=debug \
           -Dskip_introspection=true \
+          -Dwith_py3=false \
           $COMMON_MESON_ARGS \
           ci_scanbuild
 

--- a/.ci/openmandriva/ci-tasks.sh
+++ b/.ci/openmandriva/ci-tasks.sh
@@ -45,6 +45,7 @@ else
     set -e
 CC=clang CXX=clang++ meson --buildtype=debug \
           -Dskip_introspection=true \
+          -Dwith_py3=false \
           $COMMON_MESON_ARGS \
           ci_scanbuild
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Run clang static analysis tests
         if: ${{ steps.scanbuild.outputs.available }}
         run: |
-          meson setup --buildtype=debug -Dskip_introspection=true ci_scanbuild
+          meson setup --buildtype=debug -Dskip_introspection=true -Dwith_py3=false ci_scanbuild
           ninja -C ci_scanbuild scan-build; if [ $? -ne 0 ]; then elinks -dump ci_scanbuild/meson-logs/scanbuild/*/index.html; fi
 
 
@@ -178,7 +178,7 @@ jobs:
       - name: Run clang static analysis tests
         if: ${{ steps.scanbuild.outputs.available }}
         run: |
-          meson setup --buildtype=debug -Dskip_introspection=true ci_scanbuild
+          meson setup --buildtype=debug -Dskip_introspection=true -Dwith_py3=false ci_scanbuild
           ninja -C ci_scanbuild scan-build; if [ $? -ne 0 ]; then elinks -dump ci_scanbuild/meson-logs/scanbuild/*/index.html; fi
 
 
@@ -484,5 +484,5 @@ jobs:
       - name: Run clang static analysis tests
         if: ${{ steps.scanbuild.outputs.available }}
         run: |
-          meson setup --buildtype=debug -Dwith_docs=false -Dlibmagic=disabled -Dskip_introspection=true ci_scanbuild
+          meson setup --buildtype=debug -Dwith_docs=false -Dlibmagic=disabled -Dskip_introspection=true -Dwith_py3=false ci_scanbuild
           ninja -C ci_scanbuild scan-build; if [ $? -ne 0 ]; then elinks -dump ci_scanbuild/meson-logs/scanbuild/*/index.html; fi

--- a/meson.build
+++ b/meson.build
@@ -107,8 +107,11 @@ has_extend_and_steal = cc.has_function(
 
 with_py3 = get_option('with_py3')
 if with_py3
-    python_name = get_option('python_name')
+    if get_option('skip_introspection')
+        error('A Python3 binding requires a GObject introspection.')
+    endif
 
+    python_name = get_option('python_name')
     if python_name != ''
         # If we've been instructed to use a specific python version
         python3 = pymod.find_installation(python_name)
@@ -122,6 +125,9 @@ endif
 
 with_py2 = get_option('with_py2')
 if with_py2
+    if get_option('skip_introspection')
+        error('A Python2 binding requires a GObject introspection.')
+    endif
     python2 = pymod.find_installation('python2')
 else
     python2 = disabler()

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -209,6 +209,76 @@ install_headers(
 )
 
 
+# --- GOBject Introspection -- #
+
+if skip_introspection
+else
+girs = gnome.generate_gir(
+        modulemd_lib,
+        sources : modulemd_srcs + modulemd_hdrs + ['include/private/gi-binding-renames.h'],
+        nsversion : '2.0',
+        namespace : 'Modulemd',
+        symbol_prefix : 'modulemd_',
+        identifier_prefix : 'Modulemd',
+        includes : [
+            'GObject-2.0',
+        ],
+        extra_args : [ '--accept-unprefixed' ],
+        install : true,
+        fatal_warnings : true,
+    )
+endif
+
+pkg.generate(
+    libraries : modulemd_lib,
+    subdirs : header_path,
+    version : libmodulemd_version,
+    name : 'modulemd-2.0',
+    filebase : 'modulemd-2.0',
+    description : 'Module metadata manipulation library',
+    requires: [ 'glib-2.0', 'gobject-2.0' ],
+)
+
+xcdata = configuration_data()
+xcdata.set('VERSION', meson.project_version())
+configure_file(
+  input : 'version.xml.in',
+  output : 'version.xml',
+  configuration : xcdata
+)
+
+if with_docs
+    gnome.gtkdoc(
+        'modulemd-2.0',
+        install_dir: 'modulemd-2.0',
+        src_dir : './modulemd',
+        main_xml : 'modulemd-docs.xml',
+        gobject_typesfile : join_paths(meson.current_build_dir(), 'modulemd-2.0.types'),
+        dependencies : [
+            modulemd_dep,
+        ],
+        fixxref_args: [
+                     '--extra-dir=@0@'.format(join_paths(glib_docpath, 'glib')),
+                     '--extra-dir=@0@'.format(join_paths(glib_docpath, 'gobject')),
+                   ],
+        install : true,
+    )
+endif
+
+help2man_opts = [
+  '--no-info',
+  '--section=1',
+]
+custom_target(
+    'modulemd-validator.1',
+    output: 'modulemd-validator.1',
+    command: [
+      help2man, help2man_opts, '--output=@OUTPUT@', modulemd_validator,
+    ],
+    install: true,
+    install_dir: join_paths(get_option('mandir'), 'man1'))
+
+
 # --- TESTS --- #
 
 # Test env with release values
@@ -332,28 +402,34 @@ python_tests = {
 }
 
 foreach name, script : python_tests
-    test_python_scripts += files(script)
-    test (name + '_python3_debug', python3,
-          env : py_test_env,
-          timeout : 60,
-          args : files(script),
-          suite : ['ci', 'py3', 'py3_debug'])
-    test (name + '_python3_release', python3,
-          env : py_test_release_env,
-          timeout : 60,
-          args : files(script),
-          suite : ['ci', 'py3', 'py3_release'])
+    if with_py3
+      test_python_scripts += files(script)
+      test (name + '_python3_debug', python3,
+            env : py_test_env,
+            timeout : 60,
+            args : files(script),
+            depends : girs,
+            suite : ['ci', 'py3', 'py3_debug'])
+      test (name + '_python3_release', python3,
+            env : py_test_release_env,
+            timeout : 60,
+            args : files(script),
+            depends : girs,
+            suite : ['ci', 'py3', 'py3_release'])
+    endif
 
     if with_py2
         test (name + '_python2_debug', python2,
               env : py_test_env,
               timeout : 60,
               args : files(script),
+              depends : girs,
               suite : ['ci', 'py2', 'py2_debug'])
         test (name + '_python2_release', python2,
               env : py_test_release_env,
               timeout : 60,
               args : files(script),
+              depends : girs,
               suite : ['ci', 'py2', 'py2_release'])
     endif #with_py2
 endforeach
@@ -371,71 +447,3 @@ test('test_import_headers', import_header_script,
       suite : ['smoketest', 'ci'])
 
 
-# --- GOBject Introspection -- #
-
-if skip_introspection
-else
-    gnome.generate_gir(
-        modulemd_lib,
-        sources : modulemd_srcs + modulemd_hdrs + ['include/private/gi-binding-renames.h'],
-        nsversion : '2.0',
-        namespace : 'Modulemd',
-        symbol_prefix : 'modulemd_',
-        identifier_prefix : 'Modulemd',
-        includes : [
-            'GObject-2.0',
-        ],
-        extra_args : [ '--accept-unprefixed' ],
-        install : true,
-        fatal_warnings : true,
-    )
-endif
-
-pkg.generate(
-    libraries : modulemd_lib,
-    subdirs : header_path,
-    version : libmodulemd_version,
-    name : 'modulemd-2.0',
-    filebase : 'modulemd-2.0',
-    description : 'Module metadata manipulation library',
-    requires: [ 'glib-2.0', 'gobject-2.0' ],
-)
-
-xcdata = configuration_data()
-xcdata.set('VERSION', meson.project_version())
-configure_file(
-  input : 'version.xml.in',
-  output : 'version.xml',
-  configuration : xcdata
-)
-
-if with_docs
-    gnome.gtkdoc(
-        'modulemd-2.0',
-        install_dir: 'modulemd-2.0',
-        src_dir : './modulemd',
-        main_xml : 'modulemd-docs.xml',
-        gobject_typesfile : join_paths(meson.current_build_dir(), 'modulemd-2.0.types'),
-        dependencies : [
-            modulemd_dep,
-        ],
-        fixxref_args: [
-                     '--extra-dir=@0@'.format(join_paths(glib_docpath, 'glib')),
-                     '--extra-dir=@0@'.format(join_paths(glib_docpath, 'gobject')),
-                   ],
-        install : true,
-    )
-endif
-
-help2man_opts = [
-  '--no-info',
-  '--section=1',
-]
-custom_target(
-    'modulemd-validator.1',
-    output: 'modulemd-validator.1',
-    command: [
-      help2man, help2man_opts, '--output=@OUTPUT@', modulemd_validator,
-    ],
-    install: true,
-    install_dir: join_paths(get_option('mandir'), 'man1'))

--- a/modulemd/tests/ModulemdTests/modulestream.py
+++ b/modulemd/tests/ModulemdTests/modulestream.py
@@ -20,9 +20,14 @@ try:
     import unittest
     import gi
 
-    gi._overridesdir = os.path.join(
-        os.getenv("MESON_SOURCE_ROOT"), "bindings", "python", "gi", "overrides"
-    )
+    if os.getenv("MMD_TEST_INSTALLED_LIBS") != "TRUE":
+        gi._overridesdir = os.path.join(
+            os.getenv("MESON_SOURCE_ROOT"),
+            "bindings",
+            "python",
+            "gi",
+            "overrides",
+        )
 
     gi.require_version("Modulemd", "2.0")
     from gi.repository import GLib


### PR DESCRIPTION
Previously, configuring and running the tests could fail because
GIR data were not built and thus the tests exhibited installed GIR
data mismatching tests and the library. E.g.:

modulemd/tests/ModulemdTests/modulestream.py", line 504, in test_demodularized_rpms
    stream.add_demodularized_rpm("foo")
AttributeError: 'ModuleStreamV2' object has no attribute 'add_demodularized_rpm'

A trivial fix was adding a build target for GIR as a dependency to the
Python tests. But that arrised a more profound bug -- Let's disable GIR
with -Dskip_introspection=true, then the build fails because Python3
tests are always performed and Python3 binding uses GIR. We simply
cannot perform Python tests without building GIR.

This patch fixes it by forbiding disabling GIR while keeping Python2 or
Python3 enabled. And it also disables the Python3 tests if the Python3
binding is disabled.