### PR TITLE
modulemd-module: Document modulemd_module_get_defaults can return NULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,12 @@ specification for a full list of information that can be retrieved.
 ModulemdModule *module =
   modulemd_module_index_get_module (merged_index, "modulename");
 ModulemdDefaults *defaults = modulemd_module_get_defaults (module);
-printf ("Default stream for modulename is %s\n",
-        modulemd_defaults_v1_get_default_stream (
-          MODULEMD_DEFAULTS_V1 (defaults), NULL));
+if (defaults)
+  {
+    printf ("Default stream for modulename is %s\n",
+            modulemd_defaults_v1_get_default_stream (
+              MODULEMD_DEFAULTS_V1 (defaults), NULL));
+  }
 ```
 
 ## Python

--- a/modulemd/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module.h
@@ -285,7 +285,7 @@ modulemd_module_remove_streams_by_NSVCA (ModulemdModule *self,
  * modulemd_module_get_defaults:
  * @self: This #ModulemdModule object.
  *
- * Returns: (transfer none): The defaults of this module.
+ * Returns: (transfer none): The defaults of this module or NULL if none.
  *
  * Since: 2.0
  */

--- a/modulemd/include/modulemd-2.0/modulemd.h
+++ b/modulemd/include/modulemd-2.0/modulemd.h
@@ -128,9 +128,12 @@ G_BEGIN_DECLS
  * ModulemdModule *module =
  *   modulemd_module_index_get_module (merged_index, "modulename");
  * ModulemdDefaults *defaults = modulemd_module_get_defaults (module);
- * printf ("Default stream for modulename is %s\n",
- *         modulemd_defaults_v1_get_default_stream (
- *           MODULEMD_DEFAULTS_V1 (defaults), NULL));
+ * if (defaults)
+ *   {
+ *     printf ("Default stream for modulename is %s\n",
+ *             modulemd_defaults_v1_get_default_stream (
+ *               MODULEMD_DEFAULTS_V1 (defaults), NULL));
+ *   }
  * ]|
  *
  * In Python:


### PR DESCRIPTION
We weren't handling this properly in libdnf. Let's document it to make
it explicit.