### PR TITLE
CI: Remove compatibility code for meson < 0.55.0

### DIFF
--- a/.ci/fedora/ci-tasks.sh
+++ b/.ci/fedora/ci-tasks.sh
@@ -44,24 +44,14 @@ meson test --suite ci_valgrind \
            -t 10
 
 # Test the code with clang-analyzer
-# This requires meson 0.49.0 or later
-set +e
-rpmdev-vercmp `meson --version` 0.49.0
-if [ $? -eq 12 ]; then
-    # Meson was older than 0.49.0, skip this step
-    echo "Meson is too old to run scan-build"
-    set -e
-else
-    set -e
-    meson --buildtype=debug \
-          -Dskip_introspection=true \
-          -Dwith_py3=false \
-          ci_scanbuild
+meson --buildtype=debug \
+      -Dskip_introspection=true \
+      -Dwith_py3=false \
+      ci_scanbuild
 
-    pushd ci_scanbuild
-    /builddir/.ci/scanbuild.sh
-    popd #ci_scanbuild
-fi
+pushd ci_scanbuild
+/builddir/.ci/scanbuild.sh
+popd #ci_scanbuild
 
 if [ $WITH_RPM_TESTS != true ]; then
     exit 0

--- a/.ci/mageia/ci-tasks.sh
+++ b/.ci/mageia/ci-tasks.sh
@@ -30,23 +30,13 @@ meson test --suite ci_valgrind \
            -t 10
 
 # Test the code with clang-analyzer
-# This requires meson 0.49.0 or later
-set +e
-rpmdev-vercmp `meson --version` 0.49.0
-if [ $? -eq 12 ]; then
-    # Meson was older than 0.49.0, skip this step
-    echo "Meson is too old to run scan-build"
-    set -e
-else
-    set -e
-    meson --buildtype=debug \
-          -Dskip_introspection=true \
-          -Dwith_py3=false \
-          $COMMON_MESON_ARGS \
-          ci_scanbuild
+meson --buildtype=debug \
+      -Dskip_introspection=true \
+      -Dwith_py3=false \
+      $COMMON_MESON_ARGS \
+      ci_scanbuild
 
-    pushd ci_scanbuild
-    /builddir/.ci/scanbuild.sh
-    popd #ci_scanbuild
-fi
+pushd ci_scanbuild
+/builddir/.ci/scanbuild.sh
+popd #ci_scanbuild
 

--- a/.ci/openmandriva/ci-tasks.sh
+++ b/.ci/openmandriva/ci-tasks.sh
@@ -34,22 +34,12 @@ meson test --suite ci_valgrind \
            -t 10
 
 # Test the code with clang-analyzer
-# This requires meson 0.49.0 or later
-set +e
-rpmdev-vercmp $(meson --version) 0.49.0
-if [ $? -eq 12 ]; then
-    # Meson was older than 0.49.0, skip this step
-    printf '%s\n' 'Meson is too old to run scan-build'
-    set -e
-else
-    set -e
 CC=clang CXX=clang++ meson --buildtype=debug \
           -Dskip_introspection=true \
           -Dwith_py3=false \
           $COMMON_MESON_ARGS \
           ci_scanbuild
 
-    pushd ci_scanbuild
-    /builddir/.ci/scanbuild.sh
-    popd #ci_scanbuild
-fi
+pushd ci_scanbuild
+/builddir/.ci/scanbuild.sh
+popd #ci_scanbuild

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,19 +29,12 @@ jobs:
       # <https://github.com/actions/virtual-environments/issues/3812>.
       options: --security-opt seccomp=unconfined
 
