### PR TITLE
ci: Enable tests on Arch without seccomp

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,13 +257,14 @@ jobs:
 
   archlinux:
     name: Arch Linux
-    # Disabled because glib2-2.70 built with capabilities breaks g_spawn_sync()
-    # used in modulemd_validator tests <https://bugs.archlinux.org/task/74037>.
-    if: false
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
       image: docker.io/library/archlinux:base
+      # Disable seccomp until a container manager in GitHub recognizes
+      # clone3() syscall,
+      # <https://github.com/actions/virtual-environments/issues/3812>.
+      options: --security-opt seccomp=unconfined
 
     steps:
       - name: Install the standard pacman config


### PR DESCRIPTION
It does not fail locally with Fedora host.