### PR TITLE
modulemd-packager-v3: Reject duplicate context

### DIFF
--- a/modulemd/tests/test-modulemd-context.c
+++ b/modulemd/tests/test-modulemd-context.c
@@ -104,6 +104,34 @@ test_modulemd_v3_context_bad_underscore (void)
 
 
 static void
+test_modulemd_v3_context_duplicate (void)
+{
+  const gchar *yaml_string = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GObject) object = NULL;
+  GType type = G_TYPE_INVALID;
+
+  yaml_string =
+    "---\n"
+    "document: modulemd-packager\n"
+    "version: 3\n"
+    "data:\n"
+    "  name: foo\n"
+    "  stream: bar\n"
+    "  license: [MIT]\n"
+    "  configurations:\n"
+    "    - context: A\n"
+    "      platform: 1\n"
+    "    - context: A\n"
+    "      platform: 2\n"
+    "...\n";
+  type = modulemd_read_packager_string (yaml_string, &object, &error);
+  g_assert_true (type == G_TYPE_INVALID);
+  g_assert_error (error, MODULEMD_ERROR, MMD_ERROR_VALIDATE);
+}
+
+
+static void
 test_modulemd_v2_context_valid (void)
 {
   const gchar *yaml_string = NULL;
@@ -214,6 +242,8 @@ main (int argc, char *argv[])
                    test_modulemd_v3_context_overlong);
   g_test_add_func ("/modulemd/v3/context/bad_underscore",
                    test_modulemd_v3_context_bad_underscore);
+  g_test_add_func ("/modulemd/v3/context/duplicate",
+                   test_modulemd_v3_context_duplicate);
 
   g_test_add_func ("/modulemd/v2/context/valid",
                    test_modulemd_v2_context_valid);


### PR DESCRIPTION
A specification requires modulemd-packager-v3 documents to have
context values unique among all configurations:

document: modulemd-packager
version: 3
data:
  name: foo
  stream: bar
  license: [MIT]
  configurations:
    - context: A
      platform: 1
    - context: A
      platform: 2

That was not enforced and previous configurations were swallowed by the last
one.

This patch fixes it.

I was tempting to augment modulemd_packager_v3_add_build_config(), but
that cannot change a prototype because it's passed to
COPY_HASHTABLE_BY_VALUE_ADDER(). A wrapper for an error-returning
variant would be too cluttery and glib < 2.40 does not report
a replacement. Next, augmenting modulemd_build_config_parse_yaml()
would bring the benefit of reporting a line number, but feeding
a packager object down to the YAML parser would be against separating
a data flow. Thus I simply added a condition just before calling
modulemd_packager_v3_add_build_config().