### PR TITLE
Remove an optional dependency on file library (libmagic)

### DIFF
--- a/.ci/archlinux/Dockerfile.deps.tmpl
+++ b/.ci/archlinux/Dockerfile.deps.tmpl
@@ -4,7 +4,6 @@ MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 
 RUN pacman -Syu --needed --noconfirm \
     base-devel \
-    file \
     glib2 \
     glib2-docs \
     gobject-introspection \

--- a/.ci/centos/Dockerfile.deps.tmpl
+++ b/.ci/centos/Dockerfile.deps.tmpl
@@ -13,7 +13,6 @@ ifelse(eval(cosrelease >= 8), 1, `dnl
         clang \
         createrepo_c \
         elinks \
-        file-devel \
         gcc \
         gcc-c++ \
         git-core \

--- a/.ci/fedora/get_fedora_deps.sh
+++ b/.ci/fedora/get_fedora_deps.sh
@@ -16,7 +16,6 @@ dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' \
     "libmodulemd >= 2.3" \
     curl \
     elinks \
-    file-devel \
     gcc \
     gcc-c++ \
     git-core \

--- a/.ci/mageia/Dockerfile.deps.tmpl
+++ b/.ci/mageia/Dockerfile.deps.tmpl
@@ -8,7 +8,6 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
     createrepo_c \
     curl \
     elinks \
-    file-devel \
     gcc \
     gcc-c++ \
     git-core \

--- a/.ci/opensuse/Dockerfile.deps.tmpl
+++ b/.ci/opensuse/Dockerfile.deps.tmpl
@@ -10,7 +10,6 @@ RUN zypper install --no-confirm --no-recommends --capability \
     clang-tools \
     createrepo_c \
     elinks \
-    file-devel \
     gcc \
     gcc-c++ \
     git-core \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -306,7 +306,6 @@ jobs:
               createrepo_c
               curl
               elinks
-              file-devel
               gcc
               gcc-c++
               git-core
@@ -387,7 +386,6 @@ jobs:
                  clang-tools
                  createrepo_c
                  elinks
-                 file-devel
                  gcc
                  gcc-c++
                  git-core

--- a/fedora/libmodulemd.spec
+++ b/fedora/libmodulemd.spec
@@ -34,7 +34,6 @@ BuildRequires:  pkgconfig(yaml-0.1)
 BuildRequires:  pkgconfig(gtk-doc)
 BuildRequires:  glib2-doc
 BuildRequires:  rpm-devel
-BuildRequires:  file-devel
 %if %{build_python2}
 BuildRequires:  python2-devel
 BuildRequires:  python-gobject-base

--- a/meson.build
+++ b/meson.build
@@ -51,11 +51,13 @@ pkg = import('pkgconfig')
 gobject = dependency('gobject-2.0')
 yaml = dependency('yaml-0.1')
 
-with_rpmio = get_option('rpmio')
 with_libmagic = get_option('libmagic')
+if with_libmagic.enabled() or with_libmagic.disabled()
+    warning('libmagic option is obsolete. libmodulemd can detect compression formats without a magic library now. Please stop using this option. It will be removed in the future and will cause a meson failure.')
+endif
 
+with_rpmio = get_option('rpmio')
 rpm = dependency('rpm', required : with_rpmio)
-magic = cc.find_library('magic', required : with_libmagic)
 
 glib = dependency('glib-2.0')
 glib_prefix = glib.get_variable(pkgconfig: 'prefix')
@@ -166,24 +168,6 @@ srpm_cdata.set('BUILDFLAG', '-bs')
 subdir('modulemd')
 subdir('bindings/python')
 
-if magic.found()
-    if with_libmagic.enabled()
-        magic_status = 'Enabled'
-    elif with_libmagic.auto()
-        magic_status = 'Enabled (autodetected)'
-    else
-        error('libmagic state is unknown')
-    endif
-else
-    if with_libmagic.disabled()
-        magic_status = 'Disabled'
-    elif with_libmagic.auto()
-        magic_status = 'Disabled (autodetection could not locate libmagic)'
-    else
-        error('libmagic state is unknown')
-    endif
-endif
-
 if rpm.found()
     if with_rpmio.enabled()
         rpmio_status = 'Enabled'
@@ -216,8 +200,7 @@ summary({'prefix': get_option('prefix'),
          'Python 3 GObject Overrides': gobject_overrides_dir_py3,
         }, section: 'Directories')
 
-summary({'libmagic Support': magic_status,
-         'Custom Python': get_option('python_name'),
+summary({'Custom Python': get_option('python_name'),
          'RPMIO Support': rpmio_status,
          'Generate Manual Pages': manpages_status,
          'Generate HTML Documentation': get_option('with_docs'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,8 +17,8 @@ option('accept_overflowed_buildorder', type : 'boolean', value: 'false',
 option('verbose_tests', type : 'boolean', value : true,
        description : 'Tests that are run under the "debug" configuration will print all debug messages. Disable this option for valgrind checks, as it speeds it up substantially.')
 
-option('libmagic', type : 'feature', value : 'enabled',
-       description : 'Enables the use of libmagic to detect compression of YAML files.')
+option('libmagic', type : 'feature', value : 'auto',
+       description : 'This option is ignored and will be removed in the future.')
 
 option('python_name', type : 'string',
        description : 'The name of the Python 3 interpreter to use for generating Python bindings and running tests. If left blank, it defaults to the version of Python 3 being used to run meson.')

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -142,7 +142,6 @@ enums = gnome.mkenums_simple ('modulemd-enums', sources : modulemd_hdrs)
 cdata = configuration_data()
 cdata.set_quoted('LIBMODULEMD_VERSION', libmodulemd_version)
 cdata.set('HAVE_RPMIO', rpm.found())
-cdata.set('HAVE_LIBMAGIC', magic.found())
 cdata.set('HAVE_GDATE_AUTOPTR', has_gdate_autoptr)
 cdata.set('HAVE_EXTEND_AND_STEAL', has_extend_and_steal)
 cdata.set('HAVE_G_SPAWN_CHECK_WAIT_STATUS', has_g_spawn_check_wait_status)
@@ -158,7 +157,6 @@ modulemd_lib = library(
     include_directories : include_dirs,
     dependencies : [
         gobject,
-        magic,
         rpm,
         yaml,
         build_lib,
@@ -200,7 +198,6 @@ else
         include_directories : include_dirs,
         dependencies : [
             gobject,
-            magic,
             rpm,
             yaml,
             modulemd_dep

--- a/modulemd/tests/test-modulemd-compression.c
+++ b/modulemd/tests/test-modulemd-compression.c
@@ -80,8 +80,7 @@ test_modulemd_detect_compression (void)
       .type = MODULEMD_COMPRESSION_TYPE_XZ_COMPRESSION },
     { .filename = "uncompressed.yaml",
       .type = MODULEMD_COMPRESSION_TYPE_NO_COMPRESSION },
-    { .filename = "empty",
-      .type = MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION },
+    { .filename = "empty", .type = MODULEMD_COMPRESSION_TYPE_NO_COMPRESSION },
     { .filename = NULL }
   };
 
@@ -104,8 +103,7 @@ test_modulemd_detect_compression (void)
     }
 
 
-    /* == Test detection by libmagic == */
-#ifdef HAVE_LIBMAGIC
+  /* == Test detection by content == */
   struct expected_compression_t expected_magic[] = {
     { .filename = "bzipped",
       .type = MODULEMD_COMPRESSION_TYPE_BZ2_COMPRESSION },
@@ -115,25 +113,9 @@ test_modulemd_detect_compression (void)
       .type = MODULEMD_COMPRESSION_TYPE_XZ_COMPRESSION },
     { .filename = "uncompressed",
       .type = MODULEMD_COMPRESSION_TYPE_NO_COMPRESSION },
-    { .filename = "empty",
-      .type = MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION },
+    { .filename = "empty", .type = MODULEMD_COMPRESSION_TYPE_NO_COMPRESSION },
     { .filename = NULL }
   };
-#else
-  struct expected_compression_t expected_magic[] = {
-    { .filename = "bzipped",
-      .type = MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION },
-    { .filename = "gzipped",
-      .type = MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION },
-    { .filename = "xzipped",
-      .type = MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION },
-    { .filename = "uncompressed",
-      .type = MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION },
-    { .filename = "empty",
-      .type = MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION },
-    { .filename = NULL }
-  };
-#endif
 
   for (size_t j = 0; expected_magic[j].filename; j++)
     {

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -1399,7 +1399,6 @@ test_module_index_read_compressed (void)
   g_autofree gchar *compressed_text = NULL;
 
 #ifdef HAVE_RPMIO
-#ifdef HAVE_LIBMAGIC
   struct expected_compressed_read_t expected[] = {
     {
       .filename = "bzipped",
@@ -1415,29 +1414,6 @@ test_module_index_read_compressed (void)
     { .filename = "xzipped.yaml.xz", .succeeds = TRUE },
     { .filename = NULL }
   };
-#else /* HAVE_LIBMAGIC */
-  struct expected_compressed_read_t expected[] = {
-    { .filename = "bzipped",
-      .succeeds = FALSE,
-      .error_domain = MODULEMD_YAML_ERROR,
-      .error_code = MMD_YAML_ERROR_UNPARSEABLE },
-    {
-      .filename = "bzipped.yaml.bz2",
-      .succeeds = TRUE,
-    },
-    { .filename = "gzipped",
-      .succeeds = FALSE,
-      .error_domain = MODULEMD_YAML_ERROR,
-      .error_code = MMD_YAML_ERROR_UNPARSEABLE },
-    { .filename = "gzipped.yaml.gz", .succeeds = TRUE },
-    { .filename = "xzipped",
-      .succeeds = FALSE,
-      .error_domain = MODULEMD_YAML_ERROR,
-      .error_code = MMD_YAML_ERROR_UNPARSEABLE },
-    { .filename = "xzipped.yaml.xz", .succeeds = TRUE },
-    { .filename = NULL }
-  };
-#endif /* HAVE_LIBMAGIC */
 
 #else /* HAVE_RPMIO */
   struct expected_compressed_read_t expected[] = {


### PR DESCRIPTION
Magic library carries a large database (9 MB). libmodulemd used that library to detect 3 compresssion formats. Thus depending on that library was perceived as too expensive.

This patch reimplements the detection of the 3 compression formats without using magic library.

Because detection of plain text is inherently unreliable (with and without libmagic), this patch changes modulemd_detect_compression() to simply return MODULEMD_COMPRESSION_TYPE_NO_COMPRESSION (a plain text) if the file is not compressed in one of the 3 supported formats. That also applies to an empty file which was previously reported as MODULEMD_COMPRESSION_TYPE_UNKNOWN_COMPRESSION (an uknown compression).

This change is considered harmless as a parser error will be reported later when the file is passed to a YAML parser.

Note that this patch preserves a detection by a file name suffix, which still takes a precedence over a detection by a file content.