### PR TITLE
Add centos-stream-9 to Packit configuration

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -21,3 +21,4 @@ jobs:
     - fedora-all
     - epel-7
     - epel-8
+    - centos-stream-9-x86_64


### PR DESCRIPTION
Test Packit with CentOS 9 Stream with this pull request.