### PR TITLE
CI: Arch: Install python-six instead of python2-six

### DIFF
--- a/.ci/archlinux/Dockerfile.deps.tmpl
+++ b/.ci/archlinux/Dockerfile.deps.tmpl
@@ -13,7 +13,7 @@ RUN pacman -Syu --needed --noconfirm \
     libyaml \
     meson \
     python-gobject \
-    python2-six \
+    python-six \
 && pacman -Scc --noconfirm
 
 RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; print(gi._overridesdir)")/Modulemd.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,7 +273,7 @@ jobs:
         run: cp /etc/pacman.conf.pacnew /etc/pacman.conf
 
       - name: Install dependencies
-        run: pacman -Syu --needed --noconfirm base-devel file git glib2 glib2-docs gobject-introspection gtk-doc jq libyaml meson python-gobject python2-six valgrind
+        run: pacman -Syu --needed --noconfirm base-devel file git glib2 glib2-docs gobject-introspection gtk-doc jq libyaml meson python-gobject python-six valgrind
 
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Arch removed python2-six package in favour of python-six. This patch adapts to it.

<https://github.com/archlinux/svntogit-packages/commit/c5eeff4728afc5d97a878957d9f0d5db71146a04>

Let Github exercise the tests to see how much Arch is broken.