### PR TITLE
Drop python-six dependency

### DIFF
--- a/.ci/archlinux/Dockerfile.deps.tmpl
+++ b/.ci/archlinux/Dockerfile.deps.tmpl
@@ -13,7 +13,6 @@ RUN pacman -Syu --needed --noconfirm \
     libyaml \
     meson \
     python-gobject \
-    python-six \
 && pacman -Scc --noconfirm
 
 RUN ln -sf /builddir/bindings/python/gi/overrides/Modulemd.py $(python3 -c "import gi; import os; os.makedirs(gi._overridesdir, exist_ok=True); print(gi._overridesdir)")/Modulemd.py

--- a/.ci/centos/Dockerfile.deps.tmpl
+++ b/.ci/centos/Dockerfile.deps.tmpl
@@ -31,11 +31,9 @@ ifelse(eval(cosrelease == 8), 1, `dnl
         pkgconfig \
 ifelse(eval(cosrelease < 9), 1, `dnl
         python2-devel \
-        python2-six \
         python36-devel \
 ',`dnl
         python3-devel \
-        python3-six \
 ')dnl
 ifelse(eval(cosrelease < 8), 1, `dnl
         python-gobject-base \

--- a/.ci/mageia/Dockerfile.deps.tmpl
+++ b/.ci/mageia/Dockerfile.deps.tmpl
@@ -22,7 +22,6 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
     openssl \
     pkgconf \
     popt-devel \
-    python3-six \
     python3-autopep8 \
     python3-devel \
     python3-gitpython \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,7 +237,7 @@ jobs:
         run: sed -i -e '\| usr/share/gtk-doc/|d' -e '\| usr/share/doc/|d' /etc/pacman.conf
 
       - name: Install dependencies
-        run: pacman -Syu --needed --noconfirm base-devel file git glib2 glib2-devel glib2-docs gobject-introspection gtk-doc jq libyaml meson python-gobject python-six valgrind
+        run: pacman -Syu --needed --noconfirm base-devel file git glib2 glib2-devel glib2-docs gobject-introspection gtk-doc jq libyaml meson python-gobject valgrind
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -300,7 +300,6 @@ jobs:
               openssl
               pkgconf
               popt-devel
-              python3-six
               python3-autopep8
               python3-devel
               python3-gitpython

--- a/bindings/python/gi/overrides/Modulemd.py
+++ b/bindings/python/gi/overrides/Modulemd.py
@@ -16,10 +16,15 @@ from ..overrides import override
 
 import functools
 
-from six import text_type
 from gi.repository import GLib
 
 import datetime
+import sys
+
+if sys.version_info[0] >= 3:
+    text_type = str
+else:
+    text_type = unicode  # noqa: F821
 
 Modulemd = get_introspection_module("Modulemd")
 

--- a/fedora/libmodulemd.spec
+++ b/fedora/libmodulemd.spec
@@ -56,7 +56,6 @@ more details.
 Summary: Python 2 bindings for %{name}
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: python-gobject-base
-Requires: python-six
 
 %description -n python2-%{name}
 Python 2 bindings for %{name}
@@ -67,13 +66,6 @@ Python 2 bindings for %{name}
 Summary: Python 3 bindings for %{name}
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: python%{python3_pkgversion}-gobject-base
-
-%if (0%{?rhel} && 0%{?rhel} <= 7)
-# The py3_dist macro on EPEL 7 doesn't work right at the moment
-Requires: python3.6dist(six)
-%else
-Requires: %{py3_dist six}
-%endif
 
 %description -n python%{python3_pkgversion}-%{name}
 Python %{python3_pkgversion} bindings for %{name}


### PR DESCRIPTION
In Ubuntu and Debian we no longer ship Python 2.7, so the translation module is an unnecessary dependency. In Python 3 the text type is always 'str', so it is not needed. Simply set the value to 'unicode' on Python2, and 'str' on Python3.