### PR TITLE
CI: drop s390x and ppc64le, add aarch64

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -13,10 +13,6 @@ jobs:
         include:
           - arch: aarch64
             distro: fedora_latest
-          - arch: ppc64le
-            distro: fedora_latest
-          - arch: s390x
-            distro: fedora_latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -11,6 +11,8 @@ jobs:
     strategy:
       matrix:
         include:
+          - arch: aarch64
+            distro: fedora_latest
           - arch: ppc64le
             distro: fedora_latest
           - arch: s390x


### PR DESCRIPTION
The Github action we use to run non-x86_64 tests recently dropped support for Fedora on s390x and ppc64le for unknown reasons. This patch removes them from the test matrix, but adds back in aarch64 support.