### PR TITLE
Replace assertRaisesRegexp() with assertRaisesRegex()

### DIFF
--- a/modulemd/tests/ModulemdTests/base.py
+++ b/modulemd/tests/ModulemdTests/base.py
@@ -56,3 +56,26 @@ class TestBase(unittest.TestCase):
     def warnings_fatal(self):
         gdebug = os.getenv("G_DEBUG", "").split(",")
         return "fatal-warnings" in gdebug
+
+    def assertRaisesRegex(
+        self, expected_exception, expected_regex, *args, **kwargs
+    ):
+        """Asserts that the message in a raised exception matches a regex.
+
+        Args:
+            expected_exception: Exception class expected to be raised.
+            expected_regex: Regex (re.Pattern object or string) expected
+                    to be found in error message.
+            args: Function to be called and extra positional args.
+            kwargs: Extra kwargs.
+            msg: Optional message used in case of failure. Can only be used
+                    when assertRaisesRegex is used as a context manager.
+        """
+        try:
+            return super().assertRaisesRegex(
+                expected_exception, expected_regex, *args, **kwargs
+            )
+        except AttributeError:
+            return super().assertRaisesRegexp(
+                expected_exception, expected_regex, *args, **kwargs
+            )

--- a/modulemd/tests/ModulemdTests/defaults.py
+++ b/modulemd/tests/ModulemdTests/defaults.py
@@ -42,25 +42,25 @@ class TestDefaults(TestBase):
         assert defs.get_module_name() == "foo"
 
         # Test that we cannot instantiate directly
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             TypeError, "cannot create instance of abstract"
         ):
             Modulemd.Defaults()
 
         # Test with a zero mdversion
-        with self.assertRaisesRegexp(TypeError, "constructor returned NULL"):
+        with self.assertRaisesRegex(TypeError, "constructor returned NULL"):
             with self.expect_signal():
                 defs = Modulemd.Defaults.new(0, "foo")
 
         # Test with an unknown mdversion
-        with self.assertRaisesRegexp(TypeError, "constructor returned NULL"):
+        with self.assertRaisesRegex(TypeError, "constructor returned NULL"):
             with self.expect_signal():
                 defs = Modulemd.Defaults.new(
                     Modulemd.DefaultsVersionEnum.LATEST + 1, "foo"
                 )
 
         # Test with no name
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             TypeError, "does not allow None as a value"
         ):
             defs = Modulemd.Defaults.new(
@@ -86,7 +86,7 @@ class TestDefaults(TestBase):
         assert defs.get_mdversion() == Modulemd.DefaultsVersionEnum.ONE
 
         # Ensure we cannot set the mdversion
-        with self.assertRaisesRegexp(TypeError, "is not writable"):
+        with self.assertRaisesRegex(TypeError, "is not writable"):
             defs.props.mdversion = 0
 
     def test_module_name(self):

--- a/modulemd/tests/ModulemdTests/defaultsv1.py
+++ b/modulemd/tests/ModulemdTests/defaultsv1.py
@@ -47,7 +47,7 @@ class TestDefaults(TestBase):
         assert defs.get_module_name() == "foo"
 
         # Test with no name
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             TypeError, "does not allow None as a value"
         ):
             defs = Modulemd.DefaultsV1.new(None)

--- a/modulemd/tests/ModulemdTests/merger.py
+++ b/modulemd/tests/ModulemdTests/merger.py
@@ -276,7 +276,7 @@ data:
             index.update_from_string(default, strict=True)
             merger.associate_index(index, 0)
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             gi.repository.GLib.GError,
             "Default stream mismatch in module python",
         ):

--- a/modulemd/tests/ModulemdTests/moduleindex.py
+++ b/modulemd/tests/ModulemdTests/moduleindex.py
@@ -99,7 +99,7 @@ profiles:
         mod_foo = idx.get_module("foo")
         self.assertTrue(mod_foo.validate())
         self.assertEqual(mod_foo.get_module_name(), "foo")
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             gi.repository.GLib.GError, "No streams matched"
         ):
             mod_foo.get_stream_by_NSVCA("a", 5, "c")
