### PR TITLE
Update libmodulemd.spec

### DIFF
--- a/fedora/libmodulemd.spec
+++ b/fedora/libmodulemd.spec
@@ -48,7 +48,7 @@ BuildRequires:  python%{python3_pkgversion}-gobject-base
 
 %description
 C Library for manipulating module metadata files.
-See https://github.com/fedora-modularity/libmodulemd/blob/master/README.md for
+See https://github.com/fedora-modularity/libmodulemd/blob/main/README.md for
 more details.
 
 


### PR DESCRIPTION
The "master" branch is no longer the default branch for libmodulemd, which means the description of the package now contains a broken link. Branch "master" has been replaced by "main" as the default branch.