### PR TITLE
Meson run_command and python search updates

### DIFF
--- a/bindings/python/meson.build
+++ b/bindings/python/meson.build
@@ -4,7 +4,8 @@ gobject_overrides_dir_py2 = get_option('gobject_overrides_dir_py2')
 # Python 3
 if with_py3
   if gobject_overrides_dir_py3 == ''
-    ret = run_command([python3, '-c', 'import gi; print(gi._overridesdir)'])
+    ret = run_command([python3, '-c', 'import gi; print(gi._overridesdir)'],
+      check: false)
 
     if ret.returncode() != 0
       error('Failed to determine Python 3 pygobject overridedir')
@@ -19,7 +20,8 @@ endif
 # Python 2
 if with_py2
   if gobject_overrides_dir_py2 == ''
-    ret2 = run_command([python2, '-c', 'import gi; print(gi._overridesdir)'])
+    ret2 = run_command([python2, '-c', 'import gi; print(gi._overridesdir)'],
+      check: false)
 
     if ret2.returncode() != 0
       error('Failed to determine Python 2 pygobject overridedir')

--- a/bindings/python/meson.build
+++ b/bindings/python/meson.build
@@ -8,7 +8,7 @@ if with_py3
       check: false)
 
     if ret.returncode() != 0
-      error('Failed to determine Python 3 pygobject overridedir')
+      error('Failed to determine Python 3 pygobject overridedir:', ret.stderr())
     else
       gobject_overrides_dir_py3 = ret.stdout().strip()
     endif
@@ -24,7 +24,7 @@ if with_py2
       check: false)
 
     if ret2.returncode() != 0
-      error('Failed to determine Python 2 pygobject overridedir')
+      error('Failed to determine Python 2 pygobject overridedir:', ret2.stderr())
     else
       gobject_overrides_dir_py2 = ret2.stdout().strip()
     endif

--- a/meson.build
+++ b/meson.build
@@ -129,6 +129,12 @@ if with_py3
         # Use the python installation that is running meson
         python3 = pymod.find_installation()
     endif
+
+    # Verify Python version <https://github.com/mesonbuild/meson/issues/11057>.
+    python3_version = python3.language_version()
+    if not python3_version.startswith('3.')
+      error('Python3 interpreter has an unexpected version:', python3_version)
+    endif
 else
     python3 = disabler()
 endif
@@ -139,6 +145,12 @@ if with_py2
         error('A Python2 binding requires a GObject introspection.')
     endif
     python2 = pymod.find_installation('python2')
+
+    # Verify Python version <https://github.com/mesonbuild/meson/issues/11057>.
+    python2_version = python2.language_version()
+    if not python2_version.startswith('2.')
+      error('Python2 interpreter has an unexpected version:', python2_version)
+    endif
 else
     python2 = disabler()
 endif

--- a/meson.build
+++ b/meson.build
@@ -69,16 +69,18 @@ if with_docs
   gtkdoc = dependency('gtk-doc')
   glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
 
-  ret = run_command ([test, '-e', join_paths(glib_docpath, 'glib/index.html')],
+  glib_index_path = join_paths(glib_docpath, 'glib/index.html')
+  ret = run_command ([test, '-e', glib_index_path],
     check: false)
   if ret.returncode() != 0
-    error('Missing documentation for GLib.')
+    error('Missing documentation for GLib:', glib_index_path)
   endif
 
-  ret = run_command ([test, '-e', join_paths(glib_docpath, 'gobject/index.html')],
+  gobject_index_path = join_paths(glib_docpath, 'gobject/index.html')
+  ret = run_command ([test, '-e', gobject_index_path],
     check: false)
   if ret.returncode() != 0
-    error('Missing documentation for GObject.')
+    error('Missing documentation for GObject:', gobject_index_path)
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -69,12 +69,14 @@ if with_docs
   gtkdoc = dependency('gtk-doc')
   glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
 
-  ret = run_command ([test, '-e', join_paths(glib_docpath, 'glib/index.html')])
+  ret = run_command ([test, '-e', join_paths(glib_docpath, 'glib/index.html')],
+    check: false)
   if ret.returncode() != 0
     error('Missing documentation for GLib.')
   endif
 
-  ret = run_command ([test, '-e', join_paths(glib_docpath, 'gobject/index.html')])
+  ret = run_command ([test, '-e', join_paths(glib_docpath, 'gobject/index.html')],
+    check: false)
   if ret.returncode() != 0
     error('Missing documentation for GObject.')
   endif


### PR DESCRIPTION
This patchset updates a meson build script to:

Verify python version
Report a cause of failures in glib-doc and gir overrides search
Pass an explicit check argument to run_command()

It makes the script more robust and failures more understandable.