@@ -147,7 +147,7 @@ profiles:
     def test_dump_empty_index(self):
         idx = Modulemd.ModuleIndex.new()
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             gi.repository.GLib.GError, "Index contains no modules."
         ):
             yaml = idx.dump_to_string()
@@ -208,7 +208,7 @@ profiles:
         self.assertIn("teststream", defs["testmodule"])
 
         # Nonexistent defaults dir
-        with self.assertRaisesRegexp(GLib.Error, "No such file or directory"):
+        with self.assertRaisesRegex(GLib.Error, "No such file or directory"):
             ret = idx.update_from_defaults_directory(
                 path=path.join(self.test_data_path, "defaults_nonexistent"),
                 strict=True,
@@ -216,7 +216,7 @@ profiles:
             self.assertFalse(ret)
 
         # Nonexistent override dir
-        with self.assertRaisesRegexp(GLib.Error, "No such file or directory"):
+        with self.assertRaisesRegex(GLib.Error, "No such file or directory"):
             ret = idx.update_from_defaults_directory(
                 path=path.join(self.test_data_path, "defaults"),
                 overrides_path="overrides_nonexistent",

--- a/modulemd/tests/ModulemdTests/modulestream.py
+++ b/modulemd/tests/ModulemdTests/modulestream.py
@@ -98,18 +98,18 @@ class TestModuleStream(TestBase):
             assert stream.get_stream_name() is None
 
         # Test that we cannot instantiate directly
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             TypeError, "cannot create instance of abstract"
         ):
             Modulemd.ModuleStream()
 
         # Test with a zero mdversion
-        with self.assertRaisesRegexp(TypeError, "constructor returned NULL"):
+        with self.assertRaisesRegex(TypeError, "constructor returned NULL"):
             with self.expect_signal():
                 defs = Modulemd.ModuleStream.new(0)
 
         # Test with an unknown mdversion
-        with self.assertRaisesRegexp(TypeError, "constructor returned NULL"):
+        with self.assertRaisesRegex(TypeError, "constructor returned NULL"):
             with self.expect_signal():
                 defs = Modulemd.ModuleStream.new(
                     Modulemd.ModuleStreamVersionEnum.LATEST + 1
@@ -1273,7 +1273,7 @@ data:
 
             # Should fail validation if both buildorder and buildafter are set for
             # the same component.
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 gi.repository.GLib.GError,
                 "Cannot mix buildorder and buildafter",
             ):
@@ -1285,7 +1285,7 @@ data:
 
             # Should fail validation if both buildorder and buildafter are set in
             # different components of the same stream.
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 gi.repository.GLib.GError,
                 "Cannot mix buildorder and buildafter",
             ):
@@ -1297,7 +1297,7 @@ data:
 
             # Should fail if a key specified in a buildafter set does not exist
             # for this module stream.
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 gi.repository.GLib.GError, "not found in components list"
             ):
                 stream = Modulemd.ModuleStream.read_file(

--- a/modulemd/tests/ModulemdTests/rpmmap.py
+++ b/modulemd/tests/ModulemdTests/rpmmap.py
@@ -64,7 +64,7 @@ class TestRpmMapEntry(TestBase):
 
         # Remove name
         entry2.props.name = None
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             gi.repository.GLib.GError, "Missing name attribute"
         ):
             entry2.validate()
@@ -73,7 +73,7 @@ class TestRpmMapEntry(TestBase):
 
         # Remove the version
         entry2.props.version = None
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             gi.repository.GLib.GError, "Missing version attribute"
         ):
             entry2.validate()
@@ -82,7 +82,7 @@ class TestRpmMapEntry(TestBase):
 
         # Remove the release
         entry2.props.release = None
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             gi.repository.GLib.GError, "Missing release attribute"
         ):
             entry2.validate()
@@ -91,7 +91,7 @@ class TestRpmMapEntry(TestBase):
 
         # Remove the arch
         entry2.props.arch = None
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             gi.repository.GLib.GError, "Missing arch attribute"
         ):
             entry2.validate()


### PR DESCRIPTION
Python 3.11 has dropped this previously-deprecated function.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>