### PR TITLE
CI: Arch: Edit /etc/pacman.conf instead of copying a nonexistent file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -233,8 +233,8 @@ jobs:
       image: docker.io/library/archlinux:base
 
     steps:
-      - name: Install the standard pacman config
-        run: cp /etc/pacman.conf.pacnew /etc/pacman.conf
+      - name: Disable excluding documenation in pacman configuration
+        run: sed -i -e '\| usr/share/gtk-doc/|d' -e '\| usr/share/doc/|d' /etc/pacman.conf
 
       - name: Install dependencies
         run: pacman -Syu --needed --noconfirm base-devel file git glib2 glib2-docs gobject-introspection gtk-doc jq libyaml meson python-gobject python-six valgrind


### PR DESCRIPTION
Base archlinux image stopped delivering a backed up configuration file for pacman and thus our CI failed:

    Run cp /etc/pacman.conf.pacnew /etc/pacman.conf
    cp: cannot stat '/etc/pacman.conf.pacnew': No such file or directory
    Error: Process completed with exit code 1.

We used to copy that file to change a pacman configuration so that GLib documentation files are not removed when installaing packages. This stopped to working.

This patch edits the file instead.