### PR TITLE
modulemd-validator to enforce document types

### DIFF
--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -469,6 +469,15 @@ modulemd_validator_tests = {
 'valid_defaultsv1_with_unexpected_document_as_defaultsv1':
     [['--code', '1'],
     ['--type', 'modulemd-defaults-v1', files('tests/test_data/valid_defaults_with_unexpected_document.yaml')]],
+'valid_modulemdv1_as_modulemdv1':
+    [['--code', '0'],
+    ['--type', 'modulemd-v1', files('../yaml_specs/modulemd_stream_v1.yaml')]],
+'invalid_modulemdv1_as_modulemdv1':
+    [['--code', '1', '--stderr', 'Unexpected key in licenses'],
+    ['--type', 'modulemd-v1', files('tests/test_data/bad_stream_v1.yaml')]],
+'valid_modulemdv2_as_modulemdv1':
+    [['--code', '1'],
+    ['--type', 'modulemd-v1', files('../yaml_specs/modulemd_stream_v2.yaml')]],
 'valid_modulemdv2_as_modulemdv2':
     [['--code', '0'],
     ['--type', 'modulemd-v2', files('../yaml_specs/modulemd_stream_v2.yaml')]],

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -469,6 +469,21 @@ modulemd_validator_tests = {
 'valid_packagerv3_as_modulemdv2':
     [['--code', '1'],
     ['--type', 'modulemd-v2', files('../yaml_specs/modulemd_packager_v3.yaml')]],
+'valid_defaultsv1.yaml':
+    [['--code', '0'],
+    [files('../yaml_specs/modulemd_defaults_v1.yaml')]],
+'invalid_defaultsv1.yaml':
+    [['--code', '1'],
+    [files('tests/test_data/invalid_defaults.yaml')]],
+'valid_defaultsv1_as_defaultsv1':
+    [['--code', '0'],
+    ['--type', 'modulemd-defaults-v1', files('../yaml_specs/modulemd_defaults_v1.yaml')]],
+'invalid_defaultsv1_as_defaultsv1':
+    [['--code', '1'],
+    ['--type', 'modulemd-defaults-v1', files('tests/test_data/invalid_defaults.yaml')]],
+'modulemdv2_as_defaultsv1':
+    [['--code', '1'],
+    ['--type', 'defaults-v1', files('../yaml_specs/modulemd_stream_v2.yaml')]],
 }
 test_modulemd_validator = executable(
     'test-modulemd-validator',

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -493,6 +493,15 @@ modulemd_validator_tests = {
 'modulemdv2_as_defaultsv1':
     [['--code', '1'],
     ['--type', 'defaults-v1', files('../yaml_specs/modulemd_stream_v2.yaml')]],
+'valid_packagerv2_as_packagerv2':
+    [['--code', '0'],
+    ['--type', 'modulemd-packager-v2', files('../yaml_specs/modulemd_packager_v2.yaml')]],
+'invalid_packagerv2_as_packagerv2':
+    [['--code', '1', '--stderr', 'Unexpected key in licenses'],
+    ['--type', 'modulemd-packager-v2', files('tests/test_data/bad_packager_v2.yaml')]],
+'valid_modulemdv2_as_packagerv2':
+    [['--code', '1'],
+    ['--type', 'modulemd-packager-v2', files('../yaml_specs/modulemd_stream_v2.yaml')]],
 'valid_packagerv3_as_packagerv3':
     [['--code', '0'],
     ['--type', 'modulemd-packager-v3', files('../yaml_specs/modulemd_packager_v3.yaml')]],

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -520,6 +520,15 @@ modulemd_validator_tests = {
 'valid_modulemdv2_as_packagerv3':
     [['--code', '1'],
     ['--type', 'modulemd-packager-v3', files('../yaml_specs/modulemd_stream_v2.yaml')]],
+'valid_translationsv1_as_translationsv1':
+    [['--code', '0'],
+    ['--type', 'modulemd-translations-v1', files('../yaml_specs/modulemd_translations_v1.yaml')]],
+'invalid_translationsv1_as_translationsv1':
+    [['--code', '1', '--stderr', 'not a valid integer'],
+    ['--type', 'modulemd-translations-v1', files('tests/test_data/bad_translations_v1.yaml')]],
+'valid_modulemdv2_as_translationsv1':
+    [['--code', '1'],
+    ['--type', 'modulemd-translations-v1', files('../yaml_specs/modulemd_stream_v2.yaml')]],
 }
 test_modulemd_validator = executable(
     'test-modulemd-validator',

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -481,6 +481,12 @@ modulemd_validator_tests = {
 'invalid_defaultsv1_as_defaultsv1':
     [['--code', '1'],
     ['--type', 'modulemd-defaults-v1', files('tests/test_data/invalid_defaults.yaml')]],
+'valid_defaultsv1_with_garbage_as_defaultsv1':
+    [['--code', '1'],
+    ['--type', 'modulemd-defaults-v1', files('tests/test_data/valid_defaults_with_garbage.yaml')]],
+'valid_defaultsv1_with_unexpected_document_as_defaultsv1':
+    [['--code', '1'],
+    ['--type', 'modulemd-defaults-v1', files('tests/test_data/valid_defaults_with_unexpected_document.yaml')]],
 'modulemdv2_as_defaultsv1':
     [['--code', '1'],
     ['--type', 'defaults-v1', files('../yaml_specs/modulemd_stream_v2.yaml')]],

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -487,6 +487,18 @@ modulemd_validator_tests = {
 'valid_defaultsv1_with_unexpected_document_as_defaultsv1':
     [['--code', '1'],
     ['--type', 'modulemd-defaults-v1', files('tests/test_data/valid_defaults_with_unexpected_document.yaml')]],
+'valid_obsoletesv1.yaml':
+    [['--code', '0'],
+    [files('../yaml_specs/modulemd_obsoletes_v1.yaml')]],
+'invalid_obsoletesv1.yaml':
+    [['--code', '1'],
+    [files('tests/test_data/invalid_obsoletes_v1.yaml')]],
+'valid_obsoletesv1_as_obsoletesv1.yaml':
+    [['--code', '0'],
+    ['--type', 'modulemd-obsoletes-v1', files('../yaml_specs/modulemd_obsoletes_v1.yaml')]],
+'invalid_obsoletesv1_as_obseletesv1.yaml':
+    [['--code', '1'],
+    ['--type', 'modulemd-obsoletes-v1', files('tests/test_data/invalid_obsoletes_v1.yaml')]],
 'modulemdv2_as_defaultsv1':
     [['--code', '1'],
     ['--type', 'defaults-v1', files('../yaml_specs/modulemd_stream_v2.yaml')]],

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -473,7 +473,7 @@ modulemd_validator_tests = {
     [['--code', '0'],
     ['--type', 'modulemd-v1', files('../yaml_specs/modulemd_stream_v1.yaml')]],
 'invalid_modulemdv1_as_modulemdv1':
-    [['--code', '1', '--stderr', 'Unexpected key in licenses'],
+    [['--code', '1', '--stderr', 'not in valid N-E:V-R.A format'],
     ['--type', 'modulemd-v1', files('tests/test_data/bad_stream_v1.yaml')]],
 'valid_modulemdv2_as_modulemdv1':
     [['--code', '1'],
@@ -506,7 +506,7 @@ modulemd_validator_tests = {
     [['--code', '0'],
     ['--type', 'modulemd-packager-v2', files('../yaml_specs/modulemd_packager_v2.yaml')]],
 'invalid_packagerv2_as_packagerv2':
-    [['--code', '1', '--stderr', 'Unexpected key in licenses'],
+    [['--code', '1', '--stderr', 'license is missing'],
     ['--type', 'modulemd-packager-v2', files('tests/test_data/bad_packager_v2.yaml')]],
 'valid_modulemdv2_as_packagerv2':
     [['--code', '1'],

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -445,9 +445,30 @@ modulemd_validator_tests = {
 'help'        : [['--code', '0'], ['--help']],
 'version'     : [['--code', '0'], ['--version']],
 'valid'       : [['--code', '0'],
-                 [files('tests/test_data/static_context.yaml')]],
+                [files('tests/test_data/static_context.yaml')]],
 'invalid'     : [['--code', '1', '--stdout', 'No data section provided'],
-                 [files('tests/test_data/good_and_bad.yaml')]],
+                [files('tests/test_data/good_and_bad.yaml')]],
+'stream_packagerv3_invalid_mix_as_index':
+    [['--code', '1'],
+    [files('tests/test_data/stream_packager_mix.yaml')]],
+'valid_packagerv3':
+    [['--code', '0'],
+    ['--type', 'modulemd-packager-v3', files('../yaml_specs/modulemd_packager_v3.yaml')]],
+'invalid_packagerv3':
+    [['--code', '1', '--stderr', 'context exceeds'],
+    ['--type', 'modulemd-packager-v3', files('tests/test_data/bad_packager_v3.yaml')]],
+'valid_modulemdv2_as_packagerv3':
+    [['--code', '1'],
+    ['--type', 'modulemd-packager-v3', files('../yaml_specs/modulemd_stream_v2.yaml')]],
+'valid_modulemdv2':
+    [['--code', '0'],
+    ['--type', 'modulemd-v2', files('../yaml_specs/modulemd_stream_v2.yaml')]],
+'invalid_modulemdv2':
+    [['--code', '1', '--stderr', 'Stream context'],
+    ['--type', 'modulemd-v2', files('tests/test_data/bad_stream_v2.yaml')]],
+'valid_packagerv3_as_modulemdv2':
+    [['--code', '1'],
+    ['--type', 'modulemd-v2', files('../yaml_specs/modulemd_packager_v3.yaml')]],
 }
 test_modulemd_validator = executable(
     'test-modulemd-validator',

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -451,19 +451,10 @@ modulemd_validator_tests = {
 'stream_packagerv3_invalid_mix_as_index':
     [['--code', '1'],
     [files('tests/test_data/stream_packager_mix.yaml')]],
-'valid_packagerv3':
-    [['--code', '0'],
-    ['--type', 'modulemd-packager-v3', files('../yaml_specs/modulemd_packager_v3.yaml')]],
-'invalid_packagerv3':
-    [['--code', '1', '--stderr', 'context exceeds'],
-    ['--type', 'modulemd-packager-v3', files('tests/test_data/bad_packager_v3.yaml')]],
-'valid_modulemdv2_as_packagerv3':
-    [['--code', '1'],
-    ['--type', 'modulemd-packager-v3', files('../yaml_specs/modulemd_stream_v2.yaml')]],
-'valid_modulemdv2':
+'valid_modulemdv2_as_modulemdv2':
     [['--code', '0'],
     ['--type', 'modulemd-v2', files('../yaml_specs/modulemd_stream_v2.yaml')]],
-'invalid_modulemdv2':
+'invalid_modulemdv2_as_modulemdv2':
     [['--code', '1', '--stderr', 'Stream context'],
     ['--type', 'modulemd-v2', files('tests/test_data/bad_stream_v2.yaml')]],
 'valid_packagerv3_as_modulemdv2':
@@ -502,6 +493,15 @@ modulemd_validator_tests = {
 'modulemdv2_as_defaultsv1':
     [['--code', '1'],
     ['--type', 'defaults-v1', files('../yaml_specs/modulemd_stream_v2.yaml')]],
+'valid_packagerv3_as_packagerv3':
+    [['--code', '0'],
+    ['--type', 'modulemd-packager-v3', files('../yaml_specs/modulemd_packager_v3.yaml')]],
+'invalid_packagerv3_as_packagerv3':
+    [['--code', '1', '--stderr', 'context exceeds'],
+    ['--type', 'modulemd-packager-v3', files('tests/test_data/bad_packager_v3.yaml')]],
+'valid_modulemdv2_as_packagerv3':
+    [['--code', '1'],
+    ['--type', 'modulemd-packager-v3', files('../yaml_specs/modulemd_stream_v2.yaml')]],
 }
 test_modulemd_validator = executable(
     'test-modulemd-validator',

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -451,15 +451,6 @@ modulemd_validator_tests = {
 'stream_packagerv3_invalid_mix_as_index':
     [['--code', '1'],
     [files('tests/test_data/stream_packager_mix.yaml')]],
-'valid_modulemdv2_as_modulemdv2':
-    [['--code', '0'],
-    ['--type', 'modulemd-v2', files('../yaml_specs/modulemd_stream_v2.yaml')]],
-'invalid_modulemdv2_as_modulemdv2':
-    [['--code', '1', '--stderr', 'Stream context'],
-    ['--type', 'modulemd-v2', files('tests/test_data/bad_stream_v2.yaml')]],
-'valid_packagerv3_as_modulemdv2':
-    [['--code', '1'],
-    ['--type', 'modulemd-v2', files('../yaml_specs/modulemd_packager_v3.yaml')]],
 'valid_defaultsv1.yaml':
     [['--code', '0'],
     [files('../yaml_specs/modulemd_defaults_v1.yaml')]],
@@ -478,6 +469,15 @@ modulemd_validator_tests = {
 'valid_defaultsv1_with_unexpected_document_as_defaultsv1':
     [['--code', '1'],
     ['--type', 'modulemd-defaults-v1', files('tests/test_data/valid_defaults_with_unexpected_document.yaml')]],
+'valid_modulemdv2_as_modulemdv2':
+    [['--code', '0'],
+    ['--type', 'modulemd-v2', files('../yaml_specs/modulemd_stream_v2.yaml')]],
+'invalid_modulemdv2_as_modulemdv2':
+    [['--code', '1', '--stderr', 'Stream context'],
+    ['--type', 'modulemd-v2', files('tests/test_data/bad_stream_v2.yaml')]],
+'valid_packagerv3_as_modulemdv2':
+    [['--code', '1'],
+    ['--type', 'modulemd-v2', files('../yaml_specs/modulemd_packager_v3.yaml')]],
 'valid_obsoletesv1.yaml':
     [['--code', '0'],
     [files('../yaml_specs/modulemd_obsoletes_v1.yaml')]],

--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -138,6 +138,21 @@ set_type (const gchar *option_name,
     return TRUE;
 }
 
+static const gchar *
+gtype2astring (const GType type)
+{
+    if (type == MODULEMD_TYPE_MODULE_INDEX)
+        return "an index";
+    else if (type == MODULEMD_TYPE_MODULE_STREAM_V2)
+        return "a modulemd-v2";
+    else if (type == MODULEMD_TYPE_DEFAULTS_V1)
+        return "a modulemd-defaults-v1";
+    else if (type == MODULEMD_TYPE_PACKAGER_V3)
+        return "a modulemd-packager-v3";
+    else
+        return "an unknown document GType";
+}
+
 // clang-format off
 static GOptionEntry entries[] = {
   { "debug", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, set_verbosity, "Output debugging messages", NULL },
@@ -257,8 +272,9 @@ parse_file (const gchar *filename, GPtrArray **failures, GError **error)
             error,
             MODULEMD_ERROR,
             0,
-            "Not a modulemd-defaults-v1 document; it is %s",
-            ModulemdYamlDocumentTypeEnum2string(type)
+            "Not %s document; it is %s",
+            gtype2astring (options.type),
+            ModulemdYamlDocumentTypeEnum2string (type)
           );
           return FALSE;
         }
@@ -269,7 +285,8 @@ parse_file (const gchar *filename, GPtrArray **failures, GError **error)
             error,
             MODULEMD_ERROR,
             0,
-            "Not a modulemd-defaults-v1 document; it is %" G_GUINT64_FORMAT " version",
+            "Not %s document; it is %" G_GUINT64_FORMAT " version",
+            gtype2astring (options.type),
             version
           );
           return FALSE;
@@ -295,7 +312,7 @@ parse_file (const gchar *filename, GPtrArray **failures, GError **error)
         }
       }
       yaml_event_delete (&event);
-      /* Already validated by modulemd_yaml_parse_document_type (). */
+      /* Already validated by modulemd_defaults_v1_parse_yaml (). */
       return (NULL != object);
     }
   else if (options.type == MODULEMD_TYPE_MODULE_STREAM_V2)

--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -45,14 +45,14 @@ enum mmd_verbosity
  * a run-time computed value and hence cannot be used in switch-cases. */
 enum mmd_type
 {
-    MMD_TYPE_INDEX, /* Untyped validation by loading into an index */
-    MMD_TYPE_MODULEMD_V1,
-    MMD_TYPE_MODULEMD_V2,
-    MMD_TYPE_MODULEMD_DEFAULTS_V1,
-    MMD_TYPE_MODULEMD_OBSOLETES_V1,
-    MMD_TYPE_MODULEMD_PACKAGER_V2,
-    MMD_TYPE_MODULEMD_PACKAGER_V3,
-    MMD_TYPE_MODULEMD_TRANSLATIONS_V1
+  MMD_TYPE_INDEX, /* Untyped validation by loading into an index */
+  MMD_TYPE_MODULEMD_V1,
+  MMD_TYPE_MODULEMD_V2,
+  MMD_TYPE_MODULEMD_DEFAULTS_V1,
+  MMD_TYPE_MODULEMD_OBSOLETES_V1,
+  MMD_TYPE_MODULEMD_PACKAGER_V2,
+  MMD_TYPE_MODULEMD_PACKAGER_V3,
+  MMD_TYPE_MODULEMD_TRANSLATIONS_V1
 };
 
 struct validator_options
@@ -139,47 +139,48 @@ set_type (const gchar *option_name,
           gpointer data,
           GError **error)
 {
-    if (!g_strcmp0 (value, "modulemd-v1"))
-        options.type = MMD_TYPE_MODULEMD_V1;
-    else if (!g_strcmp0 (value, "modulemd-v2"))
-        options.type = MMD_TYPE_MODULEMD_V2;
-    else if (!g_strcmp0 (value, "modulemd-defaults-v1"))
-        options.type = MMD_TYPE_MODULEMD_DEFAULTS_V1;
-    else if (!g_strcmp0 (value, "modulemd-obsoletes-v1"))
-        options.type = MMD_TYPE_MODULEMD_OBSOLETES_V1;
-    else if (!g_strcmp0 (value, "modulemd-packager-v2"))
-        options.type = MMD_TYPE_MODULEMD_PACKAGER_V2;
-    else if (!g_strcmp0 (value, "modulemd-packager-v3"))
-        options.type = MMD_TYPE_MODULEMD_PACKAGER_V3;
-    else if (!g_strcmp0 (value, "modulemd-translations-v1"))
-        options.type = MMD_TYPE_MODULEMD_TRANSLATIONS_V1;
-    else
-      {
-        g_set_error (error,
-                    G_OPTION_ERROR,
-                    G_OPTION_ERROR_FAILED,
-                    "Unknown document type: %s",
-                    value);
-        return FALSE;
-      }
-    return TRUE;
+  if (!g_strcmp0 (value, "modulemd-v1"))
+    options.type = MMD_TYPE_MODULEMD_V1;
+  else if (!g_strcmp0 (value, "modulemd-v2"))
+    options.type = MMD_TYPE_MODULEMD_V2;
+  else if (!g_strcmp0 (value, "modulemd-defaults-v1"))
+    options.type = MMD_TYPE_MODULEMD_DEFAULTS_V1;
+  else if (!g_strcmp0 (value, "modulemd-obsoletes-v1"))
+    options.type = MMD_TYPE_MODULEMD_OBSOLETES_V1;
+  else if (!g_strcmp0 (value, "modulemd-packager-v2"))
+    options.type = MMD_TYPE_MODULEMD_PACKAGER_V2;
+  else if (!g_strcmp0 (value, "modulemd-packager-v3"))
+    options.type = MMD_TYPE_MODULEMD_PACKAGER_V3;
+  else if (!g_strcmp0 (value, "modulemd-translations-v1"))
+    options.type = MMD_TYPE_MODULEMD_TRANSLATIONS_V1;
+  else
+    {
+      g_set_error (error,
+                   G_OPTION_ERROR,
+                   G_OPTION_ERROR_FAILED,
+                   "Unknown document type: %s",
+                   value);
+      return FALSE;
+    }
+  return TRUE;
 }
 
 static const gchar *
 mmd_type2astring (enum mmd_type type)
 {
-    switch (type)
-      {
-        case MMD_TYPE_INDEX: return "an index";
-        case MMD_TYPE_MODULEMD_V1: return "a modulemd-v1";
-        case MMD_TYPE_MODULEMD_V2: return "a modulemd-v2";
-        case MMD_TYPE_MODULEMD_DEFAULTS_V1: return "a modulemd-defaults-v1";
-        case MMD_TYPE_MODULEMD_OBSOLETES_V1: return "a modulemd-obsoletes-v1";
-        case MMD_TYPE_MODULEMD_PACKAGER_V2: return "a modulemd-packager-v2";
-        case MMD_TYPE_MODULEMD_PACKAGER_V3: return "a modulemd-packager-v3";
-        case MMD_TYPE_MODULEMD_TRANSLATIONS_V1: return "a modulemd-translations-v1";
-      }
-    return "an unknown document type";
+  switch (type)
+    {
+    case MMD_TYPE_INDEX: return "an index";
+    case MMD_TYPE_MODULEMD_V1: return "a modulemd-v1";
+    case MMD_TYPE_MODULEMD_V2: return "a modulemd-v2";
+    case MMD_TYPE_MODULEMD_DEFAULTS_V1: return "a modulemd-defaults-v1";
+    case MMD_TYPE_MODULEMD_OBSOLETES_V1: return "a modulemd-obsoletes-v1";
+    case MMD_TYPE_MODULEMD_PACKAGER_V2: return "a modulemd-packager-v2";
+    case MMD_TYPE_MODULEMD_PACKAGER_V3: return "a modulemd-packager-v3";
+    case MMD_TYPE_MODULEMD_TRANSLATIONS_V1:
+      return "a modulemd-translations-v1";
+    }
+  return "an unknown document type";
 }
 
 // clang-format off
@@ -197,15 +198,15 @@ static const gchar *
 ModulemdYamlDocumentTypeEnum2string (ModulemdYamlDocumentTypeEnum type)
 {
   switch (type)
-   {
-     case MODULEMD_YAML_DOC_MODULESTREAM: return "modulemd";
-     case MODULEMD_YAML_DOC_DEFAULTS: return "modulemd-defaults";
-     case MODULEMD_YAML_DOC_TRANSLATIONS: return "modulemd-translations";
-     case MODULEMD_YAML_DOC_PACKAGER: return "modulemd-packager";
-     case MODULEMD_YAML_DOC_OBSOLETES: return "modulemd-obsoletes";
-     case MODULEMD_YAML_DOC_UNKNOWN: /* fall through */
-     default: return "unknown type";
-   }
+    {
+    case MODULEMD_YAML_DOC_MODULESTREAM: return "modulemd";
+    case MODULEMD_YAML_DOC_DEFAULTS: return "modulemd-defaults";
+    case MODULEMD_YAML_DOC_TRANSLATIONS: return "modulemd-translations";
+    case MODULEMD_YAML_DOC_PACKAGER: return "modulemd-packager";
+    case MODULEMD_YAML_DOC_OBSOLETES: return "modulemd-obsoletes";
+    case MODULEMD_YAML_DOC_UNKNOWN: /* fall through */
+    default: return "unknown type";
+    }
 }
 
 /* We cannot load by index as it converts from old versions before
@@ -214,10 +215,10 @@ ModulemdYamlDocumentTypeEnum2string (ModulemdYamlDocumentTypeEnum type)
  * parsers. */
 static gboolean
 parse_file_as_subdoc_and_validate (const gchar *filename,
-                      enum mmd_type validation_type,
-                      ModulemdYamlDocumentTypeEnum expected_type,
-                      guint64 expected_version,
-                      GError **error)
+                                   enum mmd_type validation_type,
+                                   ModulemdYamlDocumentTypeEnum expected_type,
+                                   guint64 expected_version,
+                                   GError **error)
 {
   g_autoptr (FILE) file = NULL;
   MMD_INIT_YAML_PARSER (parser);
@@ -229,55 +230,43 @@ parse_file_as_subdoc_and_validate (const gchar *filename,
   g_autoptr (GObject) object = NULL;
 
   /* Open the file and determine a document type */
-  file = fopen(filename, "r");
+  file = fopen (filename, "r");
   if (!file)
     {
-      g_set_error (
-        error,
-        MODULEMD_YAML_ERROR,
-        MMD_YAML_ERROR_OPEN,
-        "Could not open %s file: %s",
-        filename,
-        strerror(errno)
-      );
+      g_set_error (error,
+                   MODULEMD_YAML_ERROR,
+                   MMD_YAML_ERROR_OPEN,
+                   "Could not open %s file: %s",
+                   filename,
+                   strerror (errno));
       return FALSE;
     }
   yaml_parser_set_input_file (&parser, file);
   if (!yaml_parser_parse (&parser, &event))
     {
-      MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-        error,
-        event,
-        "Invalid YAML"
-      );
+      MMD_YAML_ERROR_EVENT_EXIT_BOOL (error, event, "Invalid YAML");
     }
-  if (event.type != YAML_STREAM_START_EVENT) {
+  if (event.type != YAML_STREAM_START_EVENT)
     {
-      MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-        error,
-        event,
-        "YAML parser could not find a start of a YAML stream"
-      );
+      {
+        MMD_YAML_ERROR_EVENT_EXIT_BOOL (
+          error, event, "YAML parser could not find a start of a YAML stream");
+      }
     }
-  }
   yaml_event_delete (&event);
   if (!yaml_parser_parse (&parser, &event))
     {
-      MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-        error,
-        event,
-        "Invalid YAML"
-      );
+      MMD_YAML_ERROR_EVENT_EXIT_BOOL (error, event, "Invalid YAML");
     }
-  if (event.type != YAML_DOCUMENT_START_EVENT) {
+  if (event.type != YAML_DOCUMENT_START_EVENT)
     {
-      MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-        error,
-        event,
-        "YAML parser could not find a start of a YAML document"
-      );
+      {
+        MMD_YAML_ERROR_EVENT_EXIT_BOOL (
+          error,
+          event,
+          "YAML parser could not find a start of a YAML document");
+      }
     }
-  }
   yaml_event_delete (&event);
   subdoc = modulemd_yaml_parse_document_type (&parser);
   subdoc_error = modulemd_subdocument_info_get_gerror (subdoc);
@@ -289,27 +278,23 @@ parse_file_as_subdoc_and_validate (const gchar *filename,
   type = modulemd_subdocument_info_get_doctype (subdoc);
   if (type != expected_type)
     {
-      g_set_error(
-        error,
-        MODULEMD_ERROR,
-        0,
-        "Not %s document; it is %s",
-        mmd_type2astring (validation_type),
-        ModulemdYamlDocumentTypeEnum2string (type)
-      );
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   0,
+                   "Not %s document; it is %s",
+                   mmd_type2astring (validation_type),
+                   ModulemdYamlDocumentTypeEnum2string (type));
       return FALSE;
     }
   version = modulemd_subdocument_info_get_mdversion (subdoc);
   if (version != expected_version)
     {
-      g_set_error(
-        error,
-        MODULEMD_ERROR,
-        0,
-        "Not %s document; it is %" G_GUINT64_FORMAT " version",
-        mmd_type2astring (validation_type),
-        version
-      );
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   0,
+                   "Not %s document; it is %" G_GUINT64_FORMAT " version",
+                   mmd_type2astring (validation_type),
+                   version);
       return FALSE;
     }
 
@@ -317,65 +302,58 @@ parse_file_as_subdoc_and_validate (const gchar *filename,
   switch (validation_type)
     {
     case MMD_TYPE_MODULEMD_V1:
-        object = G_OBJECT (modulemd_module_stream_v1_parse_yaml (subdoc,
-          TRUE, error));
-        if (object && !modulemd_module_stream_validate(
-          MODULEMD_MODULE_STREAM (object), error))
-            g_clear_object (&object);
-        break;
+      object =
+        G_OBJECT (modulemd_module_stream_v1_parse_yaml (subdoc, TRUE, error));
+      if (object && !modulemd_module_stream_validate (
+                      MODULEMD_MODULE_STREAM (object), error))
+        g_clear_object (&object);
+      break;
     case MMD_TYPE_MODULEMD_DEFAULTS_V1:
-        object = G_OBJECT (modulemd_defaults_v1_parse_yaml (subdoc,
-          TRUE, error));
-        /* validated implicitly */
-        break;
+      object =
+        G_OBJECT (modulemd_defaults_v1_parse_yaml (subdoc, TRUE, error));
+      /* validated implicitly */
+      break;
     case MMD_TYPE_MODULEMD_OBSOLETES_V1:
-        object = G_OBJECT (modulemd_obsoletes_parse_yaml (subdoc, TRUE, error));
-        /* validated implicitly */
-        break;
+      object = G_OBJECT (modulemd_obsoletes_parse_yaml (subdoc, TRUE, error));
+      /* validated implicitly */
+      break;
     case MMD_TYPE_MODULEMD_PACKAGER_V2:
-        object = G_OBJECT (modulemd_module_stream_v2_parse_yaml (subdoc,
-          TRUE, TRUE, error));
-        if (object && !modulemd_module_stream_validate(
-          MODULEMD_MODULE_STREAM (object), error))
-            g_clear_object (&object);
-        break;
+      object = G_OBJECT (
+        modulemd_module_stream_v2_parse_yaml (subdoc, TRUE, TRUE, error));
+      if (object && !modulemd_module_stream_validate (
+                      MODULEMD_MODULE_STREAM (object), error))
+        g_clear_object (&object);
+      break;
     case MMD_TYPE_MODULEMD_TRANSLATIONS_V1:
-        object = G_OBJECT (modulemd_translation_parse_yaml (subdoc,
-          TRUE, error));
-        /* validated implicitly */
-        break;
+      object =
+        G_OBJECT (modulemd_translation_parse_yaml (subdoc, TRUE, error));
+      /* validated implicitly */
+      break;
     default:
-        g_set_error(
-          error,
-          MODULEMD_ERROR,
-          0,
-          "Internal error: %s type is not supported",
-          mmd_type2astring (validation_type)
-        );
-        return FALSE;
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   0,
+                   "Internal error: %s type is not supported",
+                   mmd_type2astring (validation_type));
+      return FALSE;
     }
   if (!object)
-      return FALSE;
+    return FALSE;
 
   /* Check for a garbage past the first document */
   if (!yaml_parser_parse (&parser, &event))
     {
       MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-        error,
-        event,
-        "Invalid YAML after first document"
-      );
+        error, event, "Invalid YAML after first document");
     }
-  if (event.type != YAML_STREAM_END_EVENT) {
+  if (event.type != YAML_STREAM_END_EVENT)
     {
-      MMD_YAML_ERROR_EVENT_EXIT_BOOL (
-        error,
-        event,
-        "Another YAML document after the first one"
-      );
-      return FALSE;
+      {
+        MMD_YAML_ERROR_EVENT_EXIT_BOOL (
+          error, event, "Another YAML document after the first one");
+        return FALSE;
+      }
     }
-  }
   yaml_event_delete (&event);
   return TRUE;
 }
@@ -398,11 +376,8 @@ parse_file (const gchar *filename, GPtrArray **failures, GError **error)
           index, filename, TRUE, TRUE, failures, error);
       }
     case MMD_TYPE_MODULEMD_V1:
-        return parse_file_as_subdoc_and_validate (filename,
-                                                  options.type,
-                                                  MODULEMD_YAML_DOC_MODULESTREAM,
-                                                  1u,
-                                                  error);
+      return parse_file_as_subdoc_and_validate (
+        filename, options.type, MODULEMD_YAML_DOC_MODULESTREAM, 1u, error);
     case MMD_TYPE_MODULEMD_V2:
       {
         GType type;
@@ -412,36 +387,25 @@ parse_file (const gchar *filename, GPtrArray **failures, GError **error)
           return FALSE;
         if (type != MODULEMD_TYPE_MODULE_STREAM_V2)
           {
-            g_set_error(
-              error,
-              MODULEMD_ERROR,
-              0,
-              "Not a modulemd-v2 document; it is %s",
-              g_type_name(type)
-            );
+            g_set_error (error,
+                         MODULEMD_ERROR,
+                         0,
+                         "Not a modulemd-v2 document; it is %s",
+                         g_type_name (type));
             return FALSE;
           }
-        return modulemd_module_stream_validate (MODULEMD_MODULE_STREAM (object),
-          error);
+        return modulemd_module_stream_validate (
+          MODULEMD_MODULE_STREAM (object), error);
       }
     case MMD_TYPE_MODULEMD_DEFAULTS_V1:
-        return parse_file_as_subdoc_and_validate (filename,
-                                                  options.type,
-                                                  MODULEMD_YAML_DOC_DEFAULTS,
-                                                  1u,
-                                                  error);
+      return parse_file_as_subdoc_and_validate (
+        filename, options.type, MODULEMD_YAML_DOC_DEFAULTS, 1u, error);
     case MMD_TYPE_MODULEMD_OBSOLETES_V1:
-        return parse_file_as_subdoc_and_validate (filename,
-                                                  options.type,
-                                                  MODULEMD_YAML_DOC_OBSOLETES,
-                                                  1u,
-                                                  error);
+      return parse_file_as_subdoc_and_validate (
+        filename, options.type, MODULEMD_YAML_DOC_OBSOLETES, 1u, error);
     case MMD_TYPE_MODULEMD_PACKAGER_V2:
-        return parse_file_as_subdoc_and_validate (filename,
-                                                  options.type,
-                                                  MODULEMD_YAML_DOC_PACKAGER,
-                                                  2u,
-                                                  error);
+      return parse_file_as_subdoc_and_validate (
+        filename, options.type, MODULEMD_YAML_DOC_PACKAGER, 2u, error);
     case MMD_TYPE_MODULEMD_PACKAGER_V3:
       {
         GType type;
@@ -451,13 +415,11 @@ parse_file (const gchar *filename, GPtrArray **failures, GError **error)
           return FALSE;
         if (type != MODULEMD_TYPE_PACKAGER_V3)
           {
-            g_set_error(
-              error,
-              MODULEMD_ERROR,
-              0,
-              "Not a modulemd-packager-v3 document; it is %s",
-              g_type_name(type)
-            );
+            g_set_error (error,
+                         MODULEMD_ERROR,
+                         0,
+                         "Not a modulemd-packager-v3 document; it is %s",
+                         g_type_name (type));
             return FALSE;
           }
         /* modulemd_packager_v3 is validated implicitly by
@@ -465,18 +427,12 @@ parse_file (const gchar *filename, GPtrArray **failures, GError **error)
         return TRUE;
       }
     case MMD_TYPE_MODULEMD_TRANSLATIONS_V1:
-        return parse_file_as_subdoc_and_validate (
-          filename,
-          options.type,
-          MODULEMD_YAML_DOC_TRANSLATIONS,
-          1u,
-          error);
+      return parse_file_as_subdoc_and_validate (
+        filename, options.type, MODULEMD_YAML_DOC_TRANSLATIONS, 1u, error);
     }
-  g_fprintf (
-    stderr,
-    "Internal error: unsupported document type: %s\n",
-    mmd_type2astring(options.type)
-  );
+  g_fprintf (stderr,
+             "Internal error: unsupported document type: %s\n",
+             mmd_type2astring (options.type));
   exit (EXIT_FAILURE);
 }
 

--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -226,8 +226,6 @@ parse_file_as_subdoc (const gchar *filename,
   const GError *subdoc_error;
   ModulemdYamlDocumentTypeEnum type;
   guint64 version;
-  /*g_autoptr (ModulemdDefaultsV1) defaults_object = NULL;
-  g_autoptr (ModulemdDefaultsV1) defaults_object = NULL;*/
   g_autoptr (GObject) object = NULL;
 
   file = fopen(filename, "r");

--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -139,9 +139,7 @@ set_type (const gchar *option_name,
           gpointer data,
           GError **error)
 {
-    if (!g_strcmp0 (value, "index"))
-        options.type = MMD_TYPE_INDEX;
-    else if (!g_strcmp0 (value, "modulemd-v1"))
+    if (!g_strcmp0 (value, "modulemd-v1"))
         options.type = MMD_TYPE_MODULEMD_V1;
     else if (!g_strcmp0 (value, "modulemd-v2"))
         options.type = MMD_TYPE_MODULEMD_V2;
@@ -187,7 +185,7 @@ mmd_type2astring (enum mmd_type type)
 // clang-format off
 static GOptionEntry entries[] = {
   { "debug", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, set_verbosity, "Output debugging messages", NULL },
-  { "type", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, set_type, "Document type (index, modulemd-v1, modulemd-v2, modulemd-defaults-v1, modulemd-obsoletes-v1, modulemd-packager-v2, modulemd-packager-v3, modulemd-translations-v1; default is index only which one accepts multi-document YAML files)", NULL },
+  { "type", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, set_type, "Constrain a document type (modulemd-v1, modulemd-v2, modulemd-defaults-v1, modulemd-obsoletes-v1, modulemd-packager-v2, modulemd-packager-v3, modulemd-translations-v1); by default any document type loadable into a modulemd index is acceptable; this option only supports single-document files", "TYPE" },
   { "quiet", 'q', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, set_verbosity, "Print no output", NULL },
   { "verbose", 'v', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, set_verbosity, "Be verbose", NULL },
   { "version", 'V', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, print_version, "Print version number, then exit", NULL },

--- a/modulemd/modulemd-validator.c
+++ b/modulemd/modulemd-validator.c
@@ -209,49 +209,37 @@ parse_file (const gchar *filename, GPtrArray **failures, GError **error)
       yaml_parser_set_input_file (&parser, file);
       if (!yaml_parser_parse (&parser, &event))
         {
-          g_set_error_literal (
+          MMD_YAML_ERROR_EVENT_EXIT_BOOL (
             error,
-            MODULEMD_YAML_ERROR,
-            MMD_YAML_ERROR_OPEN,
+            event,
             "Invalid YAML"
           );
-          /* Detailed error? */
-          return FALSE;
         }
       if (event.type != YAML_STREAM_START_EVENT) {
         {
-          g_set_error_literal (
+          MMD_YAML_ERROR_EVENT_EXIT_BOOL (
             error,
-            MODULEMD_YAML_ERROR,
-            MMD_YAML_ERROR_OPEN,
+            event,
             "YAML parser could not find a start of a YAML stream"
           );
-          /* Detailed error? */
-          return FALSE;
         }
       }
       yaml_event_delete (&event);
       if (!yaml_parser_parse (&parser, &event))
         {
-          g_set_error_literal (
+          MMD_YAML_ERROR_EVENT_EXIT_BOOL (
             error,
-            MODULEMD_YAML_ERROR,
-            MMD_YAML_ERROR_OPEN,
+            event,
             "Invalid YAML"
           );
-          /* Detailed error? */
-          return FALSE;
         }
       if (event.type != YAML_DOCUMENT_START_EVENT) {
         {
-          g_set_error_literal (
+          MMD_YAML_ERROR_EVENT_EXIT_BOOL (
             error,
-            MODULEMD_YAML_ERROR,
-            MMD_YAML_ERROR_OPEN,
+            event,
             "YAML parser could not find a start of a YAML document"
           );
-          /* Detailed error? */
-          return FALSE;
         }
       }
       yaml_event_delete (&event);
@@ -290,24 +278,19 @@ parse_file (const gchar *filename, GPtrArray **failures, GError **error)
       /* Check for a garbage past the first document */
       if (!yaml_parser_parse (&parser, &event))
         {
-          g_set_error_literal (
+          MMD_YAML_ERROR_EVENT_EXIT_BOOL (
             error,
-            MODULEMD_YAML_ERROR,
-            MMD_YAML_ERROR_UNPARSEABLE,
+            event,
             "Invalid YAML after first document"
           );
-          /* Detailed error? */
-          return FALSE;
         }
       if (event.type != YAML_STREAM_END_EVENT) {
         {
-          g_set_error_literal (
+          MMD_YAML_ERROR_EVENT_EXIT_BOOL (
             error,
-            MODULEMD_YAML_ERROR,
-            MMD_YAML_ERROR_PARSE,
+            event,
             "Another YAML document after the first one"
           );
-          /* Detailed error? */
           return FALSE;
         }
       }

--- a/modulemd/modulemd-yaml-util.c
+++ b/modulemd/modulemd-yaml-util.c
@@ -453,7 +453,8 @@ modulemd_yaml_parse_uint64 (yaml_parser_t *parser, GError **error)
 
   g_debug ("Parsing scalar: %s", (const gchar *)event.data.scalar.value);
 
-  value = g_ascii_strtoull ((const gchar *)event.data.scalar.value, &endptr, 10);
+  value =
+    g_ascii_strtoull ((const gchar *)event.data.scalar.value, &endptr, 10);
 
   if (value == G_MAXUINT64 && errno == ERANGE)
     {
@@ -477,7 +478,7 @@ modulemd_yaml_parse_uint64 (yaml_parser_t *parser, GError **error)
     }
 
   if ((value == 0u && endptr == (gchar *)event.data.scalar.value) ||
-          *endptr != '\0')
+      *endptr != '\0')
     {
       g_set_error (error,
                    MODULEMD_YAML_ERROR,

--- a/modulemd/tests/test_data/bad_packager_v2.yaml
+++ b/modulemd/tests/test_data/bad_packager_v2.yaml
@@ -5,6 +5,5 @@ data:
   summary: Trivial Summary
   description: >-
     Trivial Description
-  license:
-    invalid: [MIT]
+  #license: a missing license breaks validity
 ...

--- a/modulemd/tests/test_data/bad_packager_v2.yaml
+++ b/modulemd/tests/test_data/bad_packager_v2.yaml
@@ -1,0 +1,10 @@
+---
+document: modulemd-packager
+version: 2
+data:
+  summary: Trivial Summary
+  description: >-
+    Trivial Description
+  license:
+    invalid: [MIT]
+...

--- a/modulemd/tests/test_data/bad_packager_v3.yaml
+++ b/modulemd/tests/test_data/bad_packager_v3.yaml
@@ -1,0 +1,14 @@
+---
+document: modulemd-packager
+version: 3
+data:
+  name: trivialname
+  stream: trivialstream
+  summary: Trivial Summary
+  description: >-
+    Trivial Description
+  license: [MIT]
+  configurations:
+    - context: a2345678901
+      platform: foo
+...

--- a/modulemd/tests/test_data/bad_stream_v1.yaml
+++ b/modulemd/tests/test_data/bad_stream_v1.yaml
@@ -8,5 +8,8 @@ data:
   description: >-
     Trivial Description
   license:
-    invalid: [MIT]
+    module: [MIT]
+  artifacts:
+    rpms:
+    - "MissingEpoch-0-0.src"
 ...

--- a/modulemd/tests/test_data/bad_stream_v1.yaml
+++ b/modulemd/tests/test_data/bad_stream_v1.yaml
@@ -1,0 +1,12 @@
+---
+document: modulemd
+version: 1
+data:
+  name: trivialname
+  stream: trivialstream
+  summary: Trivial Summary
+  description: >-
+    Trivial Description
+  license:
+    invalid: [MIT]
+...

--- a/modulemd/tests/test_data/bad_stream_v2.yaml
+++ b/modulemd/tests/test_data/bad_stream_v2.yaml
@@ -1,0 +1,14 @@
+---
+document: modulemd
+version: 2
+data:
+  name: trivialname
+  stream: trivialstream
+  summary: Trivial Summary
+  description: >-
+    Trivial Description
+  license:
+    module: [MIT]
+  static_context: true
+  context: '-'
+...

--- a/modulemd/tests/test_data/bad_translations_v1.yaml
+++ b/modulemd/tests/test_data/bad_translations_v1.yaml
@@ -1,0 +1,7 @@
+document: modulemd-translations
+version: 1
+data:
+    module: foo
+    stream: bar
+    modified: 42invalid
+    translations:

--- a/modulemd/tests/test_data/invalid_defaults.yaml
+++ b/modulemd/tests/test_data/invalid_defaults.yaml
@@ -1,0 +1,5 @@
+document: modulemd-defaults
+version: 1
+data:
+    module: foo
+    modified: 42invalid

--- a/modulemd/tests/test_data/invalid_obsoletes_v1.yaml
+++ b/modulemd/tests/test_data/invalid_obsoletes_v1.yaml
@@ -1,0 +1,8 @@
+---
+document: modulemd-obsoletes
+version: 1
+data:
+    module: foo
+    stream: '42'
+    modified: 1970-01-01T00:00Z
+    # message: a missing message breaks validity

--- a/modulemd/tests/test_data/valid_defaults_with_garbage.yaml
+++ b/modulemd/tests/test_data/valid_defaults_with_garbage.yaml
@@ -1,0 +1,7 @@
+document: modulemd-defaults
+version: 1
+data:
+    module: foo
+    modified: 42
+...
+garbage

--- a/modulemd/tests/test_data/valid_defaults_with_unexpected_document.yaml
+++ b/modulemd/tests/test_data/valid_defaults_with_unexpected_document.yaml
@@ -1,0 +1,7 @@
+document: modulemd-defaults
+version: 1
+data:
+    module: foo
+    modified: 42
+...
+garbage


### PR DESCRIPTION
modulemd-validator tool was a tiny wrapper around loading documents into a modulemd index. However, the index does not support modulemd-packager document type and it automatically converts some formats (modulemd-v1, modulemd-packager-v2) into more advanced formats. As a result, it was not possible to validate modulemd-packager-v3 format and enforce document types. Reported in <https://bugzilla.redhat.com/show_bug.cgi?id=1947077>.

This patch set address these problem by introducing a new --type option which enforced a given document type for the validation. Because most of the required functions are not exposed in modulemd's public API, the tool extensively builds on private functions. Alternative solution in which the API would open more or be enhanced was postponed at this moment.

This parch set also adds an extensive test suite for modulemd-validator and fixes a lax parsing of unsigned 64-bit integers in a library (e.g. "42blah" module version was erroneously accepted).

The new --type option supports single-document YAML files now. This deficiency and a current error messaging will be improved in the future.