### PR TITLE
CI: Use Packit to build on non-x86_64 architectures

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -19,6 +19,11 @@ jobs:
   metadata:
     targets:
     - fedora-all
+    - fedora-rawhide-aarch64
+    - fedora-rawhide-i386
+    - fedora-rawhide-ppc64le
+    # fedora-rawhide-x86_64 is included in fedora-all
+    # fedora-rawhide-s390x has too long wait queue
     - epel-7
     - epel-8
     - centos-stream-9

--- a/fedora/libmodulemd.spec
+++ b/fedora/libmodulemd.spec
@@ -108,7 +108,7 @@ export LC_CTYPE=C.utf8
 
 # Don't run tests on ARM for now. There are problems with
 # performance on the builders and often these time out.
-%ifnarch %{arm} aarch64
+%ifnarch %{arm}
 # The tests sometimes time out in CI, so give them a little extra time
 %{__meson} test -C %{_vpath_builddir} %{?_smp_mesonflags} --print-errorlogs -t 5
 %endif


### PR DESCRIPTION
This patch enables Packit to build on AArch64, 32-bit x86, PPC64LE, and s390x platforms on Fedora Rawhide distribution. It also reenables running tests on AArch64 in the upstream spec file.

This way we should get test coverage for some common non-x86_64 architectures at a reasonable speed.