### PR TITLE
ci: Update OpenSUSE and disable Mandriva and Arch

### DIFF
--- a/.ci/opensuse/Dockerfile.deps.tmpl
+++ b/.ci/opensuse/Dockerfile.deps.tmpl
@@ -35,8 +35,4 @@ RUN zypper install --no-confirm --no-recommends --capability \
     sudo \
     valgrind
 
-# Install glib2-doc by a package name (glib2-devel erroneously provides glib2-doc)
-RUN zypper install --no-confirm --no-recommends glib2-doc \
-&& zypper clean --all
-
 RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,6 +257,9 @@ jobs:
 
   archlinux:
     name: Arch Linux
+    # Disabled because glib2-2.70 built with capabilities breaks g_spawn_sync()
+    # used in modulemd_validator tests <https://bugs.archlinux.org/task/74037>.
+    if: false
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
@@ -446,6 +449,10 @@ jobs:
 
   mandriva:
     name: OpenMandriva Cooker
+    # Disabled because of broken glib2 (gmodule-no-export-2.0.pc lists -pthread
+    # linker flag, but glibc does not package a standalone pthread library)
+    # <https://github.com/OpenMandrivaAssociation/distribution/issues/2698>.
+    if: false
     runs-on: ubuntu-latest
     continue-on-error: true
     container:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -419,10 +419,6 @@ jobs:
                  sudo
                  valgrind
 
-      - name: Install glib2-doc by a package name (glib2-devel erroneously provides glib2-doc)
-        run:
-            zypper install --no-confirm --no-recommends glib2-doc
-
       - name: Checkout code
         uses: actions/checkout@v2
 


### PR DESCRIPTION
OpenSUSE fixed a packaging bug. A work around removed.
Mandriva and Arch have long standing bugs. Disabling them for now.