### PR TITLE
Add support for stripping XMD from an Index

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-module-index.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-index.h
@@ -667,4 +667,19 @@ modulemd_module_index_upgrade_defaults (ModulemdModuleIndex *self,
                                         GError **error);
 
 
+/**
+ * modulemd_module_index_clear_xmds:
+ * @self: This #ModulemdModuleIndex object.
+ *
+ * Iterates through all #ModulemdModuleStream entries in this
+ * #ModulemdModuleIndex and removes any XMD sections that are present. This is
+ * generally done to trim down the metadata to only the portions that are
+ * useful to the package manager.
+ *
+ * Since: 2.14.0
+ */
+void
+modulemd_module_index_clear_xmds (ModulemdModuleIndex *self);
+
+
 G_END_DECLS

--- a/modulemd/include/modulemd-2.0/modulemd-module-stream-v2.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module-stream-v2.h
@@ -960,6 +960,16 @@ modulemd_module_stream_v2_get_xmd (ModulemdModuleStreamV2 *self);
 
 
 /**
+ * modulemd_module_stream_v2_clear_xmd:
+ * @self: (in): This #ModulemdModuleStreamV2 object.
+ *
+ * Removes all XMD data from this #ModulemdModuleStreamV2
+ */
+void
+modulemd_module_stream_v2_clear_xmd (ModulemdModuleStreamV2 *self);
+
+
+/**
  * modulemd_module_stream_v2_set_static_context:
  * @self: (in): This #ModulemdModuleStreamV2 object.
  *

--- a/modulemd/include/modulemd-2.0/modulemd-module.h
+++ b/modulemd/include/modulemd-2.0/modulemd-module.h
@@ -336,4 +336,20 @@ modulemd_module_get_newest_active_obsoletes (ModulemdModule *self,
                                              const gchar *stream,
                                              const gchar *context);
 
+
+/**
+ * modulemd_module_clear_xmds:
+ * @self: (in): This #ModulemdModule object.
+ *
+ * Iterates through all #ModulemdModuleStream entries in this
+ * #ModulemdModule and removes any XMD sections that are present. This is
+ * generally done to trim down the metadata to only the portions that are
+ * useful to the package manager.
+ *
+ * Since: 2.14.0
+ */
+void
+modulemd_module_clear_xmds (ModulemdModule *self);
+
+
 G_END_DECLS

--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -1439,6 +1439,26 @@ modulemd_module_index_add_translation (ModulemdModuleIndex *self,
 }
 
 
+static void
+clear_xmds (gpointer key, gpointer value, gpointer user_data)
+{
+  MODULEMD_INIT_TRACE ();
+
+  g_return_if_fail (MODULEMD_IS_MODULE (value));
+
+  modulemd_module_clear_xmds (MODULEMD_MODULE (value));
+}
+
+
+void
+modulemd_module_index_clear_xmds (ModulemdModuleIndex *self)
+{
+  MODULEMD_INIT_TRACE ();
+
+  g_hash_table_foreach (self->modules, clear_xmds, NULL);
+}
+
+
 gboolean
 modulemd_module_index_merge (ModulemdModuleIndex *from,
                              ModulemdModuleIndex *into,

--- a/modulemd/modulemd-module-stream-v2.c
+++ b/modulemd/modulemd-module-stream-v2.c
@@ -1263,6 +1263,15 @@ modulemd_module_stream_v2_get_xmd (ModulemdModuleStreamV2 *self)
 }
 
 
+void
+modulemd_module_stream_v2_clear_xmd (ModulemdModuleStreamV2 *self)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (self));
+
+  g_clear_pointer (&self->xmd, g_variant_unref);
+}
+
+
 gboolean
 modulemd_module_stream_v2_includes_nevra (ModulemdModuleStreamV2 *self,
                                           const gchar *nevra_pattern)

--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -1088,3 +1088,23 @@ modulemd_module_get_newest_active_obsoletes (ModulemdModule *self,
 
   return newestActiveObsoletes;
 }
+
+
+static void
+clear_xmds (gpointer data, gpointer user_data)
+{
+  g_return_if_fail (MODULEMD_IS_MODULE_STREAM_V2 (data));
+
+  modulemd_module_stream_v2_clear_xmd (MODULEMD_MODULE_STREAM_V2 (data));
+}
+
+
+void
+modulemd_module_clear_xmds (ModulemdModule *self)
+{
+  MODULEMD_INIT_TRACE ();
+
+  g_return_if_fail (MODULEMD_IS_MODULE (self));
+
+  g_ptr_array_foreach (self->streams, clear_xmds, NULL);
+}


### PR DESCRIPTION
By specification, the XMD contents are not meant to be used by
consumers. This will provide a simple method of stripping that content
out from the metadata of all streams.

This could be used to sanitize the module metadata prior to including it
in a composed RPM repository.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>