### PR TITLE
CI: Adapt for dnf5

### DIFF
--- a/.ci/fedora/get_fedora_deps.sh
+++ b/.ci/fedora/get_fedora_deps.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd $SCRIPT_DIR
 
 dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' \
-       --nogpgcheck --skip-broken --quiet install \
+       --nogpgcheck --quiet install --skip-broken \
     python3-black \
     clang \
     clang-analyzer \

--- a/fedora/tests.yml
+++ b/fedora/tests.yml
@@ -10,7 +10,7 @@
     - classic
   tasks:
   - name: Make sure fedpkg and selinux bindings are installed
-    shell: dnf -y install fedpkg python{2,3}-libselinux libmodulemd-devel --skip-broken
+    shell: dnf -y install --skip-broken fedpkg python{2,3}-libselinux libmodulemd-devel
   - name: Copy spec file to remote machine
     copy:
       src: "{{ playbook_dir }}/../libmodulemd.spec"


### PR DESCRIPTION
DNF5 is stricter in distinguishing between global and subcommand options. --skip-broken belongs to install subcommand.