### PR TITLE
CI: Install glib2-devel on Arch Linux

### DIFF
--- a/.ci/archlinux/Dockerfile.deps.tmpl
+++ b/.ci/archlinux/Dockerfile.deps.tmpl
@@ -5,6 +5,7 @@ MAINTAINER Stephen Gallagher <sgallagh@redhat.com>
 RUN pacman -Syu --needed --noconfirm \
     base-devel \
     glib2 \
+    glib2-devel \
     glib2-docs \
     gobject-introspection \
     gtk-doc \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,7 +237,7 @@ jobs:
         run: sed -i -e '\| usr/share/gtk-doc/|d' -e '\| usr/share/doc/|d' /etc/pacman.conf
 
       - name: Install dependencies
-        run: pacman -Syu --needed --noconfirm base-devel file git glib2 glib2-docs gobject-introspection gtk-doc jq libyaml meson python-gobject python-six valgrind
+        run: pacman -Syu --needed --noconfirm base-devel file git glib2 glib2-devel glib2-docs gobject-introspection gtk-doc jq libyaml meson python-gobject python-six valgrind
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
CI failed on Arch Linux with:

    Dependency glib-2.0 found: YES 2.84.1 (cached)
    Program /usr/bin/glib-mkenums found: NO

    modulemd/meson.build:140:14: ERROR: Dependency 'glib-2.0' tool variable 'glib_mkenums' contains erroneous value: '/usr/bin/glib-mkenums'

The cause is that /usr/bin/glib-mkenums is packaged in glib2-devel now.