### PR TITLE
Fix a crash when converting a modulemd-packager with a default profile without a module name or stream

### DIFF
--- a/modulemd/include/modulemd-2.0/modulemd-packager-v3.h
+++ b/modulemd/include/modulemd-2.0/modulemd-packager-v3.h
@@ -813,7 +813,8 @@ modulemd_packager_v3_get_rpm_component (ModulemdPackagerV3 *self,
  * containing a set of one or more #ModulemdModuleStreamV2 objects and possibly
  * a #ModulemdDefaults object corresponding to the #ModulemdPackagerV3 object
  * @self. NULL if there was an error doing the mapping and sets @error
- * appropriately.
+ * appropriately. One of the errors is missing a module name or a stream name
+ * if a default profile is present.
  *
  * Since: 2.11
  */

--- a/modulemd/modulemd-packager-v3.c
+++ b/modulemd/modulemd-packager-v3.c
@@ -825,6 +825,28 @@ modulemd_packager_v3_to_defaults (ModulemdPackagerV3 *self,
       profile = MODULEMD_PROFILE (value);
       if (modulemd_profile_is_default (profile))
         {
+          if (!self->module_name)
+            {
+              g_set_error (
+                error,
+                MODULEMD_ERROR,
+                MMD_ERROR_MISSING_REQUIRED,
+                "A module name is required when generating "
+                "a modulemd-defaults document for a default profile %s",
+                modulemd_profile_get_name (profile));
+              return FALSE;
+            }
+          if (!self->stream_name)
+            {
+              g_set_error (
+                error,
+                MODULEMD_ERROR,
+                MMD_ERROR_MISSING_REQUIRED,
+                "A module stream is required when generating "
+                "a modulemd-defaults document for a default profile %s",
+                modulemd_profile_get_name (profile));
+              return FALSE;
+            }
           if (!defaults)
             {
               defaults = modulemd_defaults_v1_new (self->module_name);


### PR DESCRIPTION
modulemd_packager_v3_convert_to_index() called on a ModulemdPackagerV3
object with an automatic name or a stream and with a default profile
aborted:

~~~~
        (process:41508): libmodulemd-CRITICAL **: 14:54:41.578: modulemd_defaults_set_module_name: assertion 'module_name' failed

        (process:41508): libmodulemd-CRITICAL **: 14:54:41.578: modulemd_defaults_v1_add_default_profile_for_stream: assertion 'stream_name' failed
        Neoprávněný přístup do paměti (SIGSEGV) (core dumped [obraz paměti uložen])
~~~~

That's because a default profile is converted to the index as a
ModulemdDefaultsV1 object and that object requires the modules name and stream.

This patch fixes it by returning a proper error. It also amends
a documentation for modulemd_packager_v3_convert_to_index() so that
users are aware of the requirements.