### PR TITLE
Adapt to GLib 2.79 documentation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -67,23 +67,21 @@ sed = find_program('sed')
 test = find_program('test')
 
 with_docs = get_option('with_docs')
+gtk_doc_referred_paths = []
 if with_docs
   gtkdoc = dependency('gtk-doc')
   glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
 
-  glib_index_path = join_paths(glib_docpath, 'glib/index.html')
-  ret = run_command ([test, '-e', glib_index_path],
-    check: false)
-  if ret.returncode() != 0
-    error('Missing documentation for GLib: @0@'.format(glib_index_path))
-  endif
-
-  gobject_index_path = join_paths(glib_docpath, 'gobject/index.html')
-  ret = run_command ([test, '-e', gobject_index_path],
-    check: false)
-  if ret.returncode() != 0
-    error('Missing documentation for GObject: @0@'.format(gobject_index_path))
-  endif
+  foreach referred_module : [ 'glib', 'gobject' ]
+    doc_module_path = join_paths(glib_docpath, referred_module)
+    doc_index_file = join_paths(doc_module_path, 'index.html')
+    ret = run_command ([test, '-e', doc_index_file],
+      check: false)
+    if ret.returncode() != 0
+      error('Missing GTK documentation for @0@: @1@'.format(referred_module, doc_index_file))
+    endif
+    gtk_doc_referred_paths += [ doc_module_path ]
+  endforeach
 endif
 
 # Keep with_manpages option a tristate feature for backward compatibility.
@@ -198,6 +196,7 @@ summary({'prefix': get_option('prefix'),
          'datadir': get_option('datadir'),
          'Python 2 GObject Overrides': gobject_overrides_dir_py2,
          'Python 3 GObject Overrides': gobject_overrides_dir_py3,
+         'GTK-Doc Referred Paths': gtk_doc_referred_paths,
         }, section: 'Directories')
 
 summary({'Custom Python': get_option('python_name'),

--- a/meson.build
+++ b/meson.build
@@ -70,7 +70,13 @@ with_docs = get_option('with_docs')
 gtk_doc_referred_paths = []
 if with_docs
   gtkdoc = dependency('gtk-doc')
-  glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
+
+  if glib.version().version_compare('<2.79.0')
+    glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
+  else
+    glib_docpath = join_paths(glib_prefix, 'share', 'doc', 'glib-2.0')
+    warning('glib >= 2.79.0 documention might not be properly referred from libmodulemd documentation.')
+  endif
 
   foreach referred_module : [ 'glib', 'gobject' ]
     doc_module_path = join_paths(glib_docpath, referred_module)

--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -256,6 +256,10 @@ configure_file(
 # --- Documenatation --- #
 
 if with_docs
+    fixxref_args = []
+    foreach path : gtk_doc_referred_paths
+      fixxref_args += [ '--extra-dir=@0@'.format(path) ]
+    endforeach
     gnome.gtkdoc(
         'modulemd-2.0',
         install_dir: 'modulemd-2.0',
@@ -265,10 +269,7 @@ if with_docs
         dependencies : [
             modulemd_dep,
         ],
-        fixxref_args: [
-                     '--extra-dir=@0@'.format(join_paths(glib_docpath, 'glib')),
-                     '--extra-dir=@0@'.format(join_paths(glib_docpath, 'gobject')),
-                   ],
+        fixxref_args: [ fixxref_args ],
         install : true,
     )
 endif


### PR DESCRIPTION
This patchset first moves a code in the build script, and then implements a special case GLib ≥ 2.79.0. If the special case proves unproductive, we will turned it into a skip later. This is a more compatible approach comparing to PR #611.