### PR TITLE
Increase Meson version to 0.55 and remove deprecated meson functions

### DIFF
--- a/bindings/python/meson.build
+++ b/bindings/python/meson.build
@@ -8,7 +8,7 @@ if with_py3
       check: false)
 
     if ret.returncode() != 0
-      error('Failed to determine Python 3 pygobject overridedir:', ret.stderr())
+      error('Failed to determine Python 3 pygobject overridedir: @0@'.format(ret.stderr()))
     else
       gobject_overrides_dir_py3 = ret.stdout().strip()
     endif
@@ -24,7 +24,7 @@ if with_py2
       check: false)
 
     if ret2.returncode() != 0
-      error('Failed to determine Python 2 pygobject overridedir:', ret2.stderr())
+      error('Failed to determine Python 2 pygobject overridedir: @0@'.format(ret2.stderr()))
     else
       gobject_overrides_dir_py2 = ret2.stdout().strip()
     endif

--- a/fedora/libmodulemd.spec
+++ b/fedora/libmodulemd.spec
@@ -24,7 +24,7 @@ License:        MIT
 URL:            https://github.com/fedora-modularity/libmodulemd
 Source0:        %{url}/releases/download/%{upstream_name}-%{version}/modulemd-%{version}.tar.xz
 
-BuildRequires:  meson >= 0.47
+BuildRequires:  meson >= 0.55
 BuildRequires:  pkgconfig
 BuildRequires:  gcc
 BuildRequires:  gcc-c++

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ project(
 version : '2.14.1',
 default_options : ['buildtype=debugoptimized', 'c_std=c11', 'warning_level=1', 'b_asneeded=true'],
 license : 'MIT',
-meson_version : '>=0.47.0'
+meson_version : '>=0.55.0'
 )
 
 libmodulemd_version = meson.project_version()
@@ -58,7 +58,7 @@ rpm = dependency('rpm', required : with_rpmio)
 magic = cc.find_library('magic', required : with_libmagic)
 
 glib = dependency('glib-2.0')
-glib_prefix = glib.get_pkgconfig_variable('prefix')
+glib_prefix = glib.get_variable(pkgconfig: 'prefix')
 
 bash = find_program('bash')
 sed = find_program('sed')
@@ -73,14 +73,14 @@ if with_docs
   ret = run_command ([test, '-e', glib_index_path],
     check: false)
   if ret.returncode() != 0
-    error('Missing documentation for GLib:', glib_index_path)
+    error('Missing documentation for GLib: @0@'.format(glib_index_path))
   endif
 
   gobject_index_path = join_paths(glib_docpath, 'gobject/index.html')
   ret = run_command ([test, '-e', gobject_index_path],
     check: false)
   if ret.returncode() != 0
-    error('Missing documentation for GObject:', gobject_index_path)
+    error('Missing documentation for GObject: @0@'.format(gobject_index_path))
   endif
 endif
 
@@ -133,7 +133,7 @@ if with_py3
     # Verify Python version <https://github.com/mesonbuild/meson/issues/11057>.
     python3_version = python3.language_version()
     if not python3_version.startswith('3.')
-      error('Python3 interpreter has an unexpected version:', python3_version)
+      error('Python3 interpreter has an unexpected version: @0@'.format(python3_version))
     endif
 else
     python3 = disabler()

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -286,9 +286,16 @@ endif
 # Test env with release values
 test_release_env = environment()
 test_release_env.set('LC_ALL', 'C')
-test_release_env.set ('MESON_SOURCE_ROOT', meson.source_root())
-test_release_env.set ('MESON_BUILD_ROOT', meson.build_root())
-test_release_env.set ('TEST_DATA_PATH', meson.source_root() + '/modulemd/tests/test_data')
+if meson.version().version_compare('< 0.56.0')
+    project_source_root = meson.source_root()
+    project_build_root = meson.build_root()
+else
+    project_source_root = meson.project_source_root()
+    project_build_root = meson.project_build_root()
+endif
+test_release_env.set ('MESON_SOURCE_ROOT', project_source_root)
+test_release_env.set ('MESON_BUILD_ROOT', project_build_root)
+test_release_env.set ('TEST_DATA_PATH', project_source_root + '/modulemd/tests/test_data')
 
 # Test env with fatal warnings and criticals
 test_env = test_release_env
@@ -304,9 +311,9 @@ py_test_env = test_env
 if not test_installed_lib
     # If we're testing an installed version, we want to use the default
     # locations for these paths.
-    py_test_env.set ('GI_TYPELIB_PATH', meson.build_root() + '/modulemd')
-    py_test_env.set ('LD_LIBRARY_PATH', meson.build_root() + '/modulemd')
-    py_test_env.set ('PYTHONPATH', meson.source_root())
+    py_test_env.set ('GI_TYPELIB_PATH', project_build_root + '/modulemd')
+    py_test_env.set ('LD_LIBRARY_PATH', project_build_root + '/modulemd')
+    py_test_env.set ('PYTHONPATH', project_source_root)
 
     # This test is just to catch whether we are accidentally not testing
     # the built version.
@@ -558,5 +565,3 @@ test('test_import_headers', import_header_script,
       args : modulemd_hdrs,
       timeout : 300,
       suite : ['smoketest', 'ci'])
-
-


### PR DESCRIPTION
meson-0.55.0 is required for gnome.generate_gir(). meson.source_root(), meson.build_root(), glib.get_pkgconfig_variable() were deprecated.

The oldest supported distribution is EPEL 7 with meson-0.55.1 now.

This patch is based on <https://github.com/fedora-modularity/libmodulemd/pull/604>.