### PR TITLE
tests: Respect compression formats rpmio supports in module_index test

### DIFF
--- a/modulemd/meson.build
+++ b/modulemd/meson.build
@@ -377,6 +377,7 @@ foreach name, sources : c_tests
         sources,
         dependencies : [
             modulemd_dep,
+            rpm,
         ],
         link_with : [
             test_utils_lib,


### PR DESCRIPTION
If rpm does not support all compression formats and libmodulemd is configured with rpmio support, module_index_release test failed:

    $ MESON_SOURCE_ROOT=/tmp/libmodulemd-2.15.0 TEST_DATA_PATH=/tmp/libmodulemd-2.15.0/modulemd/tests/test_data /tmp/b/modulemd/module_index
    TAP version 14
    # random seed: R02Sf9e05b79de9e908ae8cb3de188499581
    1..18
    # Start of modulemd tests
    # Start of v2 tests
    # Start of module tests
    # Start of index tests
    ok 1 /modulemd/v2/module/index/dump
    ok 2 /modulemd/v2/module/index/read
    ok 3 /modulemd/v2/module/index/remove_module
    ok 4 /modulemd/v2/module/index/custom_read
    ok 5 /modulemd/v2/module/index/custom_write
    ok 6 /modulemd/v2/module/index/get_default_streams
    ok 7 /modulemd/v2/module/index/empty
    **
    libmodulemd:ERROR:../libmodulemd-2.15.0/modulemd/tests/test-modulemd-moduleindex.c:1493:test_module_index_read_compressed: assertion failed (error == NULL): Parser error (modulemd-yaml-error-quark, 2)
    not ok /modulemd/v2/module/index/compressed - libmodulemd:ERROR:../libmodulemd-2.15.0/modulemd/tests/test-modulemd-moduleindex.c:1493:test_module_index_read_compressed: assertion failed (error == NULL): Parser
    +error (modulemd-yaml-error-quark, 2)
    Bail out!

The test assumed that rpmio library supports all compression formats. That's not guaranteed, the support is optional for each format.

This patch fixes it by probing rpmio library for each compression format and if that does not work (rpmio returns compressed data), the test will assume that that format is not supported.

Implementation details: The probing happens at run-time and thus links the rpmio library to the the tests. Probing at configure time would not work when crosscompiling.

Resolve: #630