### PR TITLE
Adjust CI on Mandriva

### DIFF
--- a/.ci/openmandriva/Dockerfile.deps.tmpl
+++ b/.ci/openmandriva/Dockerfile.deps.tmpl
@@ -14,13 +14,12 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
     valgrind \
     wget \
     task-devel \
-    'pkgconfig(zlib)' \
+    'pkgconfig(glib-2.0)' \
     'pkgconfig(gobject-introspection-1.0)' \
+    'pkgconfig(rpm)' \
+    'pkgconfig(yaml-0.1)' \
     'python3dist(autopep8)' \
     'python3dist(pygobject)' \
-    'pkgconfig(yaml-0.1)' \
-    'pkgconfig(rpm)' \
-    magic-devel \
     git-core \
     elinks \
     && dnf -y clean all

--- a/.ci/openmandriva/Dockerfile.deps.tmpl
+++ b/.ci/openmandriva/Dockerfile.deps.tmpl
@@ -21,7 +21,6 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
     'python3dist(autopep8)' \
     'python3dist(pygobject)' \
     git-core \
-    elinks \
     && dnf -y clean all
 
 RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; import os; os.makedirs(gi._overridesdir, exist_ok=True); print(gi._overridesdir)")/Modulemd.py

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -441,7 +441,6 @@ jobs:
               'python3dist(pygobject)'
               'pkgconfig(rpm)'
               git-core
-              elinks
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -460,7 +459,8 @@ jobs:
       - name: Run CI tests
         run: meson test -C ci --suite ci --print-errorlogs -t 5
 
-      - name: Run clang static analysis tests
-        run: |
-          meson setup --buildtype=debug -Dwith_docs=false -Dskip_introspection=true -Dwith_py3=false ci_scanbuild
-          ninja -C ci_scanbuild scan-build; if [ $? -ne 0 ]; then elinks -dump ci_scanbuild/meson-logs/scanbuild/*/index.html; fi
+      # Do not run "ninja -C ci_scanbuild" on this platform because glib2.0
+      # HTML documentation does not exist and -Dwith_docs=false is needed.
+      # The internal ci_scanbuild target ignores build options
+      # <https://github.com/mesonbuild/meson/issues/1167> and the build would
+      # fail.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -434,13 +434,12 @@ jobs:
               valgrind
               wget
               task-devel
-              'pkgconfig(zlib)'
+              'pkgconfig(glib-2.0)'
               'pkgconfig(gobject-introspection-1.0)'
+              'pkgconfig(yaml-0.1)'
               'python3dist(autopep8)'
               'python3dist(pygobject)'
-              'pkgconfig(yaml-0.1)'
               'pkgconfig(rpm)'
-              magic-devel
               git-core
               elinks
 


### PR DESCRIPTION
This attempts to resolve CI failure on [OpenMandriva Cooker](https://github.com/fedora-modularity/libmodulemd/actions/runs/14734099369/job/41355643930?pr=625#logs) because of missing glib2.0 HTML documenation.