### PR TITLE
Configure packit to use caret notation for postrelease snapshots

### DIFF
--- a/.ci/fedora/ci-tasks.sh
+++ b/.ci/fedora/ci-tasks.sh
@@ -64,7 +64,7 @@ fi
 arch=$(uname -m)
 mkdir -p rpmbuild/RPMS/
 pushd rpmbuild/RPMS/
-packit --debug build locally ../..
+packit --debug build locally -p libmodulemd ../..
 createrepo_c $arch
 
 $RETRY_CMD dnf -y install --nogpgcheck \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
         working-directory: ${{github.workspace}}/rpmbuild/RPMS
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          packit --debug build locally ../..
+          packit --debug build locally -p libmodulemd ../..
           createrepo_c x86_64
 
       - name: Install the packages
@@ -197,7 +197,7 @@ jobs:
         working-directory: ${{github.workspace}}/rpmbuild/RPMS
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          packit --debug build locally ../..
+          packit --debug build locally -p libmodulemd ../..
           createrepo_c x86_64
 
       - name: Install the packages

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,7 +1,19 @@
-specfile_path: fedora/libmodulemd.spec
-upstream_package_name: libmodulemd
-upstream_project_url: https://github.com/fedora-modularity/libmodulemd
-downstream_package_name: libmodulemd
+_:
+  project_settings: &project_settings
+    upstream_package_name: libmodulemd
+    upstream_project_url: https://github.com/fedora-modularity/libmodulemd
+    downstream_package_name: libmodulemd
+    specfile_path: fedora/libmodulemd.spec
+
+packages:
+  libmodulemd:
+    << : *project_settings
+    version_suffix: "^{PACKIT_PROJECT_SNAPSHOTID}"
+    update_release: false
+
+  # rpmbuild doesn't allow '^' in version on rhel 7, don't use caret notation
+  libmodulemd-epel7:
+    << : *project_settings
 
 actions:
   get-current-version: ./get_version.sh
@@ -16,6 +28,7 @@ jobs:
 
 - job: copr_build
   trigger: pull_request
+  packages: [libmodulemd]
   metadata:
     targets:
     - fedora-all
@@ -24,7 +37,13 @@ jobs:
     - fedora-rawhide-ppc64le
     # fedora-rawhide-x86_64 is included in fedora-all
     # fedora-rawhide-s390x has too long wait queue
-    - epel-7
     - epel-8
     - centos-stream-9
     - centos-stream-10
+
+- job: copr_build
+  trigger: pull_request
+  packages: [libmodulemd-epel7]
+  metadata:
+    targets:
+    - epel-7


### PR DESCRIPTION
This ensures the build of that specific version is considered newer than any other regular release of it.

For rpm-software-management/ci-dnf-stack#1843

Example build: https://copr.fedorainfracloud.org/coprs/amatej/dnf-nightly/build/10282557/