### PR TITLE
Specification: Document module version, buildorder, and epoch limits

### DIFF
--- a/yaml_specs/modulemd_packager_v2.yaml
+++ b/yaml_specs/modulemd_packager_v2.yaml
@@ -452,7 +452,7 @@ data:
                 # Multiple components can have the same buildorder index
                 # to map them into build groups.
                 # Defaults to zero.
-                # Integer, negative values are allowed.
+                # Integer, from an interval [-(2^63), +2^63-1].
                 # In this example, bar and baz are built first in no particular
                 # order, then tagged into the buildroot, then, finally, xxx is
                 # built.

--- a/yaml_specs/modulemd_packager_v3.yaml
+++ b/yaml_specs/modulemd_packager_v3.yaml
@@ -514,7 +514,7 @@ data:
                 # Multiple components can have the same buildorder index
                 # to map them into build groups.
                 # Defaults to zero.
-                # Integer, negative values are allowed.
+                # Integer, from an interval [-(2^63), +2^63-1].
                 # In this example, bar and baz are built first in no particular
                 # order, then tagged into the buildroot, then, finally, xxx is
                 # built.

--- a/yaml_specs/modulemd_stream_v1.yaml
+++ b/yaml_specs/modulemd_stream_v1.yaml
@@ -12,7 +12,7 @@ data:
     # Typically filled in by the buildsystem, using the VCS branch name
     # as the name of the stream.
     stream: "stream-name"
-    # Module version, integer, optional, cannot be negative
+    # Module version, a 64-bit unsigned integer, optional,
     # Typically filled in by the buildsystem, using the VCS commit
     # timestamp.  Module version defines upgrade path for the particular
     # update stream.
@@ -246,7 +246,7 @@ data:
                 # Multiple components can have the same buildorder index
                 # to map them into build groups.
                 # Optional, defaults to zero.
-                # Integer, negative values are allowed.
+                # Integer, from an interval [-(2^63), +2^63-1].
                 # In this example, bar, baz and xxx are built first in
                 # no particular order, then tagged into the buildroot,
                 # then, finally, xyz is built.

--- a/yaml_specs/modulemd_stream_v2.yaml
+++ b/yaml_specs/modulemd_stream_v2.yaml
@@ -62,7 +62,7 @@ data:
     stream: "latest"
 
     # version:
-    # Module version, integer, cannot be negative
+    # Module version, 64-bit unsigned integer
     # If this value is unset (or set to zero), it will be filled in by the
     # buildsystem, using the VCS commit timestamp.  Module version defines the
     # upgrade path for the particular update stream.
@@ -610,7 +610,7 @@ data:
                 # Multiple components can have the same buildorder index
                 # to map them into build groups.
                 # Defaults to zero.
-                # Integer, negative values are allowed.
+                # Integer, from an interval [-(2^63), +2^63-1].
                 # In this example, bar, baz and xxx are built first in
                 # no particular order, then tagged into the buildroot,
                 # then, finally, xyz is built.
@@ -709,6 +709,7 @@ data:
 
               # epoch:
               # The RPM epoch.
+              # A 32-bit unsigned integer.
               #
               # Type: OPTIONAL
               epoch: 0


### PR DESCRIPTION
libmodulemd's code stores all integers into 64-bit types.

RPM epoch is limited by RPM which currently does not accept more than
32-bit values. We document it but do not enforce it.

https://github.com/fedora-modularity/libmodulemd/issues/578