### PR TITLE
tests: Use g_spawn_check_wait_status() if possible

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -105,6 +105,11 @@ has_extend_and_steal = cc.has_function(
     'g_ptr_array_extend_and_steal',
     dependencies : [ glib ])
 
+# Check whether we can use a new g_spawn_check_wait_status() from glib2.
+has_g_spawn_check_wait_status = cc.has_function(
+    'g_spawn_check_wait_status',
+    dependencies : [ glib ])
+
 with_py3 = get_option('with_py3')
 if with_py3
     if get_option('skip_introspection')

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -144,6 +144,7 @@ cdata.set('HAVE_RPMIO', rpm.found())
 cdata.set('HAVE_LIBMAGIC', magic.found())
 cdata.set('HAVE_GDATE_AUTOPTR', has_gdate_autoptr)
 cdata.set('HAVE_EXTEND_AND_STEAL', has_extend_and_steal)
+cdata.set('HAVE_G_SPAWN_CHECK_WAIT_STATUS', has_g_spawn_check_wait_status)
 configure_file(
   output : 'config.h',
   configuration : cdata

--- a/modulemd/tests/test-modulemd-validator.c
+++ b/modulemd/tests/test-modulemd-validator.c
@@ -11,6 +11,7 @@
  * For more information on free software, see <https://www.gnu.org/philosophy/free-sw.en.html>.
  */
 
+#include "config.h"
 #include <glib.h>
 #include <glib/gprintf.h>
 #include <stdlib.h>
@@ -133,7 +134,11 @@ test_exit_code (void)
 {
   g_autoptr (GError) error = NULL;
   g_autofree gchar *message = NULL;
+#ifdef HAVE_G_SPAWN_CHECK_WAIT_STATUS
+  g_spawn_check_wait_status (validator_exit_status, &error);
+#else
   g_spawn_check_exit_status (validator_exit_status, &error);
+#endif
   message = g_strdup_printf ("exit code was %d", expected_exit_code);
   if (0 == expected_exit_code)
     ok (!error, message);


### PR DESCRIPTION
glib2-2.69.0 deprecated g_spawn_check_exit_status() in favour of newly
added g_spawn_check_wait_status():

[82/85] Compiling C object modulemd/test-modulemd-validator.p/tests_test-modulemd-validator.c.o
../../home/test/libmodulemd-devel/modulemd/tests/test-modulemd-validator.c: In function ‘test_exit_code’:
../../home/test/libmodulemd-devel/modulemd/tests/test-modulemd-validator.c:136:3: warning: ‘g_spawn_check_exit_status’ is deprecated: Use 'g_spawn_check_wait_status' instead [-Wdeprecated-declarations]
  136 |   g_spawn_check_exit_status (validator_exit_status, &error);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/glib.h:81,
                 from ../../home/test/libmodulemd-devel/modulemd/tests/test-modulemd-validator.c:14:
/usr/include/glib-2.0/glib/gspawn.h:280:10: note: declared here
  280 | gboolean g_spawn_check_exit_status (gint      wait_status,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~

This patch uses the new function if it is available.

(It seems an explicit dependency on config.h for
test-modulemd-validator.c is not needed because meson automatically
adds all generated files as dependencies.)