### PR TITLE
CI: Update Mageia distribution and the checkout action

### DIFF
--- a/.ci/mageia/Dockerfile.deps.tmpl
+++ b/.ci/mageia/Dockerfile.deps.tmpl
@@ -12,7 +12,6 @@ RUN dnf -y --setopt=install_weak_deps=False --setopt=tsflags='' install \
     gcc-c++ \
     git-core \
     glib2-devel \
-    /usr/share/gtk-doc/html/glib/index.html \
     gobject-introspection-devel \
     gtk-doc \
     jq \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: $GITHUB_WORKSPACE/.ci/fedora/get_fedora_deps.sh
@@ -80,7 +80,7 @@ jobs:
         run: dnf -y install git-core
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: $GITHUB_WORKSPACE/.ci/fedora/get_fedora_deps.sh
@@ -133,7 +133,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: $GITHUB_WORKSPACE/.ci/fedora/get_fedora_deps.sh
@@ -185,7 +185,7 @@ jobs:
         run: dnf -y install git-core
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: $GITHUB_WORKSPACE/.ci/fedora/get_fedora_deps.sh
@@ -240,7 +240,7 @@ jobs:
         run: pacman -Syu --needed --noconfirm base-devel file git glib2 glib2-devel glib2-docs gobject-introspection gtk-doc jq libyaml meson python-gobject valgrind
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up the build directory
         run:
@@ -318,7 +318,7 @@ jobs:
               wget
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up the build directory
         run: meson setup --buildtype=debugoptimized ci $GITHUB_WORKSPACE
@@ -386,7 +386,7 @@ jobs:
                  valgrind
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up the build directory
         run: meson setup --buildtype=debugoptimized ci $GITHUB_WORKSPACE
@@ -442,7 +442,7 @@ jobs:
               git-core
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up the build directory
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,12 +270,12 @@ jobs:
           meson test -C ci_valgrind --suite ci_valgrind --print-errorlogs -t 10
             --wrap=$GITHUB_WORKSPACE/contrib/valgrind/valgrind_wrapper.sh
 
-  mageia_9:
-    name: Mageia 9
+  mageia_10:
+    name: Mageia 10
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: docker.io/library/mageia:9
+      image: docker.io/library/mageia:10
 
     steps:
       - name: Install dependencies
@@ -290,7 +290,6 @@ jobs:
               gcc-c++
               git-core
               glib2-devel
-              /usr/share/gtk-doc/html/glib/index.html
               gobject-introspection-devel
               gtk-doc
               jq

--- a/.github/workflows/formatters.yaml
+++ b/.github/workflows/formatters.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install formatters
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,10 +11,10 @@ jobs:
     if: github.repository == 'fedora-modularity/libmodulemd'
     steps:
       - name: Checkout code repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout documentation repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: fedora-modularity/fedora-modularity.github.io
           ref: main

--- a/.github/workflows/upstreamed.yaml
+++ b/.github/workflows/upstreamed.yaml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'fedora-modularity/libmodulemd'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Coverity Scan
         env:
@@ -25,10 +25,10 @@ jobs:
     if: github.repository == 'fedora-modularity/libmodulemd'
     steps:
       - name: Checkout code repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout documentation repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: fedora-modularity/fedora-modularity.github.io
           ref: main


### PR DESCRIPTION
Upgrade Upgrade actions/checkout to v6 and Replace Mageia 9 with Mageia 10.
The CI failure in OpenMandriva Cooker is unrelated.