### PR TITLE
doc: Adapt GLib documentation path to GLib 2.80.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -73,12 +73,18 @@ if with_docs
 
   if glib.version().version_compare('<2.79.0')
     glib_docpath = join_paths(glib_prefix, 'share', 'gtk-doc', 'html')
-  else
+    modules = ['glib', 'gobject' ]
+  elif glib.version().version_compare('<2.80.1')
     glib_docpath = join_paths(glib_prefix, 'share', 'doc', 'glib-2.0')
+    modules = ['glib', 'gobject' ]
+    warning('glib >= 2.79.0 documention might not be properly referred from libmodulemd documentation.')
+  else
+    glib_docpath = join_paths(glib_prefix, 'share', 'doc')
+    modules = ['glib-2.0', 'gobject-2.0' ]
     warning('glib >= 2.79.0 documention might not be properly referred from libmodulemd documentation.')
   endif
 
-  foreach referred_module : [ 'glib', 'gobject' ]
+  foreach referred_module : modules
     doc_module_path = join_paths(glib_docpath, referred_module)
     doc_index_file = join_paths(doc_module_path, 'index.html')
     ret = run_command ([test, '-e', doc_index_file],


### PR DESCRIPTION
With GLib 2.80.1 (commit 548ec9f1), the installation paths for the documentation
has changed once again.

Rationale there was:
The `gi-docgen` tool is not designed to be used like that. In
particular, when nesting documentation directories, the generated
`*.devhelp2` files (needed by Devhelp to show the documentation) are
nested one directory level too deep for Devhelp to find them, and hence
are useless, and the documentation doesn’t show up in this common
documentation viewer.
