### PR TITLE
Fix various null pointer dereferences

### DIFF
--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -1289,6 +1289,16 @@ modulemd_module_index_add_obsoletes (ModulemdModuleIndex *self,
   g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
   g_return_val_if_fail (MODULEMD_IS_OBSOLETES (obsoletes), FALSE);
 
+  if (!modulemd_obsoletes_get_module_name (obsoletes))
+    {
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   MMD_ERROR_MISSING_REQUIRED,
+                   "The obsoletes requries a module name when adding to "
+                   "ModuleIndex.");
+      return FALSE;
+    }
+
   modulemd_module_add_obsoletes (
     get_or_create_module (self,
                           modulemd_obsoletes_get_module_name (obsoletes)),

--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -1442,6 +1442,16 @@ modulemd_module_index_add_translation (ModulemdModuleIndex *self,
       return FALSE;
     }
 
+  if (!modulemd_translation_get_module_stream (translation))
+    {
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   MMD_ERROR_MISSING_REQUIRED,
+                   "The translation requries a module stream when adding to "
+                   "ModuleIndex.");
+      return FALSE;
+    }
+
   modulemd_module_add_translation (
     get_or_create_module (self,
                           modulemd_translation_get_module_name (translation)),

--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -1540,10 +1540,17 @@ modulemd_module_index_merge (ModulemdModuleIndex *from,
           if (!modulemd_module_index_add_module_stream (
                 into, stream, &nested_error))
             {
-              g_info ("Could not add stream %s due to %s",
-                      nsvca,
-                      nested_error->message);
-              g_clear_error (&nested_error);
+              if (nested_error)
+                {
+                  g_info ("Could not add stream %s due to %s",
+                          nsvca,
+                          nested_error->message);
+                  g_clear_error (&nested_error);
+                }
+              else
+                {
+                  g_info ("Could not add stream %s", nsvca);
+                }
             }
           g_clear_pointer (&nsvca, g_free);
         }

--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -1430,6 +1430,7 @@ modulemd_module_index_add_translation (ModulemdModuleIndex *self,
                                        GError **UNUSED (error))
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
+  g_return_val_if_fail (MODULEMD_IS_TRANSLATION (translation), FALSE);
 
   modulemd_module_add_translation (
     get_or_create_module (self,

--- a/modulemd/modulemd-module-index.c
+++ b/modulemd/modulemd-module-index.c
@@ -1427,10 +1427,20 @@ modulemd_module_index_upgrade_defaults (ModulemdModuleIndex *self,
 gboolean
 modulemd_module_index_add_translation (ModulemdModuleIndex *self,
                                        ModulemdTranslation *translation,
-                                       GError **UNUSED (error))
+                                       GError **error)
 {
   g_return_val_if_fail (MODULEMD_IS_MODULE_INDEX (self), FALSE);
   g_return_val_if_fail (MODULEMD_IS_TRANSLATION (translation), FALSE);
+
+  if (!modulemd_translation_get_module_name (translation))
+    {
+      g_set_error (error,
+                   MODULEMD_ERROR,
+                   MMD_ERROR_MISSING_REQUIRED,
+                   "The translation requries a module name when adding to "
+                   "ModuleIndex.");
+      return FALSE;
+    }
 
   modulemd_module_add_translation (
     get_or_create_module (self,

--- a/modulemd/modulemd-translation.c
+++ b/modulemd/modulemd-translation.c
@@ -103,7 +103,15 @@ modulemd_translation_copy (ModulemdTranslation *self)
 gboolean
 modulemd_translation_validate (ModulemdTranslation *self, GError **error)
 {
-  g_return_val_if_fail (MODULEMD_IS_TRANSLATION (self), FALSE);
+  if (!MODULEMD_IS_TRANSLATION (self))
+    {
+      g_set_error_literal (error,
+                           MODULEMD_ERROR,
+                           MMD_ERROR_VALIDATE,
+                           "The object is not ModulemdTranslation type.");
+      g_return_val_if_fail (MODULEMD_IS_TRANSLATION (self), FALSE);
+      return FALSE;
+    }
 
   if (g_str_equal (modulemd_translation_get_module_name (self),
                    T_PLACEHOLDER_STRING))

--- a/modulemd/modulemd-util.c
+++ b/modulemd/modulemd-util.c
@@ -379,10 +379,18 @@ modulemd_variant_deep_copy (GVariant *variant)
 gboolean
 modulemd_validate_nevra (const gchar *nevra)
 {
-  g_autofree gchar *tmp = g_strdup (nevra);
-  gsize len = strlen (nevra);
+  g_autofree gchar *tmp = NULL;
+  gsize len;
   gchar *i;
   gchar *endptr;
+
+  if (!nevra)
+    {
+      return FALSE;
+    }
+
+  tmp = g_strdup (nevra);
+  len = strlen (nevra);
 
   /* Since the "name" portion of a NEVRA can have an infinite number of
    * hyphens, we need to parse from the end backwards.

--- a/modulemd/tests/test-modulemd-compression.c
+++ b/modulemd/tests/test-modulemd-compression.c
@@ -96,6 +96,7 @@ test_modulemd_detect_compression (void)
       filename = g_strdup_printf ("%s/compression/%s",
                                   g_getenv ("TEST_DATA_PATH"),
                                   expected[i].filename);
+      g_assert_nonnull (filename);
       g_debug ("Getting compression type for %s", filename);
       filestream = g_fopen (filename, "rbe");
       g_assert_nonnull (filestream);
@@ -130,6 +131,7 @@ test_modulemd_detect_compression (void)
       filename = g_strdup_printf ("%s/compression/%s",
                                   g_getenv ("TEST_DATA_PATH"),
                                   expected_magic[j].filename);
+      g_assert_nonnull (filename);
       g_debug ("Getting compression type for %s", filename);
       filestream = g_fopen (filename, "rbe");
       g_assert_nonnull (filestream);

--- a/modulemd/tests/test-modulemd-moduleindex.c
+++ b/modulemd/tests/test-modulemd-moduleindex.c
@@ -1980,6 +1980,23 @@ test_module_index_search_rpms (void)
 }
 
 
+/* NULL translation should be rejected */
+static void
+test_module_index_add_translation_null (void)
+{
+  if (g_test_subprocess ())
+    {
+      g_autoptr (ModulemdModuleIndex) index = NULL;
+      g_autoptr (GError) error = NULL;
+      index = modulemd_module_index_new ();
+      modulemd_module_index_add_translation (index, NULL, &error);
+      return;
+    }
+  g_test_trap_subprocess (NULL, 0, G_TEST_SUBPROCESS_DEFAULT);
+  g_test_trap_assert_failed ();
+}
+
+
 int
 main (int argc, char *argv[])
 {
@@ -2041,6 +2058,9 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/modulemd/v2/module/index/search_rpms",
                    test_module_index_search_rpms);
+
+  g_test_add_func ("/modulemd/v2/module/index/add_translation/null",
+                   test_module_index_add_translation_null);
 
   return g_test_run ();
 }


### PR DESCRIPTION
<https://svashisht.fedorapeople.org/openscanhub/mass-scans/f45-01-Jun-2026/libmodulemd-2.15.2-7.fc45/scan-results.html> static analysis reported various possible null-pointer dereferences. While they are mostly theoretical or about a wrong use, and most of them get caught by fatalized warnings about failed preconditions, it's better to fix them.