-    outputs:
-        meson_version: ${{ steps.scanbuild.outputs.available }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Install dependencies
         run: $GITHUB_WORKSPACE/.ci/fedora/get_fedora_deps.sh
-
-      - name: Determine if we can run scan-build
-        id: scanbuild
-        run: echo "::set-output name=available::echo $(rpmdev-vercmp $(meson --version) 0.49.0 > /dev/null; if [ $? == 12 ];then echo false; else echo true; fi )"
 
 
       - name: Set up the build directory
@@ -68,7 +61,6 @@ jobs:
             --wrap=$GITHUB_WORKSPACE/contrib/valgrind/valgrind_wrapper.sh
 
       - name: Run clang static analysis tests
-        if: ${{ steps.scanbuild.outputs.available }}
         run: |
           meson setup --buildtype=debug -Dskip_introspection=true -Dwith_py3=false ci_scanbuild
           ninja -C ci_scanbuild scan-build; if [ $? -ne 0 ]; then elinks -dump ci_scanbuild/meson-logs/scanbuild/*/index.html; fi
@@ -151,19 +143,12 @@ jobs:
       # <https://github.com/actions/virtual-environments/issues/3812>.
       options: --security-opt seccomp=unconfined
 
-    outputs:
-        meson_version: ${{ steps.scanbuild.outputs.available }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Install dependencies
         run: $GITHUB_WORKSPACE/.ci/fedora/get_fedora_deps.sh
-
-      - name: Determine if we can run scan-build
-        id: scanbuild
-        run: echo "::set-output name=available::echo $(rpmdev-vercmp $(meson --version) 0.49.0 > /dev/null; if [ $? == 12 ];then echo false; else echo true; fi )"
 
 
       - name: Set up the build directory
@@ -189,7 +174,6 @@ jobs:
             --wrap=$GITHUB_WORKSPACE/contrib/valgrind/valgrind_wrapper.sh
 
       - name: Run clang static analysis tests
-        if: ${{ steps.scanbuild.outputs.available }}
         run: |
           meson setup --buildtype=debug -Dskip_introspection=true -Dwith_py3=false ci_scanbuild
           ninja -C ci_scanbuild scan-build; if [ $? -ne 0 ]; then elinks -dump ci_scanbuild/meson-logs/scanbuild/*/index.html; fi
@@ -497,10 +481,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Determine if we can run scan-build
-        id: scanbuild
-        run: echo "::set-output name=available::echo $(rpmdev-vercmp $(meson --version) 0.49.0 > /dev/null; if [ $? == 12 ];then echo false; else echo true; fi )"
-
       - name: Set up the build directory
         env:
           CC: clang
@@ -517,7 +497,6 @@ jobs:
         run: meson test -C ci --suite ci --print-errorlogs -t 5
 
       - name: Run clang static analysis tests
-        if: ${{ steps.scanbuild.outputs.available }}
         run: |
           meson setup --buildtype=debug -Dwith_docs=false -Dlibmagic=disabled -Dskip_introspection=true -Dwith_py3=false ci_scanbuild
           ninja -C ci_scanbuild scan-build; if [ $? -ne 0 ]; then elinks -dump ci_scanbuild/meson-logs/scanbuild/*/index.html; fi

--- a/contrib/release-tools/release.sh
+++ b/contrib/release-tools/release.sh
@@ -64,15 +64,11 @@ cat $TMPDIR/tag_header $TMPDIR/shortlog > $TMPDIR/tag_message
 git tag -s -F $TMPDIR/tag_message $NEWTAG || error_out code=4 message="Couldn't create new signed tag for the release"
 git tag -s -F $TMPDIR/tag_message $NEWVERSION || error_out code=4 message="Couldn't create new signed tag for the release"
 
-# meson 0.50.0 and later can modify the version field programmatically
-if [ $($SCRIPT_DIR/semver compare 0.50.0 $(meson --version)) = -1 ]; then
-    bump_version=$($SCRIPT_DIR/semver bump patch $NEWVERSION)
-    pushd $SOURCE_ROOT
-    meson rewrite kwargs set project / version $bump_version #|| error_out code=11 message="Couldn't bump the version in meson.build"
-
-    git commit -sm "Bump version in meson.build to $bump_version" meson.build
-    popd #$SOURCE_ROOT
-fi
+bump_version=$($SCRIPT_DIR/semver bump patch $NEWVERSION)
+pushd $SOURCE_ROOT
+meson rewrite kwargs set project / version $bump_version #|| error_out code=11 message="Couldn't bump the version in meson.build"
+git commit -sm "Bump version in meson.build to $bump_version" meson.build
+popd #$SOURCE_ROOT
 
 # Make sure everything is up-to-date on Github
 git push --follow-tags upstream main || error_out code=5 message="Couldn't push the new tags to Github"


### PR DESCRIPTION
In commit 6d3e284d11ab4b56e23bc3dea9d8327a17b02e87 we increased minimal meson version to 0.55. Also long ago in
0761d0b11e7f9b56c691d207f02c0a5ef0aa7cc9 we moved CI for Mageia from Mageia 7 (EOL 2021-06-30) to Mageia 8.

This PR is here to verify the changes in CI.