### PR TITLE
Reject invalid values when parsing integers

### DIFF
--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -355,6 +355,7 @@ c_tests = {
 'module_index_merger' : [ 'tests/test-modulemd-merger.c' ],
 'modulestream'        : [ 'tests/test-modulemd-modulestream.c' ],
 'packagerv3'          : [ 'tests/test-modulemd-packager-v3.c' ],
+'parse_int64'         : [ 'tests/test-modulemd-parse_int64.c' ],
 'profile'             : [ 'tests/test-modulemd-profile.c' ],
 'rpm_map'             : [ 'tests/test-modulemd-rpmmap.c' ],
 'service_level'       : [ 'tests/test-modulemd-service-level.c' ],

--- a/modulemd/modulemd-yaml-util.c
+++ b/modulemd/modulemd-yaml-util.c
@@ -453,6 +453,17 @@ modulemd_yaml_parse_uint64 (yaml_parser_t *parser, GError **error)
 
   g_debug ("Parsing scalar: %s", (const gchar *)event.data.scalar.value);
 
+  /* g_ascii_strtoull() accepts negative values by definition. */
+  if (event.data.scalar.value[0] == '-')
+    {
+      g_set_error (error,
+                   MODULEMD_YAML_ERROR,
+                   MODULEMD_ERROR_VALIDATE,
+                   "%s: The integer value is negative",
+                   (const gchar *)event.data.scalar.value);
+      return 0u;
+    }
+
   value =
     g_ascii_strtoull ((const gchar *)event.data.scalar.value, &endptr, 10);
 

--- a/modulemd/tests/test-modulemd-parse_int64.c
+++ b/modulemd/tests/test-modulemd-parse_int64.c
@@ -1,0 +1,90 @@
+/*
+ * This file is part of libmodulemd
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Fedora-License-Identifier: MIT
+ * SPDX-2.0-License-Identifier: MIT
+ * SPDX-3.0-License-Identifier: MIT
+ *
+ * This program is free software.
+ * For more information on the license, see COPYING.
+ * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
+ */
+
+#include <glib.h>
+#include <locale.h>
+#include <string.h>
+
+#include "private/modulemd-yaml.h"
+#include "private/test-utils.h"
+#include <yaml.h>
+
+static void
+utest (const char *input, guint64 expected_value, gboolean expected_error)
+{
+  guint64 parsed;
+  g_autoptr (GError) error = NULL;
+  MMD_INIT_YAML_EVENT (event);
+  MMD_INIT_YAML_PARSER (parser);
+
+  yaml_parser_set_input_string (
+    &parser, (const unsigned char *)input, strlen (input));
+  parser_skip_document_start (&parser);
+
+  parsed = modulemd_yaml_parse_uint64 (&parser, &error);
+  if (expected_error)
+    g_assert_nonnull (error);
+  else
+    g_assert_null (error);
+  g_assert_cmpuint (parsed, ==, expected_value);
+}
+
+static void
+test_uint64_valid (void)
+{
+  utest ("42", 42u, FALSE);
+}
+
+static void
+test_uint64_invalid_no_digit (void)
+{
+  utest ("foo", 0u, TRUE);
+}
+
+static void
+test_uint64_invalid_incomplete (void)
+{
+  utest ("42foo", 0u, TRUE);
+}
+
+static void
+test_uint64_invalid_negative (void)
+{
+  utest ("-42", 0u, TRUE);
+}
+
+static void
+test_uint64_invalid_too_big (void)
+{
+  utest ("18446744073709551616", 0u, TRUE);
+}
+
+
+int
+main (int argc, char *argv[])
+{
+  setlocale (LC_ALL, "");
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/modulemd/v2/uint64/yaml/parse/valid", test_uint64_valid);
+  g_test_add_func ("/modulemd/v2/uint64/yaml/parse/invalid_no_digit",
+                   test_uint64_invalid_no_digit);
+  g_test_add_func ("/modulemd/v2/uint64/yaml/parse/invalid_incomplete",
+                   test_uint64_invalid_incomplete);
+  g_test_add_func ("/modulemd/v2/uint64/yaml/parse/invalid_negative",
+                   test_uint64_invalid_negative);
+  g_test_add_func ("/modulemd/v2/uint64/yaml/parse/invalid_too_big",
+                   test_uint64_invalid_too_big);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
This adds a thorough tests for parsing signed and unsigned 64-bit integers and fixes the code accordingly.

Unsigned integers were already fixed in a previous commit 351c26537adbd792ec88d2074891cef92716ad28. The only corner case were negative values. Glib for some reason silently wraps negative values.