### PR TITLE
Harden modulemd_module_add_... functions against null-pointer dereferences

### DIFF
--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -824,10 +824,18 @@ modulemd_module_add_obsoletes (ModulemdModule *self,
   ModulemdModuleStream *stream = NULL;
   ModulemdObsoletes *new_obsoletes = NULL;
   ModulemdObsoletes *current_obsoletes = NULL;
+  const gchar * self_module_name = NULL;
+  const gchar * obsoletes_module_name = NULL;
 
-  g_return_if_fail (
-    g_str_equal (modulemd_obsoletes_get_module_name (obsoletes),
-                 modulemd_module_get_module_name (self)));
+  g_return_if_fail ( self != NULL );
+  self_module_name = modulemd_module_get_module_name(self);
+  g_return_if_fail ( self_module_name != NULL );
+
+  g_return_if_fail ( obsoletes != NULL );
+  obsoletes_module_name = modulemd_obsoletes_get_module_name (obsoletes);
+  g_return_if_fail ( obsoletes_module_name != NULL );
+
+  g_return_if_fail ( g_str_equal (obsoletes_module_name, self_module_name) );
 
   new_obsoletes = modulemd_obsoletes_copy (obsoletes);
 

--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -767,10 +767,18 @@ modulemd_module_add_translation (ModulemdModule *self,
   gsize i;
   ModulemdModuleStream *stream = NULL;
   ModulemdTranslation *newtrans = NULL;
+  const gchar * self_module_name = NULL;
+  const gchar * translation_module_name = NULL;
 
-  g_return_if_fail (
-    g_str_equal (modulemd_translation_get_module_name (translation),
-                 modulemd_module_get_module_name (self)));
+  g_return_if_fail ( self != NULL );
+  self_module_name = modulemd_module_get_module_name(self);
+  g_return_if_fail ( self_module_name != NULL );
+
+  g_return_if_fail ( translation != NULL );
+  translation_module_name = modulemd_translation_get_module_name (translation);
+  g_return_if_fail ( translation_module_name != NULL );
+
+  g_return_if_fail ( g_str_equal (translation_module_name, self_module_name) );
 
   newtrans = modulemd_translation_copy (translation);
 

--- a/modulemd/modulemd-module.c
+++ b/modulemd/modulemd-module.c
@@ -767,18 +767,18 @@ modulemd_module_add_translation (ModulemdModule *self,
   gsize i;
   ModulemdModuleStream *stream = NULL;
   ModulemdTranslation *newtrans = NULL;
-  const gchar * self_module_name = NULL;
-  const gchar * translation_module_name = NULL;
+  const gchar *self_module_name = NULL;
+  const gchar *translation_module_name = NULL;
 
-  g_return_if_fail ( self != NULL );
-  self_module_name = modulemd_module_get_module_name(self);
-  g_return_if_fail ( self_module_name != NULL );
+  g_return_if_fail (self != NULL);
+  self_module_name = modulemd_module_get_module_name (self);
+  g_return_if_fail (self_module_name != NULL);
 
-  g_return_if_fail ( translation != NULL );
+  g_return_if_fail (translation != NULL);
   translation_module_name = modulemd_translation_get_module_name (translation);
-  g_return_if_fail ( translation_module_name != NULL );
+  g_return_if_fail (translation_module_name != NULL);
 
-  g_return_if_fail ( g_str_equal (translation_module_name, self_module_name) );
+  g_return_if_fail (g_str_equal (translation_module_name, self_module_name));
 
   newtrans = modulemd_translation_copy (translation);
 
@@ -824,18 +824,18 @@ modulemd_module_add_obsoletes (ModulemdModule *self,
   ModulemdModuleStream *stream = NULL;
   ModulemdObsoletes *new_obsoletes = NULL;
   ModulemdObsoletes *current_obsoletes = NULL;
-  const gchar * self_module_name = NULL;
-  const gchar * obsoletes_module_name = NULL;
+  const gchar *self_module_name = NULL;
+  const gchar *obsoletes_module_name = NULL;
 
-  g_return_if_fail ( self != NULL );
-  self_module_name = modulemd_module_get_module_name(self);
-  g_return_if_fail ( self_module_name != NULL );
+  g_return_if_fail (self != NULL);
+  self_module_name = modulemd_module_get_module_name (self);
+  g_return_if_fail (self_module_name != NULL);
 
-  g_return_if_fail ( obsoletes != NULL );
+  g_return_if_fail (obsoletes != NULL);
   obsoletes_module_name = modulemd_obsoletes_get_module_name (obsoletes);
-  g_return_if_fail ( obsoletes_module_name != NULL );
+  g_return_if_fail (obsoletes_module_name != NULL);
 
-  g_return_if_fail ( g_str_equal (obsoletes_module_name, self_module_name) );
+  g_return_if_fail (g_str_equal (obsoletes_module_name, self_module_name));
 
   new_obsoletes = modulemd_obsoletes_copy (obsoletes);
 


### PR DESCRIPTION
modulemd_module_add_obsoletes() and modulemd_module_add_translation() do not expect modules, translation, or obsletes objects with NULL module name. While it is not a problem in current use of these function, we cannot guarantee it in the future and we should add preconditions against the NULL names.

Found by Fedora 45 static analysis in August 2026 <https://svashisht.fedorapeople.org/openscanhub/mass-scans/f45-03-Aug-2026/libmodulemd-2.15.3-3.fc45/scan-results.html>.