### PR TITLE
Drop fixxref from gtk-doc

### DIFF
--- a/fedora/libmodulemd.spec
+++ b/fedora/libmodulemd.spec
@@ -32,7 +32,6 @@ BuildRequires:  pkgconfig(gobject-2.0)
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
 BuildRequires:  pkgconfig(yaml-0.1)
 BuildRequires:  pkgconfig(gtk-doc)
-BuildRequires:  glib2-doc
 BuildRequires:  rpm-devel
 %if %{build_python2}
 BuildRequires:  python2-devel

--- a/meson.build
+++ b/meson.build
@@ -69,21 +69,6 @@ test = find_program('test')
 with_docs = get_option('with_docs')
 if with_docs
   gtkdoc = dependency('gtk-doc')
-  glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
-
-  glib_index_path = join_paths(glib_docpath, 'glib/index.html')
-  ret = run_command ([test, '-e', glib_index_path],
-    check: false)
-  if ret.returncode() != 0
-    error('Missing documentation for GLib: @0@'.format(glib_index_path))
-  endif
-
-  gobject_index_path = join_paths(glib_docpath, 'gobject/index.html')
-  ret = run_command ([test, '-e', gobject_index_path],
-    check: false)
-  if ret.returncode() != 0
-    error('Missing documentation for GObject: @0@'.format(gobject_index_path))
-  endif
 endif
 
 # Keep with_manpages option a tristate feature for backward compatibility.

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -265,10 +265,6 @@ if with_docs
         dependencies : [
             modulemd_dep,
         ],
-        fixxref_args: [
-                     '--extra-dir=@0@'.format(join_paths(glib_docpath, 'glib')),
-                     '--extra-dir=@0@'.format(join_paths(glib_docpath, 'gobject')),
-                   ],
         install : true,
     )
 endif


### PR DESCRIPTION
GLib 2.79.0 switched from gtk-doc to gi-docgen, whose format and installation location are both not compatible.  This allows the docs to build with the latest GLib at the price of some broken links.

This fixes the F40FTBFS from the mass rebuild.
