### PR TITLE
CI: Move Mageia from version 8 to 9

### DIFF
--- a/.ci/ci-mageia.sh
+++ b/.ci/ci-mageia.sh
@@ -8,7 +8,7 @@ source $SCRIPT_DIR/ci-common.inc
 set -e
 set -x
 
-release=${1:-8}
+release=${1:-9}
 
 mmd_run_docker_tests \
     os=mageia \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,12 +270,12 @@ jobs:
           meson test -C ci_valgrind --suite ci_valgrind --print-errorlogs -t 10
             --wrap=$GITHUB_WORKSPACE/contrib/valgrind/valgrind_wrapper.sh
 
-  mageia_8:
-    name: Mageia 8
+  mageia_9:
+    name: Mageia 9
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: docker.io/library/mageia:8
+      image: docker.io/library/mageia:9
 
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Mageia 8 reached end of life on 2023-11-30. Now the latest released version is 9.