### PR TITLE
CI: Mark $GITHUB_WORKSPACE directory safe for git

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,7 @@ jobs:
       - name: Build the RPM repository
         working-directory: ${{github.workspace}}/rpmbuild/RPMS
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           packit --debug local-build ../..
           createrepo_c x86_64
 
@@ -227,6 +228,7 @@ jobs:
       - name: Build the RPM repository
         working-directory: ${{github.workspace}}/rpmbuild/RPMS
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           packit --debug local-build ../..
           createrepo_c x86_64
 


### PR DESCRIPTION
git addressed CVE-2022-24765 by refusing to process a git repository
configuration file if the repository is owned by a different user.

That broke CI on GitHub which uses a different user for checking out
and for running the tests. actions/checkout worked around it for
itself, but it reverts safe.directory git settings on exit.

Hence this patch fixes it by explicitly setting git option
safe.directory when a packit, which calls git, is called.

https://github.com/github-actions-x/commit/issues/30