### PR TITLE
CI: Replace Mageia 7 with Mageia 8

### DIFF
--- a/.ci/ci-mageia.sh
+++ b/.ci/ci-mageia.sh
@@ -8,7 +8,7 @@ source $SCRIPT_DIR/ci-common.inc
 set -e
 set -x
 
-release=${1:-7}
+release=${1:-8}
 
 mmd_run_docker_tests \
     os=mageia \

--- a/.ci/mageia/Dockerfile.deps.tmpl
+++ b/.ci/mageia/Dockerfile.deps.tmpl
@@ -24,7 +24,7 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
 	openssl \
 	pkgconf \
 	popt-devel \
-	python2-six \
+	python3-six \
 	python3-autopep8 \
 	python3-devel \
 	python3-gitpython \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -281,12 +281,12 @@ jobs:
           meson test -C ci_valgrind --suite ci_valgrind --print-errorlogs -t 10
             --wrap=$GITHUB_WORKSPACE/contrib/valgrind/valgrind_wrapper.sh
 
-  mageia_7:
-    name: Mageia 7
+  mageia_8:
+    name: Mageia 8
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: docker.io/mageia:7
+      image: docker.io/library/mageia:8
 
     steps:
       - name: Install dependencies
@@ -313,7 +313,7 @@ jobs:
               openssl
               pkgconf
               popt-devel
-              python2-six
+              python3-six
               python3-autopep8
               python3-devel
               python3-gitpython


### PR DESCRIPTION
Mageia 7 ended on 2021-06-30. Mageia 8 removed python2-six package
<https://wiki.mageia.org/en/Mageia_8_Release_Notes#Python2_is_mostly_dead